### PR TITLE
[rount-5] Practical Read Optimization

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/CommerceApiApplication.java
+++ b/apps/commerce-api/src/main/java/com/loopers/CommerceApiApplication.java
@@ -1,10 +1,12 @@
 package com.loopers;
 
-import jakarta.annotation.PostConstruct;
+import java.util.TimeZone;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import java.util.TimeZone;
+
+import jakarta.annotation.PostConstruct;
 
 @ConfigurationPropertiesScan
 @SpringBootApplication

--- a/apps/commerce-api/src/main/java/com/loopers/application/member/MemberModifyService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/member/MemberModifyService.java
@@ -13,6 +13,8 @@ import com.loopers.domain.member.DuplicateMemberIdException;
 import com.loopers.domain.member.Member;
 import com.loopers.domain.member.MemberId;
 import com.loopers.interfaces.api.member.dto.MemberV1Dto.Request.MemberRegisterRequest;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -54,7 +56,12 @@ public class MemberModifyService implements MemberRegister {
     @Override
     public Member usePoint(MemberId memberId, BigDecimal discountedPrice) {
         Member member = memberFinder.findByMemberIdWithPessimisticLock(memberId);
-        member.usePoint(discountedPrice);
+
+        try {
+            member.usePoint(discountedPrice);
+        } catch (IllegalArgumentException e) {
+            throw new CoreException(ErrorType.BAD_REQUEST, e.getMessage());
+        }
         return member;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderModifyService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderModifyService.java
@@ -1,11 +1,16 @@
 package com.loopers.application.order;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import com.loopers.application.provided.OrderRegister;
 import com.loopers.application.required.OrderRepository;
 import com.loopers.domain.order.CreateOrderSpec;
 import com.loopers.domain.order.Order;
+import com.loopers.domain.order.orderitem.CreateOrderItemSpec;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 
 import lombok.RequiredArgsConstructor;
 
@@ -15,8 +20,13 @@ public class OrderModifyService implements OrderRegister {
     private final OrderRepository orderRepository;
 
     @Override
-    public Order register(CreateOrderSpec createOrderSpec) {
-        Order order = Order.create(createOrderSpec);
-        return orderRepository.save(order);
+    public Order createOrder(CreateOrderSpec createOrderSpec, List<CreateOrderItemSpec> createOrderItemSpecs) {
+        try {
+            Order order = Order.create(createOrderSpec);
+            order.createOrderItems(createOrderItemSpecs);
+            return orderRepository.save(order);
+        } catch (IllegalArgumentException e) {
+            throw new CoreException(ErrorType.BAD_REQUEST, e.getMessage());
+        }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -48,8 +48,8 @@ public class ProductFacade {
     }
 
     @Transactional
-    public ProductInfoPageResponse findProductsInfoNormalization(String sort, List<Long> brandIds, Pageable pageable) {
-        Page<ProductWithLikeCount> withLikeCount = productFinder.findByBrandAndLikeCountNormalization(sort, brandIds, pageable);
+    public ProductInfoPageResponse findProductsInfoDenormalization(String sort, List<Long> brandIds, Pageable pageable) {
+        Page<ProductWithLikeCount> withLikeCount = productFinder.findByBrandAndLikeCountDenormalization(sort, brandIds, pageable);
 
         List<ProductInfo> productInfos
                 = withLikeCount.stream()
@@ -61,8 +61,8 @@ public class ProductFacade {
     }
 
     @Transactional
-    public ProductInfoPageResponse findProductsInfoDenormalization(String sort, List<Long> brandIds, Pageable pageable) {
-        Page<ProductWithLikeCount> withLikeCount = productFinder.findByBrandAndLikeCountDenormalization(sort, brandIds, pageable);
+    public ProductInfoPageResponse findProductsInfoDenormalizationWithRedis(String sort, List<Long> brandIds, Pageable pageable) {
+        Page<ProductWithLikeCount> withLikeCount = productFinder.findByBrandAndLikeCountDenormalizationWithRedis(sort, brandIds, pageable);
 
         List<ProductInfo> productInfos
                 = withLikeCount.stream()

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -48,6 +48,19 @@ public class ProductFacade {
     }
 
     @Transactional
+    public ProductInfoPageResponse findProductsInfoNormalization(String sort, List<Long> brandIds, Pageable pageable) {
+        Page<ProductWithLikeCount> withLikeCount = productFinder.findByBrandAndLikeCountNormalization(sort, brandIds, pageable);
+
+        List<ProductInfo> productInfos
+                = withLikeCount.stream()
+                               .map(p -> productBrandDomainService.findProductWithBrand(p.product(),
+                                                                                        p.product().getBrand(),
+                                                                                        p.likeCount()))
+                               .toList();
+        return ProductInfoPageResponse.from(new PageImpl<>(productInfos, pageable, withLikeCount.getTotalElements()));
+    }
+
+    @Transactional
     public ProductInfoPageResponse findProductsInfoDenormalization(String sort, List<Long> brandIds, Pageable pageable) {
         Page<ProductWithLikeCount> withLikeCount = productFinder.findByBrandAndLikeCountDenormalization(sort, brandIds, pageable);
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -35,8 +35,8 @@ public class ProductFacade {
     }
 
     @Transactional
-    public ProductInfoPageResponse findProductsInfo(String sort, Pageable pageable) {
-        Page<ProductWithLikeCount> withLikeCount = productFinder.findWithLikeCount(sort, pageable);
+    public ProductInfoPageResponse findProductsInfo(String sort, Long brandId, Pageable pageable) {
+        Page<ProductWithLikeCount> withLikeCount = productFinder.findWithLikeCount(sort, brandId, pageable);
 
         List<ProductInfo> productInfos
                 = withLikeCount.stream()

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -14,7 +14,7 @@ import com.loopers.domain.brand.Brand;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductBrandDomainService;
 import com.loopers.domain.product.ProductInfo;
-import com.loopers.infrastructure.product.ProductQueryDslRepositoryImpl.ProductWithLikeCount;
+import com.loopers.infrastructure.product.ProductWithLikeCount;
 import com.loopers.interfaces.api.product.dto.ProductV1Dto.Response.ProductInfoPageResponse;
 
 import lombok.RequiredArgsConstructor;

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -46,4 +46,17 @@ public class ProductFacade {
                                .toList();
         return ProductInfoPageResponse.from(new PageImpl<>(productInfos, pageable, withLikeCount.getTotalElements()));
     }
+
+    @Transactional
+    public ProductInfoPageResponse findProductsInfoDenormalization(String sort, List<Long> brandIds, Pageable pageable) {
+        Page<ProductWithLikeCount> withLikeCount = productFinder.findByBrandAndLikeCountDenormalization(sort, brandIds, pageable);
+
+        List<ProductInfo> productInfos
+                = withLikeCount.stream()
+                               .map(p -> productBrandDomainService.findProductWithBrand(p.product(),
+                                                                                        p.product().getBrand(),
+                                                                                        p.likeCount()))
+                               .toList();
+        return ProductInfoPageResponse.from(new PageImpl<>(productInfos, pageable, withLikeCount.getTotalElements()));
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -35,8 +35,8 @@ public class ProductFacade {
     }
 
     @Transactional
-    public ProductInfoPageResponse findProductsInfo(String sort, Long brandId, Pageable pageable) {
-        Page<ProductWithLikeCount> withLikeCount = productFinder.findWithLikeCount(sort, brandId, pageable);
+    public ProductInfoPageResponse findProductsInfo(String sort, List<Long> brandIds, Pageable pageable) {
+        Page<ProductWithLikeCount> withLikeCount = productFinder.findWithLikeCount(sort, brandIds, pageable);
 
         List<ProductInfo> productInfos
                 = withLikeCount.stream()

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductModifyService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductModifyService.java
@@ -2,8 +2,10 @@ package com.loopers.application.product;
 
 import org.springframework.stereotype.Service;
 
+import com.loopers.application.provided.ProductFinder;
 import com.loopers.application.provided.ProductRegister;
 import com.loopers.application.required.ProductRepository;
+import com.loopers.domain.product.CreateProductSpec;
 import com.loopers.domain.product.Product;
 
 import lombok.RequiredArgsConstructor;
@@ -12,9 +14,27 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ProductModifyService implements ProductRegister {
     private final ProductRepository productRepository;
+    private final ProductFinder productFinder;
 
     @Override
-    public Product register(Product product) {
+    public Product register(CreateProductSpec createProductSpec) {
+        Product product = createProductSpec.toEntity();
+        return productRepository.save(product);
+    }
+
+    @Override
+    public Product increaseLike(Long productId) {
+        Product product = productFinder.findProductPessimisticLock(productId);
+
+        product.increaseLikeCount();
+        return productRepository.save(product);
+    }
+
+    @Override
+    public Product decreaseLike(Long productId) {
+        Product product = productFinder.findProductPessimisticLock(productId);
+
+        product.decreaseLikeCount();
         return productRepository.save(product);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductModifyService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductModifyService.java
@@ -7,6 +7,7 @@ import com.loopers.application.provided.ProductRegister;
 import com.loopers.application.required.ProductRepository;
 import com.loopers.domain.product.CreateProductSpec;
 import com.loopers.domain.product.Product;
+import com.loopers.infrastructure.redis.RedisService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 public class ProductModifyService implements ProductRegister {
     private final ProductRepository productRepository;
     private final ProductFinder productFinder;
+    private final RedisService redisService;
 
     @Override
     public Product register(CreateProductSpec createProductSpec) {
@@ -25,9 +27,12 @@ public class ProductModifyService implements ProductRegister {
     @Override
     public Product increaseLike(Long productId) {
         Product product = productFinder.findProductPessimisticLock(productId);
-
         product.increaseLikeCount();
-        return productRepository.save(product);
+        Product savedProduct = productRepository.save(product);
+
+        String key = "product:like:" + product.getId();
+        redisService.save(key, product.getLikeCount());
+        return savedProduct;
     }
 
     @Override

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
@@ -50,8 +50,8 @@ public class ProductQueryService implements ProductFinder {
     }
 
     @Override
-    public Page<ProductWithLikeCount> findWithLikeCount(String sortKey, List<Long> brandId, Pageable pageable) {
-        return productRepository.findWithLikeCount(sortKey, brandId, pageable);
+    public Page<ProductWithLikeCount> findWithLikeCount(String sortKey, List<Long> brandIds, Pageable pageable) {
+        return productRepository.findWithLikeCount(sortKey, brandIds, pageable);
     }
 
     @Override

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
@@ -1,6 +1,7 @@
 package com.loopers.application.product;
 
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -87,7 +88,7 @@ public class ProductQueryService implements ProductFinder {
                                                                               () -> new CoreException(ErrorType.NOT_FOUND,
                                                                                                       "존재하지 않는 상품입니다."));
                                            likeCount = product.getLikeCount();
-                                           redisService.save(redisKey, likeCount);
+                                           redisService.save(redisKey, likeCount, Duration.ofMinutes(1));
                                        }
                                        return new ProductWithLikeCount(p.product(), p.brand(), likeCount);
                                    })

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
@@ -77,4 +77,11 @@ public class ProductQueryService implements ProductFinder {
         List<Product> products = productRepository.findByIdIn(productIds);
         return products.stream().collect(Collectors.toMap(Product::getId, Function.identity()));
     }
+
+    @Override
+    public Product findProductPessimisticLock(Long productId) {
+        return productRepository.findByIdPessimisticLock(productId)
+                                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND,
+                                                                     "상품을 찾을 수 없습니다 " + productId));
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
@@ -46,7 +46,14 @@ public class ProductQueryService implements ProductFinder {
 
     @Override
     public Page<ProductWithLikeCount> findWithLikeCount(String sortKey, Long brandId, Pageable pageable) {
-        return productRepository.findWithLikeCount(sortKey,brandId, pageable);
+        return productRepository.findWithLikeCount(sortKey, brandId, pageable);
+    }
+
+    @Override
+    public Page<ProductWithLikeCount> findByBrandAndLikeCountDenormalization(String sortKey,
+                                                                             List<Long> brandIds,
+                                                                             Pageable pageable) {
+        return productRepository.findByBrandAndLikeCountDenormalization(sortKey, brandIds, pageable);
     }
 
     @Override

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
@@ -75,11 +75,11 @@ public class ProductQueryService implements ProductFinder {
                 = productWithBrands.stream()
                                    .map(p -> {
                                        String redisKey = "product:like:" + p.product().getId();
-                                       Optional<Long> likeCountOpt = redisService.get(redisKey, Long.class);
+                                       Optional<Integer> likeCountOpt = redisService.get(redisKey, Integer.class);
 
                                        long likeCount;
                                        if (likeCountOpt.isPresent()) {
-                                           likeCount = likeCountOpt.get();
+                                           likeCount = likeCountOpt.get().longValue();
                                        } else {
                                            Product product
                                                    = productRepository.find(p.product().getId())

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
@@ -50,7 +50,7 @@ public class ProductQueryService implements ProductFinder {
     }
 
     @Override
-    public Page<ProductWithLikeCount> findWithLikeCount(String sortKey, Long brandId, Pageable pageable) {
+    public Page<ProductWithLikeCount> findWithLikeCount(String sortKey, List<Long> brandId, Pageable pageable) {
         return productRepository.findWithLikeCount(sortKey, brandId, pageable);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
@@ -55,6 +55,15 @@ public class ProductQueryService implements ProductFinder {
     }
 
     @Override
+    public Page<ProductWithLikeCount> findByBrandAndLikeCountNormalization(String sortKey, List<Long> brandIds,
+                                                                           Pageable pageable) {
+
+        Page<ProductWithLikeCount> productWithLikeCounts
+                = productRepository.findByBrandNormalization(sortKey, brandIds, pageable);
+        return productWithLikeCounts;
+    }
+
+    @Override
     public Page<ProductWithLikeCount> findByBrandAndLikeCountDenormalization(String sortKey,
                                                                              List<Long> brandIds,
                                                                              Pageable pageable) {

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
@@ -15,7 +15,7 @@ import com.loopers.application.provided.ProductFinder;
 import com.loopers.application.required.ProductRepository;
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.product.Product;
-import com.loopers.infrastructure.product.ProductQueryDslRepositoryImpl.ProductWithLikeCount;
+import com.loopers.infrastructure.product.ProductWithLikeCount;
 import com.loopers.interfaces.api.order.dto.OrderV1Dto.Request.CreateOrderRequest;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
@@ -53,7 +53,11 @@ public class ProductQueryService implements ProductFinder {
     public Page<ProductWithLikeCount> findByBrandAndLikeCountDenormalization(String sortKey,
                                                                              List<Long> brandIds,
                                                                              Pageable pageable) {
-        return productRepository.findByBrandAndLikeCountDenormalization(sortKey, brandIds, pageable);
+
+        Page<ProductWithLikeCount> productWithBrands
+                = productRepository.findByBrandDenormalization(sortKey, brandIds, pageable);
+
+        return productWithBrands;
     }
 
     @Override

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
@@ -45,8 +45,8 @@ public class ProductQueryService implements ProductFinder {
     }
 
     @Override
-    public Page<ProductWithLikeCount> findWithLikeCount(String sortKey, Pageable pageable) {
-        return productRepository.findWithLikeCount(sortKey, pageable);
+    public Page<ProductWithLikeCount> findWithLikeCount(String sortKey, Long brandId, Pageable pageable) {
+        return productRepository.findWithLikeCount(sortKey,brandId, pageable);
     }
 
     @Override

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryService.java
@@ -55,18 +55,18 @@ public class ProductQueryService implements ProductFinder {
     }
 
     @Override
-    public Page<ProductWithLikeCount> findByBrandAndLikeCountNormalization(String sortKey, List<Long> brandIds,
-                                                                           Pageable pageable) {
+    public Page<ProductWithLikeCount> findByBrandAndLikeCountDenormalization(String sortKey, List<Long> brandIds,
+                                                                             Pageable pageable) {
 
         Page<ProductWithLikeCount> productWithLikeCounts
-                = productRepository.findByBrandNormalization(sortKey, brandIds, pageable);
+                = productRepository.findByBrandDenormalizationWithLike(sortKey, brandIds, pageable);
         return productWithLikeCounts;
     }
 
     @Override
-    public Page<ProductWithLikeCount> findByBrandAndLikeCountDenormalization(String sortKey,
-                                                                             List<Long> brandIds,
-                                                                             Pageable pageable) {
+    public Page<ProductWithLikeCount> findByBrandAndLikeCountDenormalizationWithRedis(String sortKey,
+                                                                                      List<Long> brandIds,
+                                                                                      Pageable pageable) {
 
         Page<ProductWithBrand> productWithBrands
                 = productRepository.findByBrandDenormalization(sortKey, brandIds, pageable);

--- a/apps/commerce-api/src/main/java/com/loopers/application/provided/OrderRegister.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/provided/OrderRegister.java
@@ -1,8 +1,11 @@
 package com.loopers.application.provided;
 
+import java.util.List;
+
 import com.loopers.domain.order.CreateOrderSpec;
 import com.loopers.domain.order.Order;
+import com.loopers.domain.order.orderitem.CreateOrderItemSpec;
 
 public interface OrderRegister {
-    Order register(CreateOrderSpec createOrderSpec);
+    Order createOrder(CreateOrderSpec createOrderSpec, List<CreateOrderItemSpec> createOrderItemSpecs);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/provided/ProductFinder.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/provided/ProductFinder.java
@@ -22,6 +22,8 @@ public interface ProductFinder {
 
     Page<ProductWithLikeCount> findWithLikeCount(String sortKey, Long brandId, Pageable pageable);
 
+    Page<ProductWithLikeCount> findByBrandAndLikeCountDenormalization(String sortKey, List<Long> brandId, Pageable pageable);
+
     BigDecimal getTotalPrice(List<CreateOrderRequest> orderRequests);
 
     Map<Long, Product> getProductMap(List<Long> productIds);

--- a/apps/commerce-api/src/main/java/com/loopers/application/provided/ProductFinder.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/provided/ProductFinder.java
@@ -24,6 +24,8 @@ public interface ProductFinder {
 
     Page<ProductWithLikeCount> findByBrandAndLikeCountDenormalization(String sortKey, List<Long> brandId, Pageable pageable);
 
+    Page<ProductWithLikeCount> findByBrandAndLikeCountNormalization(String sortKey, List<Long> brandId, Pageable pageable);
+
     BigDecimal getTotalPrice(List<CreateOrderRequest> orderRequests);
 
     Map<Long, Product> getProductMap(List<Long> productIds);

--- a/apps/commerce-api/src/main/java/com/loopers/application/provided/ProductFinder.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/provided/ProductFinder.java
@@ -27,4 +27,6 @@ public interface ProductFinder {
     BigDecimal getTotalPrice(List<CreateOrderRequest> orderRequests);
 
     Map<Long, Product> getProductMap(List<Long> productIds);
+
+    Product findProductPessimisticLock(Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/provided/ProductFinder.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/provided/ProductFinder.java
@@ -24,7 +24,7 @@ public interface ProductFinder {
 
     Page<ProductWithLikeCount> findByBrandAndLikeCountDenormalization(String sortKey, List<Long> brandId, Pageable pageable);
 
-    Page<ProductWithLikeCount> findByBrandAndLikeCountNormalization(String sortKey, List<Long> brandId, Pageable pageable);
+    Page<ProductWithLikeCount> findByBrandAndLikeCountDenormalizationWithRedis(String sortKey, List<Long> brandId, Pageable pageable);
 
     BigDecimal getTotalPrice(List<CreateOrderRequest> orderRequests);
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/provided/ProductFinder.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/provided/ProductFinder.java
@@ -20,7 +20,7 @@ public interface ProductFinder {
 
     List<Product> findByBrand(Brand brand);
 
-    Page<ProductWithLikeCount> findWithLikeCount(String sortKey, Long brandId, Pageable pageable);
+    Page<ProductWithLikeCount> findWithLikeCount(String sortKey, List<Long> brandIds, Pageable pageable);
 
     Page<ProductWithLikeCount> findByBrandAndLikeCountDenormalization(String sortKey, List<Long> brandId, Pageable pageable);
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/provided/ProductFinder.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/provided/ProductFinder.java
@@ -10,7 +10,7 @@ import org.springframework.data.domain.Sort;
 
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.product.Product;
-import com.loopers.infrastructure.product.ProductQueryDslRepositoryImpl.ProductWithLikeCount;
+import com.loopers.infrastructure.product.ProductWithLikeCount;
 import com.loopers.interfaces.api.order.dto.OrderV1Dto.Request.CreateOrderRequest;
 
 public interface ProductFinder {

--- a/apps/commerce-api/src/main/java/com/loopers/application/provided/ProductFinder.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/provided/ProductFinder.java
@@ -20,7 +20,7 @@ public interface ProductFinder {
 
     List<Product> findByBrand(Brand brand);
 
-    Page<ProductWithLikeCount> findWithLikeCount(String sortKey, Pageable pageable);
+    Page<ProductWithLikeCount> findWithLikeCount(String sortKey, Long brandId, Pageable pageable);
 
     BigDecimal getTotalPrice(List<CreateOrderRequest> orderRequests);
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/provided/ProductRegister.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/provided/ProductRegister.java
@@ -1,7 +1,12 @@
 package com.loopers.application.provided;
 
+import com.loopers.domain.product.CreateProductSpec;
 import com.loopers.domain.product.Product;
 
 public interface ProductRegister {
-    Product register(Product product);
+    Product register(CreateProductSpec createProductSpec);
+
+    Product increaseLike(Long product);
+
+    Product decreaseLike(Long product);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/required/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/required/ProductRepository.java
@@ -23,7 +23,9 @@ public interface ProductRepository {
 
     Page<ProductWithLikeCount> findWithLikeCount(String sortKey, Long brandId, Pageable pageable);
 
-    Page<ProductWithBrand> findByBrandDenormalization(String sortKey, List<Long> brandId, Pageable pageable);
+    Page<ProductWithLikeCount> findByBrandNormalization(String sortKey, List<Long> brandIds, Pageable pageable);
+
+    Page<ProductWithBrand> findByBrandDenormalization(String sortKey, List<Long> brandIds, Pageable pageable);
 
     List<Product> findByIdIn(List<Long> productIds);
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/required/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/required/ProductRepository.java
@@ -20,7 +20,7 @@ public interface ProductRepository {
 
     List<Product> findByBrand(Brand brand);
 
-    Page<ProductWithLikeCount> findWithLikeCount(String sortKey, Pageable pageable);
+    Page<ProductWithLikeCount> findWithLikeCount(String sortKey, Long brandId, Pageable pageable);
 
     List<Product> findByIdIn(List<Long> productIds);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/required/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/required/ProductRepository.java
@@ -21,7 +21,7 @@ public interface ProductRepository {
 
     List<Product> findByBrand(Brand brand);
 
-    Page<ProductWithLikeCount> findWithLikeCount(String sortKey, Long brandId, Pageable pageable);
+    Page<ProductWithLikeCount> findWithLikeCount(String sortKey, List<Long> brandIds, Pageable pageable);
 
     Page<ProductWithLikeCount> findByBrandNormalization(String sortKey, List<Long> brandIds, Pageable pageable);
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/required/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/required/ProductRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.domain.Sort;
 
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.product.Product;
-import com.loopers.infrastructure.product.ProductQueryDslRepositoryImpl.ProductWithLikeCount;
+import com.loopers.infrastructure.product.ProductWithLikeCount;
 
 public interface ProductRepository {
     Product save(Product product);
@@ -22,7 +22,7 @@ public interface ProductRepository {
 
     Page<ProductWithLikeCount> findWithLikeCount(String sortKey, Long brandId, Pageable pageable);
 
-    Page<ProductWithLikeCount> findByBrandAndLikeCountDenormalization(String sortKey, List<Long> brandId, Pageable pageable);
+    Page<ProductWithLikeCount> findByBrandDenormalization(String sortKey, List<Long> brandId, Pageable pageable);
 
     List<Product> findByIdIn(List<Long> productIds);
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/required/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/required/ProductRepository.java
@@ -26,4 +26,5 @@ public interface ProductRepository {
 
     List<Product> findByIdIn(List<Long> productIds);
 
+    Optional<Product> findByIdPessimisticLock(Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/required/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/required/ProductRepository.java
@@ -22,5 +22,8 @@ public interface ProductRepository {
 
     Page<ProductWithLikeCount> findWithLikeCount(String sortKey, Long brandId, Pageable pageable);
 
+    Page<ProductWithLikeCount> findByBrandAndLikeCountDenormalization(String sortKey, List<Long> brandId, Pageable pageable);
+
     List<Product> findByIdIn(List<Long> productIds);
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/required/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/required/ProductRepository.java
@@ -23,7 +23,7 @@ public interface ProductRepository {
 
     Page<ProductWithLikeCount> findWithLikeCount(String sortKey, List<Long> brandIds, Pageable pageable);
 
-    Page<ProductWithLikeCount> findByBrandNormalization(String sortKey, List<Long> brandIds, Pageable pageable);
+    Page<ProductWithLikeCount> findByBrandDenormalizationWithLike(String sortKey, List<Long> brandIds, Pageable pageable);
 
     Page<ProductWithBrand> findByBrandDenormalization(String sortKey, List<Long> brandIds, Pageable pageable);
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/required/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/required/ProductRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Sort;
 
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.product.Product;
+import com.loopers.infrastructure.product.ProductWithBrand;
 import com.loopers.infrastructure.product.ProductWithLikeCount;
 
 public interface ProductRepository {
@@ -22,7 +23,7 @@ public interface ProductRepository {
 
     Page<ProductWithLikeCount> findWithLikeCount(String sortKey, Long brandId, Pageable pageable);
 
-    Page<ProductWithLikeCount> findByBrandDenormalization(String sortKey, List<Long> brandId, Pageable pageable);
+    Page<ProductWithBrand> findByBrandDenormalization(String sortKey, List<Long> brandId, Pageable pageable);
 
     List<Product> findByIdIn(List<Long> productIds);
 

--- a/apps/commerce-api/src/main/java/com/loopers/config/RedisConfig.java
+++ b/apps/commerce-api/src/main/java/com/loopers/config/RedisConfig.java
@@ -7,10 +7,12 @@ import org.springframework.data.redis.connection.RedisPassword;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
+@EnableRedisRepositories
 public class RedisConfig {
 
     @Bean

--- a/apps/commerce-api/src/main/java/com/loopers/config/RedisConfig.java
+++ b/apps/commerce-api/src/main/java/com/loopers/config/RedisConfig.java
@@ -3,9 +3,10 @@ package com.loopers.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisPassword;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -17,13 +18,13 @@ public class RedisConfig {
         RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration();
         redisConfig.setHostName("localhost");
         redisConfig.setPort(6379);
-        redisConfig.setPassword("yong");
+        redisConfig.setPassword(RedisPassword.of("yong"));
         return new LettuceConnectionFactory(redisConfig);
     }
 
     @Bean
-    StringRedisTemplate stringRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
-        StringRedisTemplate template = new StringRedisTemplate();
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(redisConnectionFactory);
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new GenericJackson2JsonRedisSerializer());

--- a/apps/commerce-api/src/main/java/com/loopers/config/RedisConfig.java
+++ b/apps/commerce-api/src/main/java/com/loopers/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package com.loopers.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration();
+        redisConfig.setHostName("localhost");
+        redisConfig.setPort(6379);
+        redisConfig.setPassword("yong");
+        return new LettuceConnectionFactory(redisConfig);
+    }
+
+    @Bean
+    StringRedisTemplate stringRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        StringRedisTemplate template = new StringRedisTemplate();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/inventory/Inventory.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/inventory/Inventory.java
@@ -34,7 +34,7 @@ public class Inventory extends BaseEntity {
 
     public static Inventory create(Long productId, Long quantity) {
         if (quantity < 0) {
-            throw new CoreException(ErrorType.BAD_REQUEST, "재고량은 0 미만이 될 수 없습니다: " + quantity);
+            throw new IllegalArgumentException("재고량은 0 미만이 될 수 없습니다: " + quantity);
         }
         return new Inventory(productId, quantity);
     }
@@ -45,15 +45,15 @@ public class Inventory extends BaseEntity {
 
     public void decrease(Long quantity) {
         if (quantity <= 0) {
-            throw new CoreException(ErrorType.BAD_REQUEST, "잘못 된 요청 값입니다. : " + quantity);
+            throw new IllegalArgumentException("잘못 된 요청 값입니다. : " + quantity);
         }
 
         if (this.quantity <= 0 || this.quantity < quantity) {
-            throw new CoreException(ErrorType.BAD_REQUEST, "잔여 재고가 없습니다.");
+            throw new IllegalArgumentException("잔여 재고가 없습니다.");
         }
 
         if (inventoryStatus == InventoryStatus.SOLD_OUT) {
-            throw new CoreException(ErrorType.BAD_REQUEST, "품절입니다.");
+            throw new IllegalArgumentException("품절입니다.");
         }
 
         this.quantity -= quantity;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/member/point/Point.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/member/point/Point.java
@@ -31,7 +31,7 @@ public class Point extends BaseEntity {
 
     public BigDecimal charge(BigDecimal amount) {
         if (amount.intValue() <= 0) {
-            throw new CoreException(ErrorType.BAD_REQUEST, "잘못된 충전 포인트입니다 : " + amount);
+            throw new IllegalArgumentException("잘못된 충전 포인트입니다 : " + amount);
         }
         this.amount = this.amount.add(amount);
         return this.amount;
@@ -39,7 +39,7 @@ public class Point extends BaseEntity {
 
     public BigDecimal usePoint(BigDecimal amount) {
         if (this.amount.intValue() <= 0 || this.amount.compareTo(amount) < 0) {
-            throw new CoreException(ErrorType.BAD_REQUEST, "잔액이 부족합니다.");
+            throw new IllegalArgumentException("잔액이 부족합니다.");
         }
         this.amount = this.amount.subtract(amount);
         return this.amount;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.loopers.domain.BaseEntity;
+import com.loopers.domain.order.orderitem.CreateOrderItemSpec;
 import com.loopers.domain.order.orderitem.OrderItem;
 import com.loopers.interfaces.api.order.dto.OrderV1Dto.Request.CreateOrderRequest;
 import com.loopers.support.error.CoreException;
@@ -48,7 +49,7 @@ public class Order extends BaseEntity {
 
     public static Order create(CreateOrderSpec createSpec) {
         if (createSpec.memberId() == null) {
-            throw new CoreException(ErrorType.BAD_REQUEST, "사용자는 필수입니다.");
+            throw new IllegalArgumentException("사용자는 필수입니다.");
         }
         return new Order(createSpec.memberId());
     }
@@ -58,9 +59,9 @@ public class Order extends BaseEntity {
         this.orderItems.add(orderItem);
     }
 
-    public Order createOrderItems(List<CreateOrderRequest> createOrderRequests) {
-        for (CreateOrderRequest createOrderRequest : createOrderRequests) {
-            addOrderItem(createOrderRequest.productId(), createOrderRequest.quantity());
+    public Order createOrderItems(List<CreateOrderItemSpec> createOrderItemSpecs) {
+        for (CreateOrderItemSpec createOrderItemSpec : createOrderItemSpecs) {
+            addOrderItem(createOrderItemSpec.productId(), createOrderItemSpec.quantity());
         }
         return this;
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/CreateProductSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/CreateProductSpec.java
@@ -1,0 +1,12 @@
+package com.loopers.domain.product;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+
+import com.loopers.domain.brand.Brand;
+
+public record CreateProductSpec(String name, String description, BigDecimal price, Brand brand, ZonedDateTime latestAt) {
+    public Product toEntity() {
+        return Product.create(name, description, price, brand, latestAt);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -36,6 +36,7 @@ public class Product extends BaseEntity {
         this.price = price;
         this.brand = brand;
         this.latestAt = latestAt;
+        this.likeCount = 0L;
     }
 
     public static Product create(String name, String description, BigDecimal price, Brand brand, ZonedDateTime latestAt) {
@@ -44,6 +45,14 @@ public class Product extends BaseEntity {
 
     public BigDecimal getTotalPrice(BigDecimal quantity) {
         return this.price.multiply(quantity);
+    }
+
+    public void increaseLikeCount() {
+        this.likeCount += 1L;
+    }
+
+    public void decreaseLikeCount() {
+        this.likeCount -= 1L;
     }
 }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -24,6 +24,7 @@ public class Product extends BaseEntity {
     private String description;
     private BigDecimal price;
     private ZonedDateTime latestAt;
+    private Long likeCount;
 
     @JoinColumn(name = "brand_id")
     @ManyToOne(fetch = FetchType.LAZY)

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -1,12 +1,22 @@
 package com.loopers.infrastructure.product;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.product.Product;
 
+import jakarta.persistence.LockModeType;
+
 public interface ProductJpaRepository extends JpaRepository<Product, Long>, ProductQueryDslRepository {
     List<Product> findByBrand(Brand brand);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select p from Product p where p.id= :productId")
+    Optional<Product> findByIdPessimisticLock(@Param("productId") Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Pageable;
 import com.loopers.infrastructure.product.ProductQueryDslRepositoryImpl.ProductWithLikeCount;
 
 public interface ProductQueryDslRepository {
-    Page<ProductWithLikeCount> findByBrandAndLikeCount(String sortKey, Pageable pageable);
+    Page<ProductWithLikeCount> findByBrandAndLikeCount(String sortKey, Long brandId, Pageable pageable);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepository.java
@@ -5,10 +5,8 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import com.loopers.infrastructure.product.ProductQueryDslRepositoryImpl.ProductWithLikeCount;
-
 public interface ProductQueryDslRepository {
     Page<ProductWithLikeCount> findByBrandAndLikeCount(String sortKey, Long brandId, Pageable pageable);
 
-    Page<ProductWithLikeCount> findByBrandAndLikeCountDenormalization(String sortKey, List<Long> brandId, Pageable pageable);
+    Page<ProductWithLikeCount> findByBrandDenormalization(String sortKey, List<Long> brandId, Pageable pageable);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepository.java
@@ -1,5 +1,7 @@
 package com.loopers.infrastructure.product;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -7,4 +9,6 @@ import com.loopers.infrastructure.product.ProductQueryDslRepositoryImpl.ProductW
 
 public interface ProductQueryDslRepository {
     Page<ProductWithLikeCount> findByBrandAndLikeCount(String sortKey, Long brandId, Pageable pageable);
+
+    Page<ProductWithLikeCount> findByBrandAndLikeCountDenormalization(String sortKey, List<Long> brandId, Pageable pageable);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ProductQueryDslRepository {
-    Page<ProductWithLikeCount> findByBrandAndLikeCount(String sortKey, Long brandId, Pageable pageable);
+    Page<ProductWithLikeCount> findByBrandAndLikeCount(String sortKey, List<Long> brandIds, Pageable pageable);
 
     Page<ProductWithLikeCount> findByBrandNormalization(String sortKey, List<Long> brandIds, Pageable pageable);
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepository.java
@@ -8,5 +8,7 @@ import org.springframework.data.domain.Pageable;
 public interface ProductQueryDslRepository {
     Page<ProductWithLikeCount> findByBrandAndLikeCount(String sortKey, Long brandId, Pageable pageable);
 
-    Page<ProductWithBrand> findByBrandDenormalization(String sortKey, List<Long> brandId, Pageable pageable);
+    Page<ProductWithLikeCount> findByBrandNormalization(String sortKey, List<Long> brandIds, Pageable pageable);
+
+    Page<ProductWithBrand> findByBrandDenormalization(String sortKey, List<Long> brandIds, Pageable pageable);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Pageable;
 public interface ProductQueryDslRepository {
     Page<ProductWithLikeCount> findByBrandAndLikeCount(String sortKey, List<Long> brandIds, Pageable pageable);
 
-    Page<ProductWithLikeCount> findByBrandNormalization(String sortKey, List<Long> brandIds, Pageable pageable);
+    Page<ProductWithLikeCount> findByBrandDenormalizationWithLike(String sortKey, List<Long> brandIds, Pageable pageable);
 
     Page<ProductWithBrand> findByBrandDenormalization(String sortKey, List<Long> brandIds, Pageable pageable);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepository.java
@@ -8,5 +8,5 @@ import org.springframework.data.domain.Pageable;
 public interface ProductQueryDslRepository {
     Page<ProductWithLikeCount> findByBrandAndLikeCount(String sortKey, Long brandId, Pageable pageable);
 
-    Page<ProductWithLikeCount> findByBrandDenormalization(String sortKey, List<Long> brandId, Pageable pageable);
+    Page<ProductWithBrand> findByBrandDenormalization(String sortKey, List<Long> brandId, Pageable pageable);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepositoryImpl.java
@@ -25,7 +25,7 @@ public class ProductQueryDslRepositoryImpl implements ProductQueryDslRepository 
     private final JPQLQueryFactory queryFactory;
 
     @Override
-    public Page<ProductWithLikeCount> findByBrandAndLikeCount(String sortKey, Long brandId, Pageable pageable) {
+    public Page<ProductWithLikeCount> findByBrandAndLikeCount(String sortKey, List<Long> brandIds, Pageable pageable) {
         OrderSpecifier<?> orderSpecifier = getOrderSpecifier(sortKey, product);
 
         List<ProductWithLikeCount> content = queryFactory
@@ -37,7 +37,7 @@ public class ProductQueryDslRepositoryImpl implements ProductQueryDslRepository 
                 .from(product)
                 .leftJoin(product.brand, brand).fetchJoin()
                 .leftJoin(productLike).on(productLike.product.eq(product))
-                .where(brand.id.eq(brandId))
+                .where(brand.id.in(brandIds))
                 .groupBy(product.id)
                 .orderBy(orderSpecifier)
                 .offset(pageable.getOffset())

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepositoryImpl.java
@@ -33,7 +33,7 @@ public class ProductQueryDslRepositoryImpl implements ProductQueryDslRepository 
     ) {}
 
     @Override
-    public Page<ProductWithLikeCount> findByBrandAndLikeCount(String sortKey, Pageable pageable) {
+    public Page<ProductWithLikeCount> findByBrandAndLikeCount(String sortKey, Long brandId, Pageable pageable) {
         OrderSpecifier<?> orderSpecifier = getOrderSpecifier(sortKey, product);
 
         List<ProductWithLikeCount> content = queryFactory
@@ -45,6 +45,7 @@ public class ProductQueryDslRepositoryImpl implements ProductQueryDslRepository 
                 .from(product)
                 .leftJoin(product.brand, brand).fetchJoin()
                 .leftJoin(productLike).on(productLike.product.eq(product))
+                .where(brand.id.eq(brandId))
                 .groupBy(product.id)
                 .orderBy(orderSpecifier)
                 .offset(pageable.getOffset())
@@ -68,6 +69,7 @@ public class ProductQueryDslRepositoryImpl implements ProductQueryDslRepository 
             case "price" -> product.price.desc();
             case "createdAt" -> product.createdAt.desc();
             case "latestAt" -> product.latestAt.desc();
+            case "LIKE_COUNT_DESC" -> productLike.countDistinct().desc();
             default -> throw new IllegalArgumentException("지원하지 않는 정렬 조건: " + sortKey);
         };
     }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepositoryImpl.java
@@ -57,7 +57,7 @@ public class ProductQueryDslRepositoryImpl implements ProductQueryDslRepository 
     }
 
     @Override
-    public Page<ProductWithLikeCount> findByBrandNormalization(String sortKey, List<Long> brandIds, Pageable pageable) {
+    public Page<ProductWithLikeCount> findByBrandDenormalizationWithLike(String sortKey, List<Long> brandIds, Pageable pageable) {
         OrderSpecifier<?> orderSpecifier = getOrderSpecifier(sortKey, product);
 
         List<ProductWithLikeCount> content = queryFactory

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepositoryImpl.java
@@ -57,16 +57,15 @@ public class ProductQueryDslRepositoryImpl implements ProductQueryDslRepository 
     }
 
     @Override
-    public Page<ProductWithLikeCount> findByBrandDenormalization(String sortKey,
-                                                                 List<Long> brandIds,
-                                                                 Pageable pageable) {
+    public Page<ProductWithBrand> findByBrandDenormalization(String sortKey,
+                                                             List<Long> brandIds,
+                                                             Pageable pageable) {
         OrderSpecifier<?> orderSpecifier = getOrderSpecifier(sortKey, product);
 
-        List<ProductWithLikeCount> content = queryFactory
-                .select(Projections.constructor(ProductWithLikeCount.class,
+        List<ProductWithBrand> content = queryFactory
+                .select(Projections.constructor(ProductWithBrand.class,
                                                 product,
-                                                brand,
-                                                product.likeCount
+                                                brand
                 ))
                 .from(product)
                 .leftJoin(product.brand, brand)

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepositoryImpl.java
@@ -12,8 +12,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Component;
 
-import com.loopers.domain.brand.Brand;
-import com.loopers.domain.product.Product;
 import com.loopers.domain.product.QProduct;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
@@ -25,12 +23,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ProductQueryDslRepositoryImpl implements ProductQueryDslRepository {
     private final JPQLQueryFactory queryFactory;
-
-    public record ProductWithLikeCount(
-            Product product,
-            Brand brand,
-            Long likeCount
-    ) {}
 
     @Override
     public Page<ProductWithLikeCount> findByBrandAndLikeCount(String sortKey, Long brandId, Pageable pageable) {
@@ -56,25 +48,24 @@ public class ProductQueryDslRepositoryImpl implements ProductQueryDslRepository 
                 content,
                 pageable,
                 () -> Optional.ofNullable(queryFactory
-                        .select(product.id.countDistinct())
-                        .from(product)
-                        .leftJoin(productLike).on(productLike.product.eq(product))
-                        .fetchOne()
+                                                  .select(product.id.countDistinct())
+                                                  .from(product)
+                                                  .leftJoin(productLike).on(productLike.product.eq(product))
+                                                  .fetchOne()
                 ).orElse(0L)
         );
     }
 
     @Override
-    public Page<ProductWithLikeCount> findByBrandAndLikeCountDenormalization(String sortKey,
-                                                                             List<Long> brandIds,
-                                                                             Pageable pageable) {
+    public Page<ProductWithLikeCount> findByBrandDenormalization(String sortKey,
+                                                                 List<Long> brandIds,
+                                                                 Pageable pageable) {
         OrderSpecifier<?> orderSpecifier = getOrderSpecifier(sortKey, product);
 
         List<ProductWithLikeCount> content = queryFactory
                 .select(Projections.constructor(ProductWithLikeCount.class,
                                                 product,
-                                                brand,
-                                                product.likeCount
+                                                brand
                 ))
                 .from(product)
                 .leftJoin(product.brand, brand)

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductQueryDslRepositoryImpl.java
@@ -65,7 +65,8 @@ public class ProductQueryDslRepositoryImpl implements ProductQueryDslRepository 
         List<ProductWithLikeCount> content = queryFactory
                 .select(Projections.constructor(ProductWithLikeCount.class,
                                                 product,
-                                                brand
+                                                brand,
+                                                product.likeCount
                 ))
                 .from(product)
                 .leftJoin(product.brand, brand)

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Repository;
 import com.loopers.application.required.ProductRepository;
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.product.Product;
-import com.loopers.infrastructure.product.ProductQueryDslRepositoryImpl.ProductWithLikeCount;
 
 import lombok.RequiredArgsConstructor;
 
@@ -46,10 +45,10 @@ public class ProductRepositoryImpl implements ProductRepository {
     }
 
     @Override
-    public Page<ProductWithLikeCount> findByBrandAndLikeCountDenormalization(String sortKey,
-                                                                             List<Long> brandIds,
-                                                                             Pageable pageable) {
-        return productJpaRepository.findByBrandAndLikeCountDenormalization(sortKey, brandIds, pageable);
+    public Page<ProductWithLikeCount> findByBrandDenormalization(String sortKey,
+                                                                 List<Long> brandIds,
+                                                                 Pageable pageable) {
+        return productJpaRepository.findByBrandDenormalization(sortKey, brandIds, pageable);
     }
 
     @Override

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -40,8 +40,8 @@ public class ProductRepositoryImpl implements ProductRepository {
     }
 
     @Override
-    public Page<ProductWithLikeCount> findWithLikeCount(String sortKey, Long brandId, Pageable pageable) {
-        return productJpaRepository.findByBrandAndLikeCount(sortKey, brandId, pageable);
+    public Page<ProductWithLikeCount> findWithLikeCount(String sortKey, List<Long> brandIds, Pageable pageable) {
+        return productJpaRepository.findByBrandAndLikeCount(sortKey, brandIds, pageable);
     }
 
     @Override

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -41,8 +41,8 @@ public class ProductRepositoryImpl implements ProductRepository {
     }
 
     @Override
-    public Page<ProductWithLikeCount> findWithLikeCount(String sortKey, Pageable pageable) {
-        return productJpaRepository.findByBrandAndLikeCount(sortKey, pageable);
+    public Page<ProductWithLikeCount> findWithLikeCount(String sortKey, Long brandId, Pageable pageable) {
+        return productJpaRepository.findByBrandAndLikeCount(sortKey, brandId, pageable);
     }
 
     @Override

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -55,4 +55,9 @@ public class ProductRepositoryImpl implements ProductRepository {
     public List<Product> findByIdIn(List<Long> productIds) {
         return productJpaRepository.findAllById(productIds);
     }
+
+    @Override
+    public Optional<Product> findByIdPessimisticLock(Long productId) {
+        return productJpaRepository.findByIdPessimisticLock(productId);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -45,14 +45,14 @@ public class ProductRepositoryImpl implements ProductRepository {
     }
 
     @Override
-    public Page<ProductWithLikeCount> findByBrandNormalization(String sortKey, List<Long> brandIds, Pageable pageable) {
-        return productJpaRepository.findByBrandNormalization(sortKey, brandIds, pageable);
+    public Page<ProductWithLikeCount> findByBrandDenormalizationWithLike(String sortKey, List<Long> brandIds, Pageable pageable) {
+        return productJpaRepository.findByBrandDenormalizationWithLike(sortKey, brandIds, pageable);
     }
 
     @Override
     public Page<ProductWithBrand> findByBrandDenormalization(String sortKey,
-                                                                 List<Long> brandIds,
-                                                                 Pageable pageable) {
+                                                             List<Long> brandIds,
+                                                             Pageable pageable) {
         return productJpaRepository.findByBrandDenormalization(sortKey, brandIds, pageable);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -45,7 +45,7 @@ public class ProductRepositoryImpl implements ProductRepository {
     }
 
     @Override
-    public Page<ProductWithLikeCount> findByBrandDenormalization(String sortKey,
+    public Page<ProductWithBrand> findByBrandDenormalization(String sortKey,
                                                                  List<Long> brandIds,
                                                                  Pageable pageable) {
         return productJpaRepository.findByBrandDenormalization(sortKey, brandIds, pageable);

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -45,6 +45,11 @@ public class ProductRepositoryImpl implements ProductRepository {
     }
 
     @Override
+    public Page<ProductWithLikeCount> findByBrandNormalization(String sortKey, List<Long> brandIds, Pageable pageable) {
+        return productJpaRepository.findByBrandNormalization(sortKey, brandIds, pageable);
+    }
+
+    @Override
     public Page<ProductWithBrand> findByBrandDenormalization(String sortKey,
                                                                  List<Long> brandIds,
                                                                  Pageable pageable) {

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -46,6 +46,13 @@ public class ProductRepositoryImpl implements ProductRepository {
     }
 
     @Override
+    public Page<ProductWithLikeCount> findByBrandAndLikeCountDenormalization(String sortKey,
+                                                                             List<Long> brandIds,
+                                                                             Pageable pageable) {
+        return productJpaRepository.findByBrandAndLikeCountDenormalization(sortKey, brandIds, pageable);
+    }
+
+    @Override
     public List<Product> findByIdIn(List<Long> productIds) {
         return productJpaRepository.findAllById(productIds);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductWithBrand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductWithBrand.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.product;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.product.Product;
+
+public record ProductWithBrand(Product product, Brand brand) {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductWithLikeCount.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductWithLikeCount.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.product;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.product.Product;
+
+public record ProductWithLikeCount(Product product, Brand brand, Long likeCount) {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/redis/RedisService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/redis/RedisService.java
@@ -1,6 +1,8 @@
 package com.loopers.infrastructure.redis;
 
 import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.redis.core.RedisTemplate;
@@ -31,5 +33,15 @@ public class RedisService {
 
     public void delete(String key) {
         redisTemplate.delete(key);
+    }
+
+    public <T> List<T> multiGet(List<String> keys, Class<T> type) {
+        List<Object> objects = redisTemplate.opsForValue().multiGet(keys);
+        if (objects == null || objects.size() == 0) {
+            return Collections.emptyList();
+        }
+        return objects
+                .stream().map(type::cast)
+                .toList();
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/redis/RedisService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/redis/RedisService.java
@@ -1,0 +1,35 @@
+package com.loopers.infrastructure.redis;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RedisService {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void save(String key, Object value) {
+        redisTemplate.opsForValue().set(key, value);
+    }
+
+    public void save(String key, Object value, Duration ttl) {
+        redisTemplate.opsForValue().set(key, value, ttl);
+    }
+
+    public <T> Optional<T> get(String key, Class<T> type) {
+        Object value = redisTemplate.opsForValue().get(key);
+        if (value == null) {
+            return Optional.empty();
+        }
+        return Optional.of(type.cast(value));
+    }
+
+    public void delete(String key) {
+        redisTemplate.delete(key);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiController.java
@@ -1,5 +1,7 @@
 package com.loopers.interfaces.api.product;
 
+import java.util.List;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,6 +25,14 @@ public class ProductV1ApiController {
                                                                 @RequestParam Long brandId,
                                                                 Pageable pageable) {
         ProductInfoPageResponse productsInfoResponse = productFacade.findProductsInfo(sort, brandId, pageable);
+        return ApiResponse.success(productsInfoResponse);
+    }
+
+    @GetMapping("/denormalization")
+    public ApiResponse<ProductInfoPageResponse> getProductsInfoDenormalization(@RequestParam String sort,
+                                                                               @RequestParam List<Long> brandIds,
+                                                                               Pageable pageable) {
+        ProductInfoPageResponse productsInfoResponse = productFacade.findProductsInfoDenormalization(sort, brandIds, pageable);
         return ApiResponse.success(productsInfoResponse);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiController.java
@@ -28,7 +28,7 @@ public class ProductV1ApiController {
         return ApiResponse.success(productsInfoResponse);
     }
 
-    @GetMapping("/normalization")
+    @GetMapping("/denormalization")
     public ApiResponse<ProductInfoPageResponse> getProductsInfoDenormalization(@RequestParam String sort,
                                                                                         @RequestParam List<Long> brandIds,
                                                                                         Pageable pageable) {

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiController.java
@@ -19,8 +19,10 @@ public class ProductV1ApiController {
     private final ProductFacade productFacade;
 
     @GetMapping
-    public ApiResponse<ProductInfoPageResponse> getProductsInfo(@RequestParam String sort, Pageable pageable) {
-        ProductInfoPageResponse productsInfoResponse = productFacade.findProductsInfo(sort, pageable);
+    public ApiResponse<ProductInfoPageResponse> getProductsInfo(@RequestParam String sort,
+                                                                @RequestParam Long brandId,
+                                                                Pageable pageable) {
+        ProductInfoPageResponse productsInfoResponse = productFacade.findProductsInfo(sort, brandId, pageable);
         return ApiResponse.success(productsInfoResponse);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiController.java
@@ -22,9 +22,9 @@ public class ProductV1ApiController {
 
     @GetMapping
     public ApiResponse<ProductInfoPageResponse> getProductsInfo(@RequestParam String sort,
-                                                                @RequestParam Long brandId,
+                                                                @RequestParam List<Long> brandIds,
                                                                 Pageable pageable) {
-        ProductInfoPageResponse productsInfoResponse = productFacade.findProductsInfo(sort, brandId, pageable);
+        ProductInfoPageResponse productsInfoResponse = productFacade.findProductsInfo(sort, brandIds, pageable);
         return ApiResponse.success(productsInfoResponse);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiController.java
@@ -36,7 +36,7 @@ public class ProductV1ApiController {
         return ApiResponse.success(productsInfoResponse);
     }
 
-    @GetMapping("/denormalization")
+    @GetMapping("/redis")
     public ApiResponse<ProductInfoPageResponse> getProductsInfoDenormalizationWithRedis(@RequestParam String sort,
                                                                                         @RequestParam List<Long> brandIds,
                                                                                         Pageable pageable) {

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiController.java
@@ -29,18 +29,18 @@ public class ProductV1ApiController {
     }
 
     @GetMapping("/normalization")
-    public ApiResponse<ProductInfoPageResponse> getProductsInfoNormalization(@RequestParam String sort,
-                                                                               @RequestParam List<Long> brandIds,
-                                                                               Pageable pageable) {
-        ProductInfoPageResponse productsInfoResponse = productFacade.findProductsInfoNormalization(sort, brandIds, pageable);
+    public ApiResponse<ProductInfoPageResponse> getProductsInfoDenormalization(@RequestParam String sort,
+                                                                                        @RequestParam List<Long> brandIds,
+                                                                                        Pageable pageable) {
+        ProductInfoPageResponse productsInfoResponse = productFacade.findProductsInfoDenormalization(sort, brandIds, pageable);
         return ApiResponse.success(productsInfoResponse);
     }
 
     @GetMapping("/denormalization")
-    public ApiResponse<ProductInfoPageResponse> getProductsInfoDenormalization(@RequestParam String sort,
-                                                                               @RequestParam List<Long> brandIds,
-                                                                               Pageable pageable) {
-        ProductInfoPageResponse productsInfoResponse = productFacade.findProductsInfoDenormalization(sort, brandIds, pageable);
+    public ApiResponse<ProductInfoPageResponse> getProductsInfoDenormalizationWithRedis(@RequestParam String sort,
+                                                                                        @RequestParam List<Long> brandIds,
+                                                                                        Pageable pageable) {
+        ProductInfoPageResponse productsInfoResponse = productFacade.findProductsInfoDenormalizationWithRedis(sort, brandIds, pageable);
         return ApiResponse.success(productsInfoResponse);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiController.java
@@ -28,6 +28,14 @@ public class ProductV1ApiController {
         return ApiResponse.success(productsInfoResponse);
     }
 
+    @GetMapping("/normalization")
+    public ApiResponse<ProductInfoPageResponse> getProductsInfoNormalization(@RequestParam String sort,
+                                                                               @RequestParam List<Long> brandIds,
+                                                                               Pageable pageable) {
+        ProductInfoPageResponse productsInfoResponse = productFacade.findProductsInfoNormalization(sort, brandIds, pageable);
+        return ApiResponse.success(productsInfoResponse);
+    }
+
     @GetMapping("/denormalization")
     public ApiResponse<ProductInfoPageResponse> getProductsInfoDenormalization(@RequestParam String sort,
                                                                                @RequestParam List<Long> brandIds,

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeIntegrationTest.java
@@ -124,7 +124,7 @@ class OrderFacadeIntegrationTest {
                                                                               CreateOrderWithCouponRequest.create(List.of(createOrderRequest), savedCoupon.getId())));
 
         assertThat(coreException.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
-        assertThat(coreException.getCustomMessage()).isEqualTo("잔액이 부족합니다.");
+        assertThat(coreException.getMessage()).isEqualTo("잔액이 부족합니다.");
     }
 
     @DisplayName("주문 성공 테스트")

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeIntegrationTest.java
@@ -96,7 +96,7 @@ class OrderFacadeIntegrationTest {
                                                    () -> orderFacade.register(savedMember.getMemberId(),
                                                                               CreateOrderWithCouponRequest.create(List.of(createOrderRequest), savedMember.getId())));
 
-        assertThat(coreException.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        assertThat(coreException.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
         assertThat(coreException.getCustomMessage()).isEqualTo("상품을 찾을 수 없습니다.");
     }
 

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderRegisterIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderRegisterIntegrationTest.java
@@ -1,6 +1,9 @@
 package com.loopers.application.order;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
+
+import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -13,6 +16,7 @@ import com.loopers.application.provided.OrderRegister;
 import com.loopers.application.required.MemberRepository;
 import com.loopers.application.required.ProductRepository;
 import com.loopers.domain.order.CreateOrderSpec;
+import com.loopers.domain.order.orderitem.CreateOrderItemSpec;
 import com.loopers.support.error.CoreException;
 import com.loopers.utils.DatabaseCleanUp;
 
@@ -40,8 +44,9 @@ class OrderRegisterIntegrationTest {
     @Test
     void create_order_fail_when_user_not_existed() {
         CreateOrderSpec createOrderSpec = CreateOrderSpec.of(null);
+        CreateOrderItemSpec createOrderItemSpec = CreateOrderItemSpec.of(1L, 10L);
 
-        assertThatThrownBy(() -> orderRegister.register(createOrderSpec))
+        assertThatThrownBy(() -> orderRegister.createOrder(createOrderSpec, List.of(createOrderItemSpec)))
                 .isInstanceOf(CoreException.class);
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/product/ProductFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/product/ProductFacadeIntegrationTest.java
@@ -3,12 +3,15 @@ package com.loopers.application.product;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import java.util.List;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import com.loopers.application.required.BrandRepository;
@@ -23,6 +26,7 @@ import com.loopers.domain.member.MemberFixture;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductFixture;
 import com.loopers.domain.product.ProductInfo;
+import com.loopers.interfaces.api.product.dto.ProductV1Dto.Response.ProductInfoPageResponse;
 import com.loopers.utils.DatabaseCleanUp;
 
 @SpringBootTest
@@ -63,7 +67,6 @@ class ProductFacadeIntegrationTest {
     @Test
     void productInfo_has_brandInfo_and_like_count() {
         Member member = memberRepository.save(MemberFixture.createMember());
-        Brand brand = brandRepository.create(Brand.create("브랜드", "브랜드입니다."));
         productLikeRepository.save(ProductLike.create(member, product));
 
         ProductInfo productInfo = productFacade.findProductInfo(product.getId());
@@ -74,6 +77,27 @@ class ProductFacadeIntegrationTest {
                 () -> assertThat(productInfo.brandName()).isEqualTo(brand.getName()),
                 () -> assertThat(productInfo.brandDescription()).isEqualTo(brand.getDescription()),
                 () -> assertThat(productInfo.likeCount()).isOne()
+        );
+    }
+
+    @DisplayName("상품 정보는 브랜드 정보, 비정규화 좋아요 수를 포함한다.")
+    @Test
+    void productInfo_has_brandInfo_and_like_count_denormalization() {
+        product.increaseLikeCount();
+        productRepository.save(product);
+
+        ProductInfoPageResponse productInfoPageResponse
+                = productFacade.findProductsInfoDenormalization("LIKE_COUNT_DESC",
+                                                                List.of(brand.getId()),
+                                                                PageRequest.of(0, 10));
+        List<ProductInfo> content = productInfoPageResponse.content();
+
+        assertAll(
+                () -> assertThat(content.get(0).productName()).isEqualTo(product.getName()),
+                () -> assertThat(content.get(0).productDescription()).isEqualTo(product.getDescription()),
+                () -> assertThat(content.get(0).brandName()).isEqualTo(brand.getName()),
+                () -> assertThat(content.get(0).brandDescription()).isEqualTo(brand.getDescription()),
+                () -> assertThat(content.get(0).likeCount()).isOne()
         );
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/product/ProductFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/product/ProductFacadeIntegrationTest.java
@@ -119,9 +119,9 @@ class ProductFacadeIntegrationTest {
         productRepository.save(product);
 
         ProductInfoPageResponse productInfoPageResponse
-                = productFacade.findProductsInfoDenormalization("LIKE_COUNT_DESC",
-                                                                List.of(brand.getId()),
-                                                                PageRequest.of(0, 10));
+                = productFacade.findProductsInfoDenormalizationWithRedis("LIKE_COUNT_DESC",
+                                                                         List.of(brand.getId()),
+                                                                         PageRequest.of(0, 10));
         List<ProductInfo> content = productInfoPageResponse.content();
 
         assertAll(

--- a/apps/commerce-api/src/test/java/com/loopers/application/product/ProductRegisterIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/product/ProductRegisterIntegrationTest.java
@@ -3,6 +3,8 @@ package com.loopers.application.product;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,9 +19,8 @@ import com.loopers.application.required.BrandRepository;
 import com.loopers.application.required.ProductRepository;
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.brand.BrandFixture;
+import com.loopers.domain.product.CreateProductSpec;
 import com.loopers.domain.product.Product;
-import com.loopers.domain.product.ProductFixture;
-
 import com.loopers.utils.DatabaseCleanUp;
 
 @SpringBootTest
@@ -36,12 +37,11 @@ public class ProductRegisterIntegrationTest {
     @MockitoSpyBean
     private BrandRepository brandRepository;
 
-    Product product;
+    Brand brand;
 
     @BeforeEach
     void setUp() {
-        Brand brand = brandRepository.create(BrandFixture.createBrand());
-        product = productRepository.save(ProductFixture.createProduct(brand));
+        brand = brandRepository.create(BrandFixture.createBrand());
     }
 
     @AfterEach
@@ -52,12 +52,13 @@ public class ProductRegisterIntegrationTest {
     @DisplayName("상품 생성 통합 테스트")
     @Test
     void createProductTest() {
-        Product expected = productRegister.register(product);
+        CreateProductSpec createProductSpec = new CreateProductSpec("상품", "상품입니다.", BigDecimal.valueOf(500), brand, ZonedDateTime.now());
+        Product expected = productRegister.register(createProductSpec);
 
         assertAll(
-                () -> assertThat(expected.getName()).isEqualTo(product.getName()),
-                () -> assertThat(expected.getPrice().abs()).isEqualTo(product.getPrice().abs()),
-                () -> assertThat(expected.getDescription()).isEqualTo(product.getDescription())
+                () -> assertThat(expected.getName()).isEqualTo(createProductSpec.name()),
+                () -> assertThat(expected.getPrice().abs()).isEqualTo(createProductSpec.price().abs()),
+                () -> assertThat(expected.getDescription()).isEqualTo(createProductSpec.description())
         );
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/redis/RedisTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/redis/RedisTest.java
@@ -1,0 +1,53 @@
+package com.loopers.application.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+@SpringBootTest
+public class RedisTest {
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Container
+    static GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:7.4-alpine"))
+            .withExposedPorts(6379)
+            .withCommand("redis-server --requirepass yong");
+
+    @BeforeAll
+    static void setUpRedisConnectionFactory(@Autowired RedisTemplate<String, String> redisTemplate) {
+        String address = redis.getHost();
+        Integer port = redis.getMappedPort(6379);
+
+        // RedisTemplate이 Testcontainers의 Redis를 바라보도록 설정
+        LettuceConnectionFactory connectionFactory =
+                new LettuceConnectionFactory(address, port);
+        connectionFactory.setPassword("yong"); // 비밀번호 설정
+        connectionFactory.afterPropertiesSet();
+
+        redisTemplate.setConnectionFactory(connectionFactory);
+        redisTemplate.afterPropertiesSet();
+    }
+
+    @Test
+    void redis_test() {
+        ValueOperations<String, String> operations = redisTemplate.opsForValue();
+        operations.set("foo", "bar");
+
+        String value = operations.get("foo");
+
+        assertThat(value).isEqualTo("bar");
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/inventory/InventoryTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/inventory/InventoryTest.java
@@ -2,15 +2,11 @@ package com.loopers.domain.inventory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-
-import com.loopers.support.error.CoreException;
-import com.loopers.support.error.ErrorType;
 
 class InventoryTest {
 
@@ -18,9 +14,8 @@ class InventoryTest {
     @ParameterizedTest
     @ValueSource(longs = { -1, -2, -3 })
     void create_inventory_fail_test(Long quantity) {
-        CoreException coreException = assertThrows(CoreException.class, () -> Inventory.create(1L, quantity));
-
-        assertThat(coreException.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThatThrownBy(() -> Inventory.create(1L, quantity))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @DisplayName("상품 ID가 NULL일 때")
@@ -51,9 +46,8 @@ class InventoryTest {
     void decrease_inventory_fail_test() {
         Inventory inventory = Inventory.create(1L, 10L);
 
-        CoreException coreException = assertThrows(CoreException.class, () -> inventory.decrease(11L));
-
-        assertThat(coreException.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThatThrownBy(() -> inventory.decrease(11L))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @DisplayName("재고 품절일 때 감소 실패 테스트")
@@ -62,10 +56,9 @@ class InventoryTest {
         Inventory inventory = Inventory.create(1L, 10L);
         inventory.decrease(10L);
 
-        CoreException coreException = assertThrows(CoreException.class, () -> inventory.decrease(1L));
-
+        assertThatThrownBy(() -> inventory.decrease(1L))
+                .isInstanceOf(IllegalArgumentException.class);
         assertThat(inventory.getInventoryStatus()).isEqualTo(InventoryStatus.SOLD_OUT);
-        assertThat(coreException.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
     }
 
     @DisplayName("재고 감소 성공 테스트")

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderTest.java
@@ -19,7 +19,7 @@ class OrderTest {
                 = CreateOrderSpec.of(null);
 
         assertThatThrownBy(() -> create(createOrderSpec))
-                .isInstanceOf(CoreException.class);
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @DisplayName("주문 생성 성공")

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointChargeTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointChargeTest.java
@@ -11,12 +11,11 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import com.loopers.domain.member.Member;
 import com.loopers.domain.member.MemberFixture;
-import com.loopers.support.error.CoreException;
 
 class PointChargeTest {
     @DisplayName("1 이상의 정수로 포인트를 충전 시 성공한다.")
     @ParameterizedTest
-    @ValueSource(ints = { 1, 10, 100})
+    @ValueSource(ints = { 1, 10, 100 })
     void successWhenChargePointInvalid(int chargePoint) {
         Member member = MemberFixture.createMember();
         BigDecimal amount = member.charge(BigDecimal.valueOf(chargePoint));
@@ -25,10 +24,11 @@ class PointChargeTest {
 
     @DisplayName("0 이하의 정수로 포인트를 충전 시 실패한다.")
     @ParameterizedTest
-    @ValueSource(ints = { -1, 0})
+    @ValueSource(ints = { -1, 0 })
     void failWhenChargePointNotInvalid(int chargePoint) {
         Member member = MemberFixture.createMember();
+
         assertThatThrownBy(() -> member.getPoint().charge(BigDecimal.valueOf(chargePoint)))
-            .isInstanceOf(CoreException.class);
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/product/ProductV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/product/ProductV1ApiE2ETest.java
@@ -76,7 +76,7 @@ class ProductV1ApiE2ETest {
 
             ParameterizedTypeReference<ApiResponse<ProductInfoPageResponse>> responseType = new ParameterizedTypeReference<>() {};
             ResponseEntity<ApiResponse<ProductInfoPageResponse>> response =
-                    testRestTemplate.exchange(ENDPOINT_GET + "?page=0&size=2&sort=latestAt", HttpMethod.GET, new HttpEntity<>(headers), responseType);
+                    testRestTemplate.exchange(ENDPOINT_GET + "?page=0&brandId="+ brand.getId() +" &size=2&sort=latestAt", HttpMethod.GET, new HttpEntity<>(headers), responseType);
 
             List<ProductInfo> productInfos = response.getBody().data().content();
 

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/product/ProductV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/product/ProductV1ApiE2ETest.java
@@ -76,7 +76,7 @@ class ProductV1ApiE2ETest {
 
             ParameterizedTypeReference<ApiResponse<ProductInfoPageResponse>> responseType = new ParameterizedTypeReference<>() {};
             ResponseEntity<ApiResponse<ProductInfoPageResponse>> response =
-                    testRestTemplate.exchange(ENDPOINT_GET + "?page=0&brandId="+ brand.getId() +" &size=2&sort=latestAt", HttpMethod.GET, new HttpEntity<>(headers), responseType);
+                    testRestTemplate.exchange(ENDPOINT_GET + "?page=0&brandIds="+ brand.getId() +" &size=2&sort=latestAt", HttpMethod.GET, new HttpEntity<>(headers), responseType);
 
             List<ProductInfo> productInfos = response.getBody().data().content();
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,8 @@ subprojects {
         // Lombok
         implementation("org.projectlombok:lombok")
         annotationProcessor("org.projectlombok:lombok")
+        //Rdis
+        implementation("org.springframework.boot:spring-boot-starter-data-redis")
         // Test
         testRuntimeOnly("org.junit.platform:junit-platform-launcher")
         // testcontainers:mysql 이 jdbc 사용함

--- a/docker/infra-compose.yml
+++ b/docker/infra-compose.yml
@@ -13,8 +13,18 @@ services:
       - MYSQL_COLLATE=utf8mb4_general_ci
     volumes:
       - mysql-8-data:/var/lib/mysql
+  cache:
+    image: redis:7.4-alpine
+    restart: always
+    ports:
+      - "6379:6379"
+    command: redis-server --save 20 1 --loglevel warning --requirepass yong
+    volumes:
+      - cache:/data
 
 volumes:
+  cache:
+    driver: local
   mysql-8-data:
 
 networks:

--- a/k6/denormalize_test.js
+++ b/k6/denormalize_test.js
@@ -33,7 +33,7 @@ export default function () {
     },
   };
 
-  const url = `${BASE}/api/v1/products/denormalize?sort=${sort}&brandIds=${brandIds.join(',')}&page=${page}`;
+  const url = `${BASE}/api/v1/products/denormalization?sort=${sort}&brandIds=${brandIds.join(',')}&page=${page}`;
 
   http.get(url, params);
 

--- a/k6/denormalize_test.js
+++ b/k6/denormalize_test.js
@@ -1,0 +1,40 @@
+import http from 'k6/http';
+
+const BASE = 'http://localhost:8080';
+
+export const options = {
+  scenarios: {
+    twenty_once: {
+      executor: 'per-vu-iterations',
+      vus: 50,
+      iterations: 1,
+      maxDuration: '1m',
+    },
+  },
+};
+
+function getRandomBrandIds(count = 30, max = 500) {
+  const set = new Set();
+  while (set.size < count) {
+    const rand = Math.floor(Math.random() * max) + 1;
+    set.add(rand);
+  }
+  return Array.from(set);
+}
+
+export default function () {
+  const userId = `member${__VU}`;
+  const sort = 'LIKE_COUNT_DESC';
+  const page = 100;
+  const brandIds = getRandomBrandIds();
+  const params = {
+    headers: {
+      'X-USER-ID': userId,
+    },
+  };
+
+  const url = `${BASE}/api/v1/products/denormalize?sort=${sort}&brandIds=${brandIds.join(',')}&page=${page}`;
+
+  http.get(url, params);
+
+}

--- a/k6/normalize_test.js
+++ b/k6/normalize_test.js
@@ -1,0 +1,40 @@
+import http from 'k6/http';
+
+const BASE = 'http://localhost:8080';
+
+export const options = {
+  scenarios: {
+    twenty_once: {
+      executor: 'per-vu-iterations',
+      vus: 50,
+      iterations: 1,
+      maxDuration: '1m',
+    },
+  },
+};
+
+function getRandomBrandIds(count = 30, max = 500) {
+  const set = new Set();
+  while (set.size < count) {
+    const rand = Math.floor(Math.random() * max) + 1;
+    set.add(rand);
+  }
+  return Array.from(set);
+}
+
+export default function () {
+  const userId = `member${__VU}`;
+  const sort = 'LIKE_COUNT_DESC';
+  const page = 100;
+  const brandIds = getRandomBrandIds();
+  const params = {
+    headers: {
+      'X-USER-ID': userId,
+    },
+  };
+
+  const url = `${BASE}/api/v1/products?sort=${sort}&brandIds=${brandIds.join(',')}&page=${page}`;
+
+  http.get(url, params);
+
+}

--- a/k6/redis_test.js
+++ b/k6/redis_test.js
@@ -1,0 +1,40 @@
+import http from 'k6/http';
+
+const BASE = 'http://localhost:8080';
+
+export const options = {
+  scenarios: {
+    twenty_once: {
+      executor: 'per-vu-iterations',
+      vus: 50,
+      iterations: 1,
+      maxDuration: '1m',
+    },
+  },
+};
+
+function getRandomBrandIds(count = 30, max = 500) {
+  const set = new Set();
+  while (set.size < count) {
+    const rand = Math.floor(Math.random() * max) + 1;
+    set.add(rand);
+  }
+  return Array.from(set);
+}
+
+export default function () {
+  const userId = `member${__VU}`;
+  const sort = 'LIKE_COUNT_DESC';
+  const page = 100;
+  const brandIds = getRandomBrandIds();
+  const params = {
+    headers: {
+      'X-USER-ID': userId,
+    },
+  };
+
+  const url = `${BASE}/api/v1/products/redis?sort=${sort}&brandIds=${brandIds.join(',')}&page=${page}`;
+
+  http.get(url, params);
+
+}

--- a/sql/data_setting.sql
+++ b/sql/data_setting.sql
@@ -1,0 +1,70 @@
+-- brand 테이블 초기화 & 데이터 삽입
+TRUNCATE TABLE loopers.brand;
+
+SET SESSION cte_max_recursion_depth = 500;
+INSERT INTO loopers.brand (created_at, updated_at, name, description)
+WITH RECURSIVE seq AS (SELECT 0 AS n
+                       UNION ALL
+                       SELECT n + 1
+                       FROM seq
+                       WHERE n < 499)
+SELECT NOW(),
+    NOW(),
+    CONCAT('Brand ', n),
+    CONCAT('Description for brand ', n)
+FROM seq;
+
+-- product 테이블 초기화 & 데이터 삽입
+TRUNCATE TABLE loopers.product;
+
+SET SESSION cte_max_recursion_depth = 300000;
+INSERT INTO loopers.product (price, brand_id, created_at, updated_at, name, description, latest_at, like_count)
+WITH RECURSIVE seq AS (SELECT 0 AS n
+                       UNION ALL
+                       SELECT n + 1
+                       FROM seq
+                       WHERE n < 299999)
+SELECT ROUND(RAND() * 3000, 2),
+    1 + FLOOR(RAND() * 500),
+    NOW(),
+    NOW(),
+    CONCAT('Product ', n),
+    CONCAT('Description for product ', n),
+    NOW(),
+    FLOOR(RAND() * 300000)
+FROM seq;
+
+-- member 테이블 초기화 & 데이터 삽입
+TRUNCATE TABLE loopers.member;
+
+SET SESSION cte_max_recursion_depth = 10000;
+INSERT INTO loopers.member (created_at, updated_at, gender, email, member_id, password_hash)
+WITH RECURSIVE seq AS (SELECT 0 AS n
+                       UNION ALL
+                       SELECT n + 1
+                       FROM seq
+                       WHERE n < 9999)
+SELECT NOW(),
+    NOW(),
+    'MALE',
+    CONCAT('user', n, '@example.com'),
+    CONCAT('member', n),
+    'hashed_password'
+FROM seq;
+
+
+-- product_like 테이블 초기화 & 데이터 삽입
+TRUNCATE TABLE loopers.product_like;
+
+SET SESSION cte_max_recursion_depth = 300000;
+INSERT INTO loopers.product_like (created_at, updated_at, member_id, product_id)
+WITH RECURSIVE seq AS (SELECT 1 AS n
+                       UNION ALL
+                       SELECT n + 1
+                       FROM seq
+                       WHERE n < 299999)
+SELECT NOW(),
+    NOW(),
+    1 + FLOOR(RAND() * 10000),
+    1 + FLOOR(RAND() * 300000)
+FROM seq;

--- a/sql/denormalization_test.sql
+++ b/sql/denormalization_test.sql
@@ -1,0 +1,116 @@
+-- 50만건의 product와 500건의 brand 일때
+
+CREATE INDEX idx_like_count_brand ON product (like_count, brand_id);
+DROP INDEX idx_like_count_brand ON product;
+
+CREATE INDEX idx_brand_like ON product (brand_id, like_count);
+DROP INDEX idx_brand_like ON product;
+
+CREATE INDEX idx_like_count ON product (like_count);
+DROP INDEX idx_like_count ON product;
+
+CREATE INDEX idx_brand_id ON product (brand_id);
+DROP INDEX idx_brand_id ON product;
+
+
+-- brand_id가 foreign key로 index설정이 되어있다.
+-- brand_id를 인덱싱에 사용하고 orderby likecount는 filesort를 사용한다.
+EXPLAIN ANALYZE
+SELECT *
+FROM product
+         LEFT JOIN brand
+                   ON product.brand_id = brand.id
+WHERE brand_id IN (1, 2, 34)
+ORDER BY product.like_count DESC;
+
+EXPLAIN
+SELECT *
+FROM product
+         LEFT JOIN brand
+                   ON product.brand_id = brand.id
+WHERE brand_id IN (1, 2, 34)
+ORDER BY product.like_count DESC;
+
+-- brand_id 필터 조건이 2개 이상이면 index를 사용한다.
+EXPLAIN ANALYZE
+SELECT *
+FROM product
+         LEFT JOIN brand
+                   ON product.brand_id = brand.id
+WHERE brand_id IN (1, 2)
+ORDER BY product.like_count DESC;
+
+EXPLAIN
+SELECT *
+FROM product
+         LEFT JOIN brand
+                   ON product.brand_id = brand.id
+WHERE brand_id IN (1, 2)
+ORDER BY product.like_count DESC;
+
+-- 필더 갯수가 하나면 index 사용 안한다.
+EXPLAIN ANALYZE
+SELECT *
+FROM product
+         LEFT JOIN brand
+                   ON product.brand_id = brand.id
+WHERE brand_id = 3
+ORDER BY product.like_count DESC;
+
+EXPLAIN
+SELECT *
+FROM product
+         LEFT JOIN brand
+                   ON product.brand_id = brand.id
+WHERE brand_id = 3
+ORDER BY product.like_count DESC;
+
+-- order by 절의 like_count는 indexing 해주지 않는다.
+
+EXPLAIN ANALYZE
+SELECT *
+FROM product
+         LEFT JOIN brand
+                   ON product.brand_id = brand.id
+WHERE brand_id IN (1, 2);
+
+EXPLAIN
+SELECT *
+FROM product
+         LEFT JOIN brand
+                   ON product.brand_id = brand.id
+WHERE brand_id IN (1, 2);
+
+EXPLAIN ANALYZE
+SELECT *
+FROM product
+         LEFT JOIN brand
+                   ON product.brand_id = brand.id
+WHERE brand_id = 1;
+
+EXPLAIN
+SELECT *
+FROM product
+         LEFT JOIN brand
+                   ON product.brand_id = brand.id
+WHERE brand_id = 1;
+
+ANALYZE TABLE product;
+SHOW INDEX FROM product;
+
+-- ORDER BY 적용시
+-- 1. 각각 단일 index 사용시
+    -- brand_id IN 조회
+        -- 필터에 사용되는 brand_id만 인덱싱하고 order by like_count는 full scan한다.
+    -- brand_id 단일 조회
+        -- indexing을 하지 않고 full scan을 한다.
+-- 2. (brand_id, like_count) 복합 index
+    -- brand_id IN 조회
+        -- 필터에 사용되는 brand_id만 인덱싱하고 order by like_count는 full scan한다.
+    -- brand_id 단일 조회
+        -- like_count Backward index scan을 한다.
+-- 3. (like_count, brand_id) 복합 index
+    -- brand_id IN 조회
+        -- indexing을 전혀 하지 않고 full scan한다.
+    -- brand_id 단일 조회
+        -- indexing을 전혀 하지 않고 full scan한다.

--- a/sql/normalization_test.sql
+++ b/sql/normalization_test.sql
@@ -1,0 +1,115 @@
+-- 50만건의 product와 500건의 brand 일때
+
+CREATE INDEX idx_like_count_brand ON product (like_count, brand_id);
+DROP INDEX idx_like_count_brand ON product;
+
+CREATE INDEX idx_brand_like ON product (brand_id, like_count);
+DROP INDEX idx_brand_like ON product;
+
+CREATE INDEX idx_like_count ON product (like_count);
+DROP INDEX idx_like_count ON product;
+
+CREATE INDEX idx_brand_id ON product (brand_id);
+DROP INDEX idx_brand_id ON product;
+
+CREATE INDEX idx_product_id ON product_like (product_id);
+DROP INDEX idx_product_id ON product_like;
+
+-- ----------------------------------------
+EXPLAIN ANALYZE
+SELECT p.*,
+       COUNT(pl.product_id) AS like_c
+FROM product p
+         LEFT JOIN brand b
+                   ON p.brand_id = b.id
+         LEFT JOIN product_like pl
+                   ON pl.product_id = p.id
+WHERE b.id IN (127, 315, 248)
+GROUP BY p.id
+ORDER BY like_c DESC;
+
+EXPLAIN
+SELECT p.*,
+       COUNT(pl.product_id) AS like_c
+FROM product p
+         LEFT JOIN brand b
+                   ON p.brand_id = b.id
+         LEFT JOIN product_like pl
+                   ON pl.product_id = p.id
+WHERE b.id IN (127, 315, 248)
+GROUP BY p.id
+ORDER BY like_c DESC;
+
+-- ----------------------------------------
+EXPLAIN ANALYZE
+SELECT p.*,
+       COUNT(pl.product_id) AS like_c
+FROM product p
+         LEFT JOIN brand b
+                   ON p.brand_id = b.id
+         LEFT JOIN product_like pl
+                   ON pl.product_id = p.id
+WHERE b.id = 127
+GROUP BY p.id
+ORDER BY like_c DESC;
+
+EXPLAIN
+SELECT p.*,
+       COUNT(pl.product_id) AS like_c
+FROM product p
+         LEFT JOIN brand b
+                   ON p.brand_id = b.id
+         LEFT JOIN product_like pl
+                   ON pl.product_id = p.id
+WHERE b.id = 127
+GROUP BY p.id
+ORDER BY like_c DESC;
+
+-- ----------------------------------------
+EXPLAIN ANALYZE
+SELECT p.*,
+       COUNT(pl.product_id) AS like_c
+FROM product p
+         LEFT JOIN brand b
+                   ON p.brand_id = b.id
+         LEFT JOIN product_like pl
+                   ON pl.product_id = p.id
+WHERE b.id IN (127, 315, 248)
+GROUP BY p.id;
+
+EXPLAIN
+SELECT p.*,
+       COUNT(pl.product_id) AS like_c
+FROM product p
+         LEFT JOIN brand b
+                   ON p.brand_id = b.id
+         LEFT JOIN product_like pl
+                   ON pl.product_id = p.id
+WHERE b.id IN (127, 315, 248)
+GROUP BY p.id;
+
+-- ----------------------------------------
+EXPLAIN ANALYZE
+SELECT p.*,
+       COUNT(pl.product_id) AS like_c
+FROM product p
+         LEFT JOIN brand b
+                   ON p.brand_id = b.id
+         LEFT JOIN product_like pl
+                   ON pl.product_id = p.id
+WHERE b.id = 127
+GROUP BY p.id;
+
+EXPLAIN
+SELECT p.*,
+       COUNT(pl.product_id) AS like_c
+FROM product p
+         LEFT JOIN brand b
+                   ON p.brand_id = b.id
+         LEFT JOIN product_like pl
+                   ON pl.product_id = p.id
+WHERE b.id = 127
+GROUP BY p.id;
+
+ANALYZE TABLE product;
+SHOW INDEX FROM product;


### PR DESCRIPTION
## 📌 Summary
정규화 되어있던 상품 좋아요 테이블을 상품 안에 비정규화로 넣어 주었다.
정규화로 되어있을 때 상품과 브랜드, 좋아요를 함께 조회하면 조회 속도가 많이 느려졌다.
비정규화로 변경 후 속도가 향상되었다.

## 💬 Review Points
https://pwy8617.tistory.com/56 <- 인덱스 블로그
<img width="2923" height="822" alt="스크린샷 2025-08-15 오후 4 52 55" src="https://github.com/user-attachments/assets/ce878199-ef3f-4232-9adc-e17ca33c9192" />

인덱스에 대해 확실하게 공부할 수 있었습니다.
k6를 처음 사용해 보았는데, 정규화에서 수 초가 걸리던 조회가 비정규로 바꾸니 마이크로 초 단위로 줄어들었습니다.
다른 테스트도 해봐야 하는데 기본적인 RPS나 p(95)만 측정해 보았습니다.
레디스는 더 공부 해 봐야할 것 같습니다... 구현을 잘못해서 레디스로 변경해도 시간이 크게 줄어들지 않습니다... 

## ✅ Checklist
- [ v ]  상품 목록 API에서 brandId 기반 검색, 좋아요 순 정렬 등을 처리했다.
- [ v ]  조회 필터, 정렬 조건별 유즈케이스를 분석하여 인덱스를 적용하고 전 후 성능비교를 진행했다. (Optional 카디널리티 분석)
- [ v ]  상품 목록/상세 조회 시 좋아요 수를 조회 및 좋아요 순 정렬이 가능하도록 구조 개선을 진행했다.
- [ v ]  좋아요 적용/해제 진행 시 상품 좋아요 수 또한 정상적으로 동기화되도록 진행하였다.
- [ v ]  Redis 캐시를 적용하고 TTL 또는 무효화 전략을 적용했다.
- [ v ]  캐시 미스 상황에서도 서비스가 정상 동작하도록 처리했다.
