### PR TITLE
feat(performance): add percentile load testing and observability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### Kotlin ###
 .kotlin
+
+### Load test results ###
+/k6/results/

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Loopers 에서 제공하는 스프링 자바 템플릿 프로젝트입니다.
 
 - Java 21
 - Docker Desktop
+- k6 2.1.0
 
 Gradle daemon은 저장소의 `gradle/gradle-daemon-jvm.properties`에 따라 Java 21을 사용합니다.
 
@@ -49,7 +50,7 @@ curl -fsS http://localhost:8085/actuator/health
 ### Monitoring
 `local` 환경에서 모니터링을 할 수 있도록, `docker-compose` 를 통해 `prometheus` 와 `grafana` 를 제공합니다.
 
-애플리케이션 실행 이후, **http://localhost:3000** 로 접속해, admin/admin 계정으로 로그인하여 확인하실 수 있습니다.
+애플리케이션 실행 이후, **http://localhost:3000** 로 접속해, admin/admin 계정으로 로그인하여 확인할 수 있습니다.
 ```shell
 docker compose -f ./docker/monitoring-compose.yml up -d
 ```
@@ -57,6 +58,51 @@ docker compose -f ./docker/monitoring-compose.yml up -d
 - Kafka UI: http://localhost:9091
 - Prometheus: http://localhost:9090
 - Grafana: http://localhost:3000
+- API Performance 대시보드: http://localhost:3000/d/loopers-performance
+
+Prometheus는 `commerce-api`의 `/actuator/prometheus`를 5초 간격으로 수집합니다. 서버 응답시간 p90/p95는
+Micrometer histogram으로 계산하며, Prometheus 시계열은 named volume에 7일간 보관합니다. Grafana 설정은
+`grafana-data` volume을 삭제하기 전까지 유지됩니다.
+
+### Performance Test
+
+상품 목록 조회의 normalize, denormalize, Redis cache 방식을 동일한 입력으로 각각 측정합니다. 로컬 프로필은 애플리케이션
+시작 시 스키마를 다시 생성하므로, `commerce-api`를 먼저 시작한 뒤 성능 테스트 데이터를 적재하고 재시작하지 않아야 합니다.
+성능 측정 중 SQL 콘솔 출력이 응답시간을 왜곡하지 않도록 다음과 같이 실행합니다.
+
+```shell
+SPRING_JPA_SHOW_SQL=false ./gradlew :apps:commerce-api:bootRun
+```
+
+> `sql/data_setting.sql`은 로컬 성능 테스트 전용이며 `commerce-api`의 기존 비즈니스 데이터를 모두 삭제합니다.
+> 공유 DB나 보존할 데이터가 있는 환경에서는 실행하면 안 됩니다.
+
+```shell
+docker compose -f ./docker/infra-compose.yml exec -T mysql \
+  mysql -uapplication -papplication < ./sql/data_setting.sql
+
+# 이전 Redis 조회 결과 제거
+docker compose -f ./docker/infra-compose.yml exec redis-master redis-cli FLUSHDB
+```
+
+기본 부하는 30초 warm-up 후 20 RPS로 2분간 실행합니다. load 구간의 p90 300ms 미만, p95 500ms 미만,
+HTTP 실패율 1% 미만, check 성공률 99% 초과, dropped iteration 0건을 자동 검증합니다.
+
+```shell
+./k6/run-product-read.sh normalize
+./k6/run-product-read.sh denormalize
+./k6/run-product-read.sh redis
+```
+
+각 실행 결과는 Prometheus로 전송되고 `k6/results/*-summary.json`에도 저장됩니다. 부하와 임계값은 환경변수로 조정할 수 있습니다.
+
+```shell
+RATE=50 DURATION=5m P90_MS=200 P95_MS=400 \
+  ./k6/run-product-read.sh redis
+```
+
+Grafana의 k6 p90/p95는 네트워크를 포함한 클라이언트 관점이고, Spring p90/p95는 서버 내부 처리시간입니다. 두 값이 다른 것은
+정상이며, 테스트 간 비교 시 같은 endpoint, 데이터, 부하, `testid` 조건을 사용해야 합니다.
 
 ## About Multi-Module Project
 본 프로젝트는 멀티 모듈 프로젝트로 구성되어 있습니다. 각 모듈의 위계 및 역할을 분명히 하고, 아래와 같은 규칙을 적용합니다.

--- a/docker/grafana/dashboards/loopers-performance.json
+++ b/docker/grafana/dashboards/loopers-performance.json
@@ -1,0 +1,606 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "description": "k6 client latency and Spring Boot server latency for Loopers product read load tests.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "End-to-end latency measured by k6. Values include network and client overhead.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "k6_http_req_duration_p90{scenario=\"load\",testid=~\"$testid\",endpoint=~\"$endpoint\"}",
+          "legendFormat": "p90 {{endpoint}} {{testid}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "k6_http_req_duration_p95{scenario=\"load\",testid=~\"$testid\",endpoint=~\"$endpoint\"}",
+          "legendFormat": "p95 {{endpoint}} {{testid}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "k6 client latency p90 / p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Server processing latency calculated from the Micrometer histogram over a one-minute window.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "commerce_api:http_server_request_duration_seconds:p90_1m{method=\"GET\",uri=~\"/api/v1/products.*\"}",
+          "legendFormat": "p90 {{uri}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "commerce_api:http_server_request_duration_seconds:p95_1m{method=\"GET\",uri=~\"/api/v1/products.*\"}",
+          "legendFormat": "p95 {{uri}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Spring server latency p90 / p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (endpoint, testid) (rate(k6_http_reqs_total{scenario=\"load\",testid=~\"$testid\",endpoint=~\"$endpoint\"}[$__rate_interval]))",
+          "legendFormat": "k6 {{endpoint}} {{testid}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "commerce_api:http_server_requests:rate1m{method=\"GET\",uri=~\"/api/v1/products.*\"}",
+          "legendFormat": "server {{uri}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Request throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.01
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "k6_http_req_failed_rate{scenario=\"load\",testid=~\"$testid\",endpoint=~\"$endpoint\"}",
+          "legendFormat": "k6 {{endpoint}} {{testid}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "commerce_api:http_server_requests:error_ratio1m{method=\"GET\",uri=~\"/api/v1/products.*\"}",
+          "legendFormat": "server {{uri}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Request error ratio",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "increase(k6_dropped_iterations_total{scenario=\"load\",testid=~\"$testid\",endpoint=~\"$endpoint\"}[$__rate_interval])",
+          "legendFormat": "dropped {{endpoint}} {{testid}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "k6_vus{testid=~\"$testid\",endpoint=~\"$endpoint\"}",
+          "legendFormat": "VUs {{endpoint}} {{testid}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "k6 load saturation",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "process_cpu_usage{application=\"commerce-api\"}",
+          "legendFormat": "process CPU",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(jvm_memory_used_bytes{application=\"commerce-api\",area=\"heap\"}) / clamp_min(sum(jvm_memory_max_bytes{application=\"commerce-api\",area=\"heap\"}), 1)",
+          "legendFormat": "JVM heap",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Application resource utilization",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 41,
+  "tags": [
+    "loopers",
+    "performance",
+    "k6"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(k6_http_req_duration_p90, testid)",
+        "includeAll": true,
+        "label": "Test run",
+        "multi": true,
+        "name": "testid",
+        "options": [],
+        "query": {
+          "query": "label_values(k6_http_req_duration_p90, testid)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 2,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(k6_http_req_duration_p90, endpoint)",
+        "includeAll": true,
+        "label": "Endpoint",
+        "multi": true,
+        "name": "endpoint",
+        "options": [],
+        "query": {
+          "query": "label_values(k6_http_req_duration_p90, endpoint)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Loopers API Performance",
+  "uid": "loopers-performance",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docker/grafana/prometheus.yml
+++ b/docker/grafana/prometheus.yml
@@ -1,8 +1,13 @@
 global:
   scrape_interval: 5s
+  evaluation_interval: 5s
+
+rule_files:
+  - /etc/prometheus/rules/*.yml
 
 scrape_configs:
-  - job_name: 'spring-boot-app'
-    metrics_path: '/actuator/prometheus'
+  - job_name: spring-boot-app
+    metrics_path: /actuator/prometheus
     static_configs:
-      - targets: ['host.docker.internal:8081']
+      - targets:
+          - host.docker.internal:8081

--- a/docker/grafana/provisioning/dashboards/dashboard.yml
+++ b/docker/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: Loopers
+    orgId: 1
+    folder: Loopers
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/dashboards

--- a/docker/grafana/provisioning/datasources/datasource.yml
+++ b/docker/grafana/provisioning/datasources/datasource.yml
@@ -1,7 +1,12 @@
 apiVersion: 1
 datasources:
   - name: Prometheus
+    uid: prometheus
     type: prometheus
     access: proxy
     url: http://prometheus:9090
     isDefault: true
+    editable: false
+    jsonData:
+      httpMethod: POST
+      timeInterval: 5s

--- a/docker/grafana/rules/commerce-api.yml
+++ b/docker/grafana/rules/commerce-api.yml
@@ -1,0 +1,46 @@
+groups:
+  - name: commerce-api-http-performance
+    interval: 5s
+    rules:
+      - record: commerce_api:http_server_request_duration_seconds:p90_1m
+        expr: |
+          histogram_quantile(
+            0.90,
+            sum by (le, application, method, uri) (
+              rate(http_server_requests_seconds_bucket{application="commerce-api"}[1m])
+            )
+          )
+
+      - record: commerce_api:http_server_request_duration_seconds:p95_1m
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (le, application, method, uri) (
+              rate(http_server_requests_seconds_bucket{application="commerce-api"}[1m])
+            )
+          )
+
+      - record: commerce_api:http_server_requests:rate1m
+        expr: |
+          sum by (application, method, uri) (
+            rate(http_server_requests_seconds_count{application="commerce-api"}[1m])
+          )
+
+      - record: commerce_api:http_server_requests:error_ratio1m
+        expr: |
+          (
+            sum by (application, method, uri) (
+              rate(http_server_requests_seconds_count{application="commerce-api",outcome!="SUCCESS"}[1m])
+            )
+            or
+            0 * sum by (application, method, uri) (
+              rate(http_server_requests_seconds_count{application="commerce-api"}[1m])
+            )
+          )
+          /
+          clamp_min(
+            sum by (application, method, uri) (
+              rate(http_server_requests_seconds_count{application="commerce-api"}[1m])
+            ),
+            0.000001
+          )

--- a/docker/monitoring-compose.yml
+++ b/docker/monitoring-compose.yml
@@ -2,18 +2,34 @@ name: loopers-monitoring
 
 services:
   prometheus:
-    image: prom/prometheus
+    image: prom/prometheus:v2.53.5
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=7d
+      - --web.enable-remote-write-receiver
     ports:
       - "9090:9090"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
-      - ./grafana/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./grafana/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./grafana/rules:/etc/prometheus/rules:ro
+      - prometheus-data:/prometheus
 
   grafana:
-    image: grafana/grafana
+    image: grafana/grafana:12.0.2
     ports:
       - "3000:3000"
     volumes:
-      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - ./grafana/dashboards:/etc/grafana/dashboards:ro
+      - grafana-data:/var/lib/grafana
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=admin
+
+volumes:
+  prometheus-data:
+  grafana-data:

--- a/k6/denormalize_test.js
+++ b/k6/denormalize_test.js
@@ -1,40 +1,11 @@
-import http from 'k6/http';
+import { createOptions, requestProductList, verifyProductData } from './product_read_scenario.js';
 
-const BASE = 'http://localhost:8080';
+export const options = createOptions('denormalize');
 
-export const options = {
-  scenarios: {
-    twenty_once: {
-      executor: 'per-vu-iterations',
-      vus: 50,
-      iterations: 1,
-      maxDuration: '1m',
-    },
-  },
-};
-
-function getRandomBrandIds(count = 30, max = 500) {
-  const set = new Set();
-  while (set.size < count) {
-    const rand = Math.floor(Math.random() * max) + 1;
-    set.add(rand);
-  }
-  return Array.from(set);
+export function setup() {
+  verifyProductData('denormalize');
 }
 
-export default function () {
-  const userId = `member${__VU}`;
-  const sort = 'LIKE_COUNT_DESC';
-  const page = 100;
-  const brandIds = getRandomBrandIds();
-  const params = {
-    headers: {
-      'X-USER-ID': userId,
-    },
-  };
-
-  const url = `${BASE}/api/v1/products/denormalization?sort=${sort}&brandIds=${brandIds.join(',')}&page=${page}`;
-
-  http.get(url, params);
-
+export default function() {
+  requestProductList('denormalize');
 }

--- a/k6/normalize_test.js
+++ b/k6/normalize_test.js
@@ -1,40 +1,11 @@
-import http from 'k6/http';
+import { createOptions, requestProductList, verifyProductData } from './product_read_scenario.js';
 
-const BASE = 'http://localhost:8080';
+export const options = createOptions('normalize');
 
-export const options = {
-  scenarios: {
-    twenty_once: {
-      executor: 'per-vu-iterations',
-      vus: 50,
-      iterations: 1,
-      maxDuration: '1m',
-    },
-  },
-};
-
-function getRandomBrandIds(count = 30, max = 500) {
-  const set = new Set();
-  while (set.size < count) {
-    const rand = Math.floor(Math.random() * max) + 1;
-    set.add(rand);
-  }
-  return Array.from(set);
+export function setup() {
+  verifyProductData('normalize');
 }
 
-export default function () {
-  const userId = `member${__VU}`;
-  const sort = 'LIKE_COUNT_DESC';
-  const page = 100;
-  const brandIds = getRandomBrandIds();
-  const params = {
-    headers: {
-      'X-USER-ID': userId,
-    },
-  };
-
-  const url = `${BASE}/api/v1/products?sort=${sort}&brandIds=${brandIds.join(',')}&page=${page}`;
-
-  http.get(url, params);
-
+export default function() {
+  requestProductList('normalize');
 }

--- a/k6/product_read_scenario.js
+++ b/k6/product_read_scenario.js
@@ -1,0 +1,123 @@
+import { check, fail } from 'k6';
+import http from 'k6/http';
+
+const BASE_URL = (__ENV.BASE_URL || 'http://localhost:8080').replace(/\/$/, '');
+const BRAND_IDS = __ENV.BRAND_IDS || Array.from({ length: 30 }, (_, index) => index + 1).join(',');
+const PAGE = __ENV.PAGE || '0';
+const SIZE = __ENV.SIZE || '20';
+const SORT = __ENV.SORT || 'LIKE_COUNT_DESC';
+
+const ENDPOINT_PATHS = {
+  normalize: '/api/v1/products',
+  denormalize: '/api/v1/products/denormalization',
+  redis: '/api/v1/products/redis',
+};
+
+function positiveNumber(name, fallback) {
+  const value = Number(__ENV[name] || fallback);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${name} must be a positive number`);
+  }
+  return value;
+}
+
+export function createOptions(endpoint) {
+  if (!ENDPOINT_PATHS[endpoint]) {
+    throw new Error(`Unsupported endpoint: ${endpoint}`);
+  }
+
+  const warmupRate = positiveNumber('WARMUP_RATE', 5);
+  const loadRate = positiveNumber('RATE', 20);
+  const preAllocatedVUs = positiveNumber('PRE_ALLOCATED_VUS', 20);
+  const maxVUs = positiveNumber('MAX_VUS', 100);
+  const p90Milliseconds = positiveNumber('P90_MS', 300);
+  const p95Milliseconds = positiveNumber('P95_MS', 500);
+  const warmupDuration = __ENV.WARMUP_DURATION || '30s';
+
+  return {
+    discardResponseBodies: true,
+    summaryTrendStats: ['avg', 'med', 'p(90)', 'p(95)', 'max'],
+    systemTags: ['method', 'name', 'scenario'],
+    tags: {
+      endpoint,
+      test_type: 'product-read',
+    },
+    scenarios: {
+      warmup: {
+        executor: 'constant-arrival-rate',
+        rate: warmupRate,
+        timeUnit: '1s',
+        duration: warmupDuration,
+        preAllocatedVUs,
+        maxVUs,
+      },
+      load: {
+        executor: 'constant-arrival-rate',
+        startTime: warmupDuration,
+        rate: loadRate,
+        timeUnit: '1s',
+        duration: __ENV.DURATION || '2m',
+        preAllocatedVUs,
+        maxVUs,
+      },
+    },
+    thresholds: {
+      'http_req_duration{scenario:load}': [
+        `p(90)<${p90Milliseconds}`,
+        `p(95)<${p95Milliseconds}`,
+      ],
+      'http_req_failed{scenario:load}': ['rate<0.01'],
+      'checks{scenario:load}': ['rate>0.99'],
+      'dropped_iterations{scenario:load}': ['count==0'],
+    },
+  };
+}
+
+function productListUrl(endpoint) {
+  const path = ENDPOINT_PATHS[endpoint];
+  const query = `sort=${SORT}&brandIds=${BRAND_IDS}&page=${PAGE}&size=${SIZE}`;
+
+  return `${BASE_URL}${path}?${query}`;
+}
+
+function requestParams(endpoint, responseType = 'none') {
+  const path = ENDPOINT_PATHS[endpoint];
+
+  return {
+    headers: {
+      'X-USER-ID': 'loadtest',
+    },
+    responseType,
+    tags: {
+      name: `GET ${path}`,
+      endpoint,
+    },
+  };
+}
+
+export function verifyProductData(endpoint) {
+  const response = http.get(productListUrl(endpoint), requestParams(endpoint, 'text'));
+
+  if (response.status !== 200) {
+    fail(`Preflight failed for ${endpoint}: HTTP ${response.status}`);
+  }
+
+  let content;
+  try {
+    content = response.json().data.content;
+  } catch (error) {
+    fail(`Preflight failed for ${endpoint}: invalid JSON response`);
+  }
+
+  if (!Array.isArray(content) || content.length === 0) {
+    fail(`Preflight failed for ${endpoint}: product data is empty`);
+  }
+}
+
+export function requestProductList(endpoint) {
+  const response = http.get(productListUrl(endpoint), requestParams(endpoint));
+
+  check(response, {
+    'status is 200': ({ status }) => status === 200,
+  });
+}

--- a/k6/redis_test.js
+++ b/k6/redis_test.js
@@ -1,40 +1,11 @@
-import http from 'k6/http';
+import { createOptions, requestProductList, verifyProductData } from './product_read_scenario.js';
 
-const BASE = 'http://localhost:8080';
+export const options = createOptions('redis');
 
-export const options = {
-  scenarios: {
-    twenty_once: {
-      executor: 'per-vu-iterations',
-      vus: 50,
-      iterations: 1,
-      maxDuration: '1m',
-    },
-  },
-};
-
-function getRandomBrandIds(count = 30, max = 500) {
-  const set = new Set();
-  while (set.size < count) {
-    const rand = Math.floor(Math.random() * max) + 1;
-    set.add(rand);
-  }
-  return Array.from(set);
+export function setup() {
+  verifyProductData('redis');
 }
 
-export default function () {
-  const userId = `member${__VU}`;
-  const sort = 'LIKE_COUNT_DESC';
-  const page = 100;
-  const brandIds = getRandomBrandIds();
-  const params = {
-    headers: {
-      'X-USER-ID': userId,
-    },
-  };
-
-  const url = `${BASE}/api/v1/products/redis?sort=${sort}&brandIds=${brandIds.join(',')}&page=${page}`;
-
-  http.get(url, params);
-
+export default function() {
+  requestProductList('redis');
 }

--- a/k6/run-product-read.sh
+++ b/k6/run-product-read.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENDPOINT="${1:-}"
+
+case "$ENDPOINT" in
+  normalize | denormalize | redis)
+    SCRIPT="$ROOT_DIR/k6/${ENDPOINT}_test.js"
+    ;;
+  *)
+    echo "Usage: $0 {normalize|denormalize|redis}" >&2
+    exit 2
+    ;;
+esac
+
+command -v k6 >/dev/null 2>&1 || {
+  echo "k6 is required: https://grafana.com/docs/k6/latest/set-up/install-k6/" >&2
+  exit 1
+}
+
+PROMETHEUS_URL="${PROMETHEUS_URL:-http://localhost:9090}"
+ACTUATOR_URL="${ACTUATOR_URL:-http://localhost:8081}"
+
+curl -fsS "$PROMETHEUS_URL/-/ready" >/dev/null || {
+  echo "Prometheus is not ready at $PROMETHEUS_URL" >&2
+  exit 1
+}
+
+curl -fsS "$ACTUATOR_URL/actuator/health/readiness" >/dev/null || {
+  echo "commerce-api is not ready at $ACTUATOR_URL" >&2
+  exit 1
+}
+
+TEST_ID="${TEST_ID:-${ENDPOINT}-$(date +%Y%m%d-%H%M%S)}"
+RESULT_DIR="$ROOT_DIR/k6/results"
+mkdir -p "$RESULT_DIR"
+
+export K6_PROMETHEUS_RW_SERVER_URL="${K6_PROMETHEUS_RW_SERVER_URL:-$PROMETHEUS_URL/api/v1/write}"
+export K6_PROMETHEUS_RW_TREND_STATS="${K6_PROMETHEUS_RW_TREND_STATS:-p(90),p(95),avg,max}"
+
+echo "endpoint=$ENDPOINT testid=$TEST_ID"
+echo "Prometheus=$PROMETHEUS_URL Grafana=http://localhost:3000/d/loopers-performance"
+
+k6 run \
+  --out experimental-prometheus-rw \
+  --tag "testid=$TEST_ID" \
+  --tag "environment=${ENVIRONMENT:-local}" \
+  --tag "endpoint=$ENDPOINT" \
+  --tag "test_type=product-read" \
+  --summary-export "$RESULT_DIR/$TEST_ID-summary.json" \
+  "$SCRIPT"

--- a/sql/data_setting.sql
+++ b/sql/data_setting.sql
@@ -1,6 +1,21 @@
--- brand 테이블 초기화 & 데이터 삽입
+-- 로컬 성능 테스트 전용 데이터입니다. commerce-api의 기존 비즈니스 데이터를 모두 삭제합니다.
+-- FK 부모/자식 테이블을 함께 초기화하므로 제약 조건 검사를 잠시 비활성화합니다.
+SET FOREIGN_KEY_CHECKS = 0;
+TRUNCATE TABLE loopers.product_event_outbox;
+TRUNCATE TABLE loopers.payments;
+TRUNCATE TABLE loopers.order_item;
+TRUNCATE TABLE loopers.orders;
+TRUNCATE TABLE loopers.member_coupon;
+TRUNCATE TABLE loopers.coupon;
+TRUNCATE TABLE loopers.inventory;
+TRUNCATE TABLE loopers.product_like;
+TRUNCATE TABLE loopers.product;
+TRUNCATE TABLE loopers.member;
+TRUNCATE TABLE loopers.point;
 TRUNCATE TABLE loopers.brand;
+SET FOREIGN_KEY_CHECKS = 1;
 
+-- brand 테이블 데이터 삽입
 SET SESSION cte_max_recursion_depth = 500;
 INSERT INTO loopers.brand (created_at, updated_at, name, description)
 WITH RECURSIVE seq AS (SELECT 0 AS n
@@ -14,9 +29,7 @@ SELECT NOW(),
     CONCAT('Description for brand ', n)
 FROM seq;
 
--- product 테이블 초기화 & 데이터 삽입
-TRUNCATE TABLE loopers.product;
-
+-- product 테이블 데이터 삽입
 SET SESSION cte_max_recursion_depth = 300000;
 INSERT INTO loopers.product (price, brand_id, created_at, updated_at, name, description, latest_at, like_count)
 WITH RECURSIVE seq AS (SELECT 0 AS n
@@ -24,19 +37,17 @@ WITH RECURSIVE seq AS (SELECT 0 AS n
                        SELECT n + 1
                        FROM seq
                        WHERE n < 299999)
-SELECT ROUND(RAND() * 3000, 2),
-    1 + FLOOR(RAND() * 500),
+SELECT MOD(n * 37, 300000) / 100,
+    1 + MOD(n, 500),
     NOW(),
     NOW(),
     CONCAT('Product ', n),
     CONCAT('Description for product ', n),
     NOW(),
-    FLOOR(RAND() * 300000)
+    0
 FROM seq;
 
--- member 테이블 초기화 & 데이터 삽입
-TRUNCATE TABLE loopers.member;
-
+-- member 테이블 데이터 삽입
 SET SESSION cte_max_recursion_depth = 10000;
 INSERT INTO loopers.member (created_at, updated_at, gender, email, member_id, password_hash)
 WITH RECURSIVE seq AS (SELECT 0 AS n
@@ -51,20 +62,25 @@ SELECT NOW(),
     CONCAT('member', n),
     'hashed_password'
 FROM seq;
-
-
--- product_like 테이블 초기화 & 데이터 삽입
-TRUNCATE TABLE loopers.product_like;
-
+-- product_like 테이블 데이터 삽입
 SET SESSION cte_max_recursion_depth = 300000;
 INSERT INTO loopers.product_like (created_at, updated_at, member_id, product_id)
 WITH RECURSIVE seq AS (SELECT 1 AS n
                        UNION ALL
                        SELECT n + 1
                        FROM seq
-                       WHERE n < 299999)
+                       WHERE n < 300000)
 SELECT NOW(),
     NOW(),
-    1 + FLOOR(RAND() * 10000),
-    1 + FLOOR(RAND() * 300000)
+    1 + MOD(n - 1, 10000),
+    1 + FLOOR(300000 * POW((n - 1) / 300000.0, 2))
 FROM seq;
+
+-- 정규화/비정규화 조회가 같은 좋아요 수를 반환하도록 집계 컬럼을 동기화합니다.
+UPDATE loopers.product product
+    LEFT JOIN (
+        SELECT product_id, COUNT(*) AS like_count
+        FROM loopers.product_like
+        GROUP BY product_id
+    ) product_like_count ON product_like_count.product_id = product.id
+SET product.like_count = COALESCE(product_like_count.like_count, 0);


### PR DESCRIPTION
## Summary

- Compare normalized, denormalized, and Redis product-read paths with one shared k6 scenario.
- Capture p90/p95 latency and publish tagged metrics through Prometheus remote write.
- Provision Prometheus rules and a Grafana performance dashboard.
- Add deterministic seed data, safe preflight checks, and usage documentation.

## Impact

Local performance runs are repeatable and percentile results can be queried and visualized without manual dashboard setup.

## Validation

- `./gradlew test --continue --no-daemon --console=plain`
- `k6 inspect` for all three entry scripts
- `bash -n k6/run-product-read.sh`
- `docker compose -f docker/monitoring-compose.yml config --quiet`
- `promtool check config` and `promtool check rules`
- Grafana dashboard JSON validation

Refs #30
