### PR TITLE
Add performance experiment lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ docker compose -f ./docker/monitoring-compose.yml up -d
 - Prometheus: http://localhost:9090
 - Grafana: http://localhost:3000
 
+Grafana에는 `Loopers Performance Lab` 대시보드가 자동으로 등록됩니다. k6의 p95·p99와 Spring 서버의 HTTP 지연시간, JVM, Tomcat, HikariCP 지표를 함께 보는 실행 방법은 [성능 실험 가이드](docs/performance/README.md)를 참고하세요.
+
 ## About Multi-Module Project
 본 프로젝트는 멀티 모듈 프로젝트로 구성되어 있습니다. 각 모듈의 위계 및 역할을 분명히 하고, 아래와 같은 규칙을 적용합니다.
 

--- a/docker/grafana/dashboards/loopers-performance.json
+++ b/docker/grafana/dashboards/loopers-performance.json
@@ -1,0 +1,1342 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Loopers application, JVM, connection-pool, web-container, and k6 load-test performance metrics from Prometheus.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Completed Spring MVC requests per second, summed across instances and grouped by application.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(sum by (application) (rate(http_server_requests_seconds_count{application=~\"${application:regex}\", uri=~\"${uri:regex}\"}[$__rate_interval])), 0)",
+          "legendFormat": "{{application}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Application RPS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "HTTP 5xx responses divided by all completed requests. The denominator is clamped to avoid division by zero during idle periods.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 * clamp_min((sum by (application) (rate(http_server_requests_seconds_count{application=~\"${application:regex}\", uri=~\"${uri:regex}\", status=~\"5..\"}[$__rate_interval])) or on (application) 0 * sum by (application) (rate(http_server_requests_seconds_count{application=~\"${application:regex}\", uri=~\"${uri:regex}\"}[$__rate_interval]))), 0) / clamp_min(sum by (application) (rate(http_server_requests_seconds_count{application=~\"${application:regex}\", uri=~\"${uri:regex}\"}[$__rate_interval])), 0.000001)",
+          "legendFormat": "{{application}} 5xx",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP 5xx Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Server-side p50, p95, and p99 latency calculated from the Micrometer HTTP request histogram buckets.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(histogram_quantile(0.50, sum by (application, le) (rate(http_server_requests_seconds_bucket{application=~\"${application:regex}\", uri=~\"${uri:regex}\"}[$__rate_interval]))), 0)",
+          "legendFormat": "{{application}} p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(histogram_quantile(0.95, sum by (application, le) (rate(http_server_requests_seconds_bucket{application=~\"${application:regex}\", uri=~\"${uri:regex}\"}[$__rate_interval]))), 0)",
+          "legendFormat": "{{application}} p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(histogram_quantile(0.99, sum by (application, le) (rate(http_server_requests_seconds_bucket{application=~\"${application:regex}\", uri=~\"${uri:regex}\"}[$__rate_interval]))), 0)",
+          "legendFormat": "{{application}} p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Server Latency p50 / p95 / p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "The ten slowest URI and method combinations by server-side p99 latency in each evaluation step.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 6,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, clamp_min(histogram_quantile(0.99, sum by (application, method, uri, le) (rate(http_server_requests_seconds_bucket{application=~\"${application:regex}\", uri=~\"${uri:regex}\"}[$__rate_interval]))), 0))",
+          "legendFormat": "{{application}} {{method}} {{uri}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Endpoint p99 Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "HikariCP connections currently in use, waiting for a connection, and configured maximum, by pool and instance.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(max by (application, instance, pool) (hikaricp_connections_active{application=~\"${application:regex}\"}), 0)",
+          "legendFormat": "{{application}} {{instance}} {{pool}} active",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(max by (application, instance, pool) (hikaricp_connections_pending{application=~\"${application:regex}\"}), 0)",
+          "legendFormat": "{{application}} {{instance}} {{pool}} pending",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(max by (application, instance, pool) (hikaricp_connections_max{application=~\"${application:regex}\"}), 0)",
+          "legendFormat": "{{application}} {{instance}} {{pool}} max",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "HikariCP Connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Tomcat request-worker threads currently busy compared with the configured maximum.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(max by (application, instance, name) (tomcat_threads_busy_threads{application=~\"${application:regex}\"}), 0)",
+          "legendFormat": "{{application}} {{instance}} busy",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(max by (application, instance, name) (tomcat_threads_config_max_threads{application=~\"${application:regex}\"}), 0)",
+          "legendFormat": "{{application}} {{instance}} max",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Tomcat Threads Busy / Max",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Recent process CPU utilization by application instance. Micrometer exports this gauge as a ratio and the panel displays percent.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 36
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 * clamp_max(clamp_min(avg_over_time(process_cpu_usage{application=~\"${application:regex}\"}[$__rate_interval]), 0), 1)",
+          "legendFormat": "{{application}} {{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Process CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Heap memory currently used compared with the JVM's reported maximum, summed across heap pools for each instance.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 36
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(sum by (application, instance) (jvm_memory_used_bytes{application=~\"${application:regex}\", area=\"heap\"}), 0)",
+          "legendFormat": "{{application}} {{instance}} used",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(sum by (application, instance) (jvm_memory_max_bytes{application=~\"${application:regex}\", area=\"heap\"}), 0)",
+          "legendFormat": "{{application}} {{instance}} max",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "JVM Heap Used / Max",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Number of recorded JVM GC pause events per second by instance.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 36
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(sum by (application, instance) (rate(jvm_gc_pause_seconds_count{application=~\"${application:regex}\"}[$__rate_interval])), 0)",
+          "legendFormat": "{{application}} {{instance}} pauses/s",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "JVM GC Pause Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Live, daemon, and peak JVM thread gauges by application instance.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(jvm_threads_live_threads{application=~\"${application:regex}\"}, 0)",
+          "legendFormat": "{{application}} {{instance}} live",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(jvm_threads_daemon_threads{application=~\"${application:regex}\"}, 0)",
+          "legendFormat": "{{application}} {{instance}} daemon",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(jvm_threads_peak_threads{application=~\"${application:regex}\"}, 0)",
+          "legendFormat": "{{application}} {{instance}} peak",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "JVM Threads",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "id": 11,
+      "panels": [],
+      "title": "k6 Load Test",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "HTTP requests generated by k6 per second. k6 exports the Counter as k6_http_reqs_total.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 53
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(sum(rate(k6_http_reqs_total{stage=\"measure\"}[$__rate_interval])), 0)",
+          "legendFormat": "k6 RPS",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "k6 RPS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Worst recent k6 HTTP failure-rate Gauge across emitted tag series. k6 maps its Rate metric to k6_http_req_failed_rate.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 53
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 * clamp_max(clamp_min(max(max_over_time(k6_http_req_failed_rate{stage=\"measure\"}[$__rate_interval])), 0), 1)",
+          "legendFormat": "k6 failures",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "k6 Failure Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Worst recent p95 and p99 request-duration Gauge across emitted k6 tag series. Run with K6_PROMETHEUS_RW_TREND_STATS=p(95),p(99); values are converted from seconds to milliseconds.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 53
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "1000 * clamp_min(max(max_over_time(k6_http_req_duration_p95{stage=\"measure\"}[$__rate_interval])), 0)",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "1000 * clamp_min(max(max_over_time(k6_http_req_duration_p99{stage=\"measure\"}[$__rate_interval])), 0)",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "k6 Latency p95 / p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Iterations k6 could not start per second. k6 exports dropped_iterations as the k6_dropped_iterations_total Counter.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 53
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(sum(rate(k6_dropped_iterations_total[$__rate_interval])), 0)",
+          "legendFormat": "dropped/s",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "k6 Dropped Iterations / s",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": [
+    "loopers",
+    "performance",
+    "prometheus",
+    "k6"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(http_server_requests_seconds_count, application)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Application",
+        "multi": true,
+        "name": "application",
+        "options": [],
+        "query": {
+          "query": "label_values(http_server_requests_seconds_count, application)",
+          "refId": "PrometheusVariableQueryEditor-application"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(http_server_requests_seconds_count{application=~\"${application:regex}\"}, uri)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "URI",
+        "multi": true,
+        "name": "uri",
+        "options": [],
+        "query": {
+          "query": "label_values(http_server_requests_seconds_count{application=~\"${application:regex}\"}, uri)",
+          "refId": "PrometheusVariableQueryEditor-uri"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "6h",
+      "12h",
+      "24h"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Loopers Performance Lab",
+  "uid": "loopers-performance",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docker/grafana/prometheus.yml
+++ b/docker/grafana/prometheus.yml
@@ -1,8 +1,23 @@
 global:
   scrape_interval: 5s
+  scrape_timeout: 4s
 
 scrape_configs:
-  - job_name: 'spring-boot-app'
+  - job_name: 'commerce-api'
     metrics_path: '/actuator/prometheus'
     static_configs:
       - targets: ['host.docker.internal:8081']
+
+  - job_name: 'pg-simulator'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8083']
+
+  - job_name: 'commerce-streamer'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8085']
+
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']

--- a/docker/grafana/provisioning/dashboards/dashboard.yml
+++ b/docker/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+providers:
+  - name: loopers-performance
+    orgId: 1
+    folder: Loopers
+    folderUid: loopers
+    type: file
+    disableDeletion: false
+    allowUiUpdates: true
+    updateIntervalSeconds: 10
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/docker/grafana/provisioning/datasources/datasource.yml
+++ b/docker/grafana/provisioning/datasources/datasource.yml
@@ -1,7 +1,9 @@
 apiVersion: 1
 datasources:
   - name: Prometheus
+    uid: prometheus
     type: prometheus
     access: proxy
     url: http://prometheus:9090
     isDefault: true
+    editable: false

--- a/docker/monitoring-compose.yml
+++ b/docker/monitoring-compose.yml
@@ -2,18 +2,32 @@ name: loopers-monitoring
 
 services:
   prometheus:
-    image: prom/prometheus
+    image: prom/prometheus:v3.5.0
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=7d
+      - --web.enable-remote-write-receiver
     ports:
       - "9090:9090"
     volumes:
-      - ./grafana/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./grafana/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
 
   grafana:
-    image: grafana/grafana
+    image: grafana/grafana:12.1.0
+    depends_on:
+      - prometheus
     ports:
       - "3000:3000"
     volumes:
-      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana-data:/var/lib/grafana
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=admin
+
+volumes:
+  prometheus-data:
+  grafana-data:

--- a/docs/performance/README.md
+++ b/docs/performance/README.md
@@ -1,0 +1,527 @@
+# Loopers 이커머스 성능 실험 가이드
+
+## 용어 정리
+
+- 백분위 지연시간 (percentile latency): 요청을 빠른 순서로 놓았을 때 일정 비율의 요청이 그 시간 안에 끝났음을 나타냅니다.
+- 처리량 (throughput): 서버가 1초 동안 실제로 처리한 요청 수이며, 이 문서에서는 주로 RPS(Requests Per Second)로 표시합니다.
+- 서비스 수준 목표 (Service Level Objective, SLO): 사용자가 받아야 할 성능과 안정성의 목표값입니다.
+- 포화 (saturation): 스레드, DB 연결, CPU 같은 제한된 자원이 거의 다 사용되어 새 요청이 기다리는 상태입니다.
+- 히스토그램 (histogram): 응답시간을 여러 구간에 나눠 요청 수를 저장하고, 서버 여러 대의 p95·p99도 합산해 계산할 수 있게 하는 메트릭입니다.
+
+## 핵심 답변
+
+이 저장소에서는 아래 흐름으로 성능 실험을 재현할 수 있습니다.
+
+```text
+k6 부하 발생기
+  -> commerce-api:8080
+     -> MySQL / Redis / Kafka / pg-simulator
+  -> k6 결과 ---------> Prometheus:9090
+commerce-api Actuator -> Prometheus:9090
+Prometheus -----------> Grafana:3000
+```
+
+가정: 첫 실험 대상은 상품 목록 조회이며, 로컬 한 대에서 병목을 찾는 학습 실험입니다. 이 결과를 그대로 운영 용량으로 환산하지 않습니다.
+
+현재 제공하는 항목은 다음과 같습니다.
+
+- `normalized`, `denormalized`, `redis` 상품 조회를 같은 요청 패턴으로 비교하는 k6 실험
+- smoke, load, stress, spike, soak 부하 프로필
+- p50·p95·p99, RPS, 오류율, 목표 요청 누락, JVM, Tomcat, HikariCP를 한 화면에서 보는 Grafana 대시보드
+- 브랜드 500건, 상품 30만 건, 회원 1만 건, 좋아요 약 30만 건의 로컬 데이터
+- 대용량 트래픽에서 추가로 확인할 실험과 정확성 검증표
+
+값의 구분:
+
+- 사실: 소스 코드나 공식 문서로 확인한 내용입니다.
+- 측정값: 이 환경에서 명령을 실행해 얻은 값이며, 실행 날짜와 조건을 함께 기록해야 합니다.
+- 권장값: 첫 실험을 시작하기 위한 예시입니다. 실제 합격 기준은 서비스 SLO로 바꿔야 합니다.
+
+## 1. 대상과 학습 목표
+
+대상은 Spring Boot 서비스를 실행해 본 주니어~미들 백엔드 개발자입니다.
+
+선행 조건:
+
+- Java 21
+- Docker Desktop
+- k6
+- 로컬 포트 `3000`, `8080`, `8081`, `9090` 사용 가능
+
+이 실험을 끝내면 다음을 할 수 있어야 합니다.
+
+1. 평균과 p95·p99의 차이를 설명합니다.
+2. 목표 RPS를 유지하면서 지연시간이 무너지는 포화 지점을 찾습니다.
+3. k6의 사용자 관점 지연과 Spring 서버 내부 지연을 구분합니다.
+4. 느린 요청과 함께 CPU, Tomcat 스레드, HikariCP DB 연결 풀을 확인합니다.
+5. 캐시 성능을 cold miss와 warm hit로 분리합니다.
+6. 성능과 함께 재고·포인트·이벤트의 정합성을 검증합니다.
+
+이번 구성에서 의도적으로 생략한 항목:
+
+- 운영 환경의 분산 부하 발생기
+- MySQL·Redis·Kafka 전용 exporter와 분산 추적
+- 운영 SLO와 비용 기준
+- 커널·네트워크 패킷 수준 분석
+
+이 항목들은 8장의 후속 실험에서 다룹니다.
+
+## 2. 10분 빠른 시작
+
+### 2.1 기능 테스트 기준선 확인
+
+목적은 부하 테스트 전에 기능 자체가 정상인지 확인하는 것입니다. 입력은 현재 소스 코드이고, 기대 결과는 `BUILD SUCCESSFUL`입니다.
+
+```bash
+mise exec java@21.0.2 -- ./gradlew build
+```
+
+전체 테스트는 Testcontainers로 MySQL과 Redis를 실행하므로 Docker Desktop이 켜져 있어야 합니다.
+
+### 2.2 로컬 인프라 실행
+
+```bash
+docker compose -f docker/infra-compose.yml up -d
+docker compose -f docker/infra-compose.yml ps -a
+```
+
+기대 신호는 MySQL, Redis, Kafka가 `healthy`이고 초기화 서비스가 성공 종료되는 것입니다.
+
+### 2.3 commerce-api 실행
+
+로컬 기본 설정은 SQL을 모두 출력하므로 성능 측정에서는 끕니다.
+
+```bash
+mise exec java@21.0.2 -- ./gradlew :apps:commerce-api:bootRun \
+  --args='--spring.jpa.show-sql=false'
+```
+
+별도 터미널에서 확인합니다.
+
+```bash
+curl -fsS http://localhost:8081/actuator/health
+```
+
+기대 결과는 `status`가 `UP`인 응답입니다.
+
+### 2.4 실험 데이터 적재
+
+경고: `sql/data_setting.sql`은 실험 전용이며 지정한 네 테이블의 데이터를 삭제합니다. `local` 프로필이 새 스키마를 만든 직후에만 실행합니다.
+
+```bash
+docker compose -f docker/infra-compose.yml exec -T mysql \
+  mysql -uapplication -papplication loopers < sql/data_setting.sql
+```
+
+적재 결과를 확인합니다.
+
+```bash
+docker compose -f docker/infra-compose.yml exec -T mysql \
+  mysql -uapplication -papplication loopers \
+  -e "SELECT COUNT(*) products FROM product; SELECT COUNT(*) likes FROM product_like;"
+```
+
+기대 규모는 상품 300,000건, 좋아요 299,999건입니다. 데이터 생성 중에는 부하 테스트를 시작하지 않습니다.
+
+### 2.5 Prometheus와 Grafana 실행
+
+```bash
+docker compose -f docker/monitoring-compose.yml up -d
+docker compose -f docker/monitoring-compose.yml ps
+```
+
+확인 위치:
+
+- Prometheus targets: <http://localhost:9090/targets>
+- Grafana: <http://localhost:3000> (`admin` / `admin`)
+- 자동 설치 대시보드: `Dashboards > Loopers > Loopers Performance Lab`
+
+Prometheus에서 다음 쿼리 결과가 `1`이면 commerce-api를 수집하고 있습니다.
+
+```promql
+up{job="commerce-api"}
+```
+
+### 2.6 첫 smoke 실험
+
+목적은 경로·데이터·메트릭 연결을 짧게 검증하는 것입니다. 이 결과로 용량을 판단하지 않습니다.
+
+```bash
+mkdir -p k6/results
+
+K6_PROMETHEUS_RW_SERVER_URL=http://localhost:9090/api/v1/write \
+K6_PROMETHEUS_RW_TREND_STATS=p(50),p(95),p(99),max \
+k6 run -o experimental-prometheus-rw \
+  -e PROFILE=smoke \
+  -e VARIANT=denormalized \
+  -e TEST_ID=local-smoke \
+  --summary-export k6/results/local-smoke.json \
+  k6/product-query-performance.js
+```
+
+합격 신호:
+
+- HTTP 상태 검사 성공
+- `http_req_failed` 기준 통과
+- `dropped_iterations`가 0
+- Grafana의 k6 및 commerce-api 패널에 같은 시간대 데이터가 표시됨
+
+## 3. p95와 p99를 읽는 법
+
+### 3.1 가장 작은 정확한 모델
+
+요청 10,000개를 응답시간이 짧은 순서로 정렬했다고 가정합니다.
+
+- p50: 가운데 요청의 응답시간에 가깝습니다.
+- p95: 9,500개 요청은 이 값 이하, 약 500개는 이 값보다 느립니다.
+- p99: 9,900개 요청은 이 값 이하, 약 100개는 이 값보다 느립니다.
+
+비유: 평균 이동 시간은 하루 전체의 대략적인 교통 상황이고, p99는 혼잡한 순간에 실제로 겪을 수 있는 긴 이동 시간입니다. 비유의 한계는 p99가 단 하나의 최악값이 아니라 상위 1%의 경계라는 점입니다.
+
+느린 요청 수를 대략 계산하는 식은 다음과 같습니다.
+
+```text
+경계보다 느린 요청/초 = RPS × (1 - P / 100)
+```
+
+- `RPS`: 초당 요청 수, 단위는 요청/초입니다.
+- `P`: 백분위 숫자입니다. p99라면 `P = 99`입니다.
+
+예를 들어 10,000 RPS에서 p99가 1초이면, 매초 약 100개 요청이 1초보다 느릴 수 있습니다.
+
+### 3.2 평균만 보면 안 되는 이유
+
+DB 잠금, 가비지 컬렉션, 커넥션 풀 대기처럼 일부 요청에만 생기는 지연은 평균에서 희석됩니다. 평균이 안정적이어도 p99와 타임아웃이 먼저 증가할 수 있습니다.
+
+### 3.3 표본 수 주의
+
+기존 k6 스크립트는 총 50건만 보냅니다. 50건의 p99는 사실상 가장 느린 한두 요청에 크게 흔들립니다.
+
+권장: 엔드포인트와 안정 구간마다 성공 요청 10,000건 이상을 확보합니다. 이는 절대적인 통계 규칙이 아니라, 상위 1%에 약 100개 표본을 확보해 비교를 쉽게 하려는 실무 기준입니다. 같은 조건을 최소 세 번 반복하고 대표값과 변동 폭을 함께 봅니다.
+
+## 4. 실험 프로필과 실행 명령
+
+### 4.1 프로필 의미
+
+| 프로필 | 질문 | 기본 형태 |
+| --- | --- | --- |
+| `smoke` | 경로와 측정 구성이 동작하는가? | 낮은 RPS, 짧은 실행 |
+| `load` | 예상 부하를 지속해서 처리하는가? | 워밍업 - 유지 - 감소 |
+| `stress` | 어느 RPS부터 무너지는가? | 여러 단계로 계속 증가 |
+| `spike` | 갑작스러운 폭증 뒤 회복하는가? | 짧은 고부하 후 정상 부하 |
+| `soak` | 오래 실행할 때 누수·지연 누적이 있는가? | 목표 부하 장시간 유지 |
+
+k6는 도착률 기반 실행기를 사용합니다. 서버가 느려져도 예정한 요청률을 유지하려고 하므로 포화 지점을 보기 쉽습니다. 필요한 가상 사용자를 확보하지 못하면 `dropped_iterations`가 증가합니다.
+
+### 4.2 조회 구현 비교
+
+동일한 브랜드, 페이지, 정렬 조건으로 세 번 실행합니다.
+
+```bash
+for variant in normalized denormalized redis; do
+  K6_PROMETHEUS_RW_SERVER_URL=http://localhost:9090/api/v1/write \
+  K6_PROMETHEUS_RW_TREND_STATS=p(50),p(95),p(99),max \
+  k6 run -o experimental-prometheus-rw \
+    -e PROFILE=load \
+    -e VARIANT="$variant" \
+    -e TEST_ID="query-$variant" \
+    -e RPS=100 \
+    -e BRAND_IDS=1,2,3 \
+    -e PAGE=0 \
+    -e SIZE=20 \
+    k6/product-query-performance.js
+done
+```
+
+비교표에는 다음을 기록합니다.
+
+| 항목 | normalized | denormalized | redis warm |
+| --- | ---: | ---: | ---: |
+| 실제 RPS |  |  |  |
+| p50 |  |  |  |
+| p95 |  |  |  |
+| p99 |  |  |  |
+| 오류율 |  |  |  |
+| dropped iterations |  |  |  |
+| DB pool pending 최대 |  |  |  |
+| CPU 최대 |  |  |  |
+
+공정 비교 조건:
+
+- 같은 데이터 스냅샷과 인덱스
+- 같은 `BRAND_IDS`, `PAGE`, `SIZE`, `SORT`
+- 같은 RPS와 실행 시간
+- 워밍업 구간 제외
+- SQL 로그 비활성화
+- 한 실험이 끝난 뒤 자원이 정상으로 회복되었는지 확인
+
+### 4.3 Redis cold와 warm 분리
+
+사실: 목록 캐시는 `page <= 1`만 저장하며 TTL은 5분입니다. 기존 `redis_test.js`의 `page=100`과 매번 달라지는 브랜드 목록은 캐시 적중 실험이 아닙니다.
+
+권장 순서:
+
+1. Redis 캐시를 비운 뒤 첫 요청 한 번의 cold miss를 확인합니다.
+2. 고정된 브랜드 순서와 `page=0`으로 warm hit를 반복합니다.
+3. 캐시가 비어 있는 순간에 높은 동시 요청을 보내 cache stampede 여부를 봅니다.
+4. `redis-cli MONITOR`는 부하 자체를 왜곡할 수 있으므로 짧은 진단에서만 사용합니다.
+
+주의: 현재 캐시 키에는 `SIZE`가 없습니다. 같은 브랜드·정렬·페이지에 서로 다른 크기를 요청하면 잘못된 크기의 캐시 응답을 재사용할 수 있습니다. 성능보다 먼저 기능 정확성을 검증해야 합니다.
+
+## 5. Grafana에서 보는 순서
+
+### 5.1 사용자 관점
+
+먼저 k6 패널을 봅니다.
+
+1. 목표 RPS를 실제로 만들었는가?
+2. `dropped_iterations`가 생겼는가?
+3. 기능 검사와 HTTP 오류율이 기준을 넘었는가?
+4. p95·p99가 어느 부하 단계부터 증가했는가?
+
+### 5.2 서버 관점
+
+그다음 같은 시간대의 commerce-api 패널을 봅니다.
+
+1. URI별 서버 p95·p99
+2. Tomcat busy threads / max threads
+3. Hikari active / pending / max connections
+4. process CPU
+5. JVM heap, GC pause, live threads
+
+판단 예:
+
+| 증상 | 함께 보이는 신호 | 우선 의심 |
+| --- | --- | --- |
+| k6 p99만 높고 서버 p99는 낮음 | 연결·수신 시간이 증가 | 부하 발생기, 네트워크, 서버 앞 대기열 |
+| 서버 p99와 Hikari pending 동시 증가 | active가 max에 근접 | 느린 쿼리, 긴 트랜잭션, DB 연결 부족 |
+| p99와 Tomcat busy 동시 증가 | busy가 max에 근접 | 동기 작업, 외부 연동 지연, 워커 포화 |
+| p99와 CPU 동시 증가 | DB pending은 낮음 | 계산, 직렬화, GC, 과도한 로깅 |
+| p99가 급증하고 RPS가 감소 | dropped도 증가 | 시스템 또는 부하 발생기 포화 |
+| 오류율만 증가하고 p99는 낮아짐 | 빠른 4xx·5xx | 실패 응답이 빨라 평균을 왜곡 |
+
+성공과 오류 요청의 지연시간은 분리해서 봅니다. 실패가 빨리 반환되면 전체 p99가 좋아진 것처럼 보일 수 있습니다.
+
+## 6. PromQL 예제
+
+### 6.1 성공 요청 p95
+
+```promql
+histogram_quantile(
+  0.95,
+  sum by (le, uri) (
+    rate(http_server_requests_seconds_bucket{
+      application="commerce-api",
+      status=~"2.."
+    }[5m])
+  )
+)
+```
+
+p99는 `0.95`를 `0.99`로 바꿉니다. `histogram_quantile()` 전에 bucket을 합칠 때 `le` label을 반드시 보존해야 합니다.
+
+### 6.2 URI별 RPS
+
+```promql
+sum by (uri) (
+  rate(http_server_requests_seconds_count{
+    application="commerce-api"
+  }[1m])
+)
+```
+
+### 6.3 5xx 비율
+
+```promql
+100 *
+sum(rate(http_server_requests_seconds_count{
+  application="commerce-api",
+  status=~"5.."
+}[1m]))
+/
+clamp_min(
+  sum(rate(http_server_requests_seconds_count{
+    application="commerce-api"
+  }[1m])),
+  0.001
+)
+```
+
+### 6.4 SLO 경계 이내 비율
+
+예를 들어 서버 응답시간 목표가 300ms라면 300ms bucket이 있어야 정확한 비율을 계산할 수 있습니다. 아래의 `le="0.3"` 시계열이 실제로 존재하는지 먼저 확인합니다.
+
+```promql
+sum(rate(http_server_requests_seconds_bucket{
+  application="commerce-api",
+  le="0.3"
+}[5m]))
+/
+sum(rate(http_server_requests_seconds_count{
+  application="commerce-api"
+}[5m]))
+```
+
+## 7. 대용량 트래픽에서 측정할 것
+
+### 7.1 네 가지 핵심 신호
+
+| 범주 | 최소 지표 | 질문 |
+| --- | --- | --- |
+| 지연시간 | p50, p95, p99, timeout | 느린 사용자가 얼마나 많은가? |
+| 트래픽 | 목표·실제 RPS, 동시 요청 | 필요한 부하를 처리했는가? |
+| 오류 | HTTP 오류, 기능 check, retry | 빠르게 실패한 요청도 잡았는가? |
+| 포화 | CPU, thread, DB pool, queue | 어떤 자원이 먼저 다 찼는가? |
+
+### 7.2 계층별 체크리스트
+
+| 계층 | 지표 | 경고 신호 |
+| --- | --- | --- |
+| k6 | actual RPS, p95/p99, failed, checks, dropped | 목표 RPS 미달, dropped 지속 증가 |
+| HTTP | URI별 RPS·p95·p99·4xx·5xx | 일부 URI만 tail latency 증가 |
+| Tomcat | busy/max threads, accept queue, rejected | busy가 max 근처에서 유지 |
+| JVM | process CPU, heap, GC pause, thread | GC 뒤에도 heap이 회복되지 않음 |
+| HikariCP | active/idle/pending/max, acquire timeout | pending 증가, active=max |
+| MySQL | query p95/p99, rows examined, lock wait, deadlock, I/O | lock wait와 쿼리 지연 동시 증가 |
+| Redis | hit/miss, command latency, memory, eviction, replica lag | hit율 저하, eviction·복제 지연 |
+| Kafka | produce/consume rate, retry, consumer lag, E2E lag | lag가 부하 종료 뒤에도 감소하지 않음 |
+| 외부 PG | p95/p99, timeout, circuit state | 외부 지연이 DB pool까지 점유 |
+| 비즈니스 | 재고·잔액·중복 주문·이벤트 유실 | HTTP 성공 수와 최종 상태 불일치 |
+
+메트릭 label에는 회원 ID, 주문 ID처럼 값이 계속 늘어나는 식별자를 넣지 않습니다. 시계열 수가 폭증해 Prometheus 자체가 병목이 될 수 있습니다.
+
+## 8. 프로젝트 전용 후속 실험
+
+### 실험 A. 정규화 대 비정규화 대 캐시
+
+- 시나리오: 브랜드별 상품을 좋아요 순으로 조회
+- 가설: 조인·집계보다 비정규화가 빠르고, warm cache가 가장 빠르다.
+- 확인: p95/p99, rows examined, CPU, Hikari pending, 응답 내용 동일성
+- 실패 진단: `EXPLAIN ANALYZE`, 인덱스 전후 비교, cache hit 분리
+
+주의: 현재 정규화 경로는 좋아요 수를 집계하지만 정렬 기준은 집계값이 아닌 `product.like_count`입니다. 성능 비교 전에 두 경로가 같은 의미의 결과를 만드는지 확인합니다.
+
+### 실험 B. Hot SKU 재고 경합
+
+- 시나리오: 같은 상품 한 개에 주문을 집중
+- 가설: 비관적 잠금이 초과 판매는 막지만 lock wait 때문에 p99가 증가한다.
+- 확인: 성공 주문 수, 남은 재고, p95/p99, lock wait, deadlock, Hikari pending
+- 불변식: `초기 재고 = 성공적으로 반영된 주문 수 + 최종 재고`
+
+여러 상품을 한 주문에서 서로 다른 순서로 잠그면 deadlock 가능성도 별도로 확인합니다.
+
+### 실험 C. 포인트 동시 충전
+
+- 시나리오: 한 회원에게 동시에 포인트를 충전
+- 가설: 잠금이나 버전 검사가 없으면 lost update가 발생할 수 있다.
+- 확인: HTTP 성공 수뿐 아니라 최종 잔액
+- 불변식: `최종 잔액 = 초기 잔액 + 성공 수 × 충전액`
+
+### 실험 D. PG 지연과 회로 차단기
+
+- 시나리오: 100~500ms 지연과 실패가 있는 pg-simulator 호출
+- 가설: DB 트랜잭션 안의 동기 외부 호출이 Hikari 연결을 오래 점유한다.
+- 확인: 결제 p99, Hikari active/pending, 회로 차단기 상태, 최종 결제 상태
+
+HTTP 200만 성공으로 세면 안 됩니다. fallback이 외부 실패를 HTTP 성공처럼 보이게 할 수 있으므로 DB의 결제 상태까지 확인합니다.
+
+### 실험 E. 주문에서 Kafka 소비까지
+
+- 시나리오: 주문 이벤트를 생성하고 commerce-streamer가 집계할 때까지 측정
+- 확인: HTTP p99와 별도로 producer 오류, outbox 최고 대기 시간, consumer lag, 이벤트 end-to-end 지연
+- 정확성: 생성 이벤트 수, broker 수신 수, 처리 완료 수가 일치하는지 확인
+
+현재 코드에는 선행 정확성 점검이 필요합니다.
+
+- streamer의 상품 메트릭 카운터가 첫 판매 이벤트에서 null일 가능성
+- producer 전송 완료를 기다리지 않고 outbox를 완료 처리하는 경로
+- 주문 재고 처리와 쿠폰 처리의 서로 다른 트랜잭션 시점
+
+이 문제를 확인하기 전에는 Kafka 처리량 수치를 성공 결과로 해석하지 않습니다.
+
+## 9. 실패 진단 순서
+
+### 증상 1. p99만 갑자기 높아짐
+
+1. 오류 요청을 제외한 p99인지 확인합니다.
+2. k6와 서버 p99를 비교합니다.
+3. Tomcat busy, Hikari pending, CPU, GC를 같은 시간축에서 확인합니다.
+4. DB slow query와 lock wait를 확인합니다.
+5. 최근 배포·캐시 만료·부하 단계 변경 시점을 겹쳐 봅니다.
+
+### 증상 2. 목표 RPS를 만들지 못함
+
+1. `dropped_iterations`를 확인합니다.
+2. 부하 발생기 CPU·메모리가 충분한지 확인합니다.
+3. `preAllocatedVUs`와 `maxVUs`가 너무 작은지 확인합니다.
+4. 서버의 빠른 실패나 연결 거부를 확인합니다.
+
+### 증상 3. Redis가 DB보다 느림
+
+1. 실제 cache hit인지 확인합니다.
+2. cache key가 요청마다 달라지는지 확인합니다.
+3. 값 직렬화·응답 크기를 비교합니다.
+4. replica lag로 write 직후 miss가 나는지 확인합니다.
+5. cold와 warm 결과를 섞지 않았는지 확인합니다.
+
+## 10. 실험 결과 기록 양식
+
+각 실행마다 아래 내용을 남깁니다.
+
+```text
+실험 ID:
+Git commit:
+실행 시각/시간대:
+장비 CPU·메모리:
+Java / k6 / Docker 버전:
+데이터 건수와 인덱스:
+프로필 / variant / 목표 RPS / 실행 시간:
+워밍업 제외 구간:
+
+실제 RPS:
+p50 / p95 / p99:
+오류율 / check 실패 / dropped iterations:
+CPU / Tomcat busy / Hikari active·pending:
+DB lock·slow query / Redis hit·miss / Kafka lag:
+비즈니스 불변식 결과:
+
+관찰된 병목:
+변경한 한 가지:
+재실행 결과와 변동 폭:
+결론 또는 다음 실험:
+```
+
+한 번에 한 변수만 바꿉니다. 예를 들어 인덱스와 Hikari pool 크기를 동시에 바꾸면 어떤 변경이 효과를 냈는지 알 수 없습니다.
+
+## 11. 연습 문제
+
+1. 평균 80ms, p95 200ms, p99 2s라면 어떤 사용자가 문제를 겪고 있습니까?
+2. p99와 Hikari pending이 함께 증가하지만 CPU는 낮습니다. 첫 진단 대상은 무엇입니까?
+3. Redis warm 실험에서 요청마다 브랜드 순서를 바꾸면 어떤 일이 생깁니까?
+4. HTTP 오류율이 0%여도 주문 성능 실험이 실패할 수 있는 이유는 무엇입니까?
+5. 목표가 500 RPS인데 실제 420 RPS이고 dropped iterations가 증가합니다. 무엇을 먼저 구분해야 합니까?
+
+### 정답과 판단 근거
+
+1. 상위 약 1%의 요청이 최대 수초 지연을 겪는 꼬리 지연 문제입니다. 평균만으로는 숨겨집니다.
+2. DB 연결 획득 대기, 느린 쿼리, 긴 트랜잭션, DB 잠금을 먼저 확인합니다.
+3. 현재 캐시 키에 브랜드 순서가 들어가므로 논리적으로 같은 조건도 다른 key가 되어 miss와 key 파편화가 늘어납니다.
+4. 초과 판매, lost update, 중복 처리처럼 HTTP 200 뒤의 최종 상태가 틀릴 수 있기 때문입니다.
+5. 서버 용량 부족과 부하 발생기 VU·CPU 부족을 먼저 구분합니다. k6와 서버 자원 신호를 함께 봅니다.
+
+전이 질문: 상품 조회가 빨라졌지만 DB CPU가 더 높아졌다면 이 변경을 배포해야 할까요? 사용자 SLO, 최대 부하, 비용, 다른 쿼리에 미치는 영향을 함께 비교해야 합니다.
+
+## 12. 공식 참고 자료
+
+- [Prometheus - Histograms and summaries](https://prometheus.io/docs/practices/histograms/)
+- [Prometheus - histogram_quantile](https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile)
+- [Prometheus - Instrumentation practices](https://prometheus.io/docs/practices/instrumentation/)
+- [Micrometer - Histograms and percentiles](https://docs.micrometer.io/micrometer/reference/concepts/histogram-quantiles.html)
+- [Spring Boot 3.4 - Metrics](https://docs.spring.io/spring-boot/3.4/reference/actuator/metrics.html)
+- [Grafana k6 - Thresholds](https://grafana.com/docs/k6/latest/using-k6/thresholds/)
+- [Grafana k6 - Open and closed models](https://grafana.com/docs/k6/latest/using-k6/scenarios/concepts/open-vs-closed/)
+- [Grafana k6 - Prometheus remote write](https://grafana.com/docs/k6/latest/results-output/real-time/prometheus-remote-write/)
+- [Google SRE - Monitoring distributed systems](https://sre.google/sre-book/monitoring-distributed-systems/)
+- [Google SRE - Service level objectives](https://sre.google/sre-book/service-level-objectives/)
+
+문서의 숫자 예시는 합성 예시입니다. 실제 프로젝트 측정값은 실행 조건과 함께 별도 결과 기록에 남깁니다.

--- a/docs/performance/results/2026-08-04-local-smoke.md
+++ b/docs/performance/results/2026-08-04-local-smoke.md
@@ -1,0 +1,95 @@
+# 2026-08-04 로컬 성능 smoke 결과
+
+## 용어 정리
+
+- smoke test: 성능 한계를 찾기 전에 요청, 데이터, 메트릭, 대시보드가 연결되는지 낮은 부하로 확인하는 시험입니다.
+- 측정 구간 (measure stage): Redis warm-up 같은 준비 요청을 빼고 p95·p99를 계산한 구간입니다.
+- 누락 반복 (dropped iterations): k6가 예정한 시각에 시작하지 못한 요청 작업 수입니다.
+
+## 핵심 답변
+
+세 상품 조회 경로 모두 2 RPS를 30초 동안 처리했고, 기능 검사 실패와 누락 반복은 0건이었습니다. 측정 구간의 참고값은 Redis warm p95 18.24ms, denormalized p95 35.63ms, normalized p95 44.65ms였습니다.
+
+중요: 각 경로의 측정 요청은 61건뿐입니다. p99 비교와 용량 판단에 필요한 표본 수가 아니며, 이번 결과는 전체 측정 경로가 동작한다는 증거입니다.
+
+## 실행 환경
+
+| 항목 | 값 |
+| --- | --- |
+| Git 기준 commit | `ea81bf3` + 작업 트리 변경 |
+| 장비 | MacBook Air, Apple M4 10-core, 24GB |
+| Java | OpenJDK 21.0.2 |
+| Spring Boot | 3.4.4 |
+| k6 | 2.1.0 |
+| Docker client / server | 29.7.1 / 29.6.1 |
+| Prometheus / Grafana | 3.5.0 / 12.1.0 |
+| 실행 시간대 | Asia/Seoul |
+
+## 데이터와 요청 조건
+
+| 항목 | 값 |
+| --- | --- |
+| 브랜드 | 500건 |
+| 상품 | 300,000건 |
+| 회원 | 10,000건 |
+| 좋아요 | 299,999건 |
+| like_count 불일치 | 0건 |
+| 브랜드 | `1,2,34` 고정 |
+| 페이지 | `0,1` 순환 |
+| 페이지 크기 | 20 |
+| 정렬 | `LIKE_COUNT_DESC` |
+| 목표 부하 | 2 RPS, 30초 |
+| Redis | setup에서 0·1페이지 warm-up |
+
+실행 순서는 `denormalized -> normalized -> redis`였습니다. 이 순서와 운영체제·DB 캐시 상태가 결과에 영향을 줄 수 있습니다.
+
+## 측정 결과
+
+k6 custom Trend인 `product_query_duration`만 사용했습니다. 따라서 setup 요청은 제외됩니다.
+
+| variant | 측정 요청 | 실제 RPS | p50 | p95 | p99 | max | 오류 | dropped |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| normalized | 61 | 2.024 | 35.65ms | 44.65ms | 46.74ms | 47.05ms | 0% | 0 |
+| denormalized | 61 | 2.014 | 30.71ms | 35.63ms | 37.64ms | 38.97ms | 0% | 0 |
+| redis warm | 61 | 2.025 | 10.91ms | 18.24ms | 39.65ms | 54.53ms | 0% | 0 |
+
+세 실행 모두 다음 예시 threshold를 통과했습니다.
+
+- p95 < 500ms
+- p99 < 1,000ms
+- 기능 check 성공률 >= 99%
+- 오류율 <= 1%
+- dropped iterations = 0
+
+이 threshold는 프로젝트의 운영 SLO가 아니라 실험 시작용 예시입니다.
+
+## Prometheus·Grafana 검증
+
+- Prometheus readiness: 성공
+- `up{job="commerce-api"}`: `1`
+- pg-simulator와 commerce-streamer: 이번 실험에서는 미실행이므로 `0`
+- `k6_http_req_duration_p95{stage="measure"}`: 실제 시계열 확인
+- 서버 `http_server_requests_seconds_bucket` 기반 p99 PromQL: 실제 값 계산 확인
+- Grafana API에서 `Loopers Performance Lab` 대시보드 자동 등록 확인
+
+setup 요청은 첫 DB 접근이나 Redis warm-up 때문에 느릴 수 있습니다. Grafana의 k6 RPS·오류·p95·p99 패널은 `stage="measure"`만 표시하도록 구성했습니다.
+
+## 해석과 다음 실험
+
+사실: 이 낮은 부하에서는 세 경로 모두 오류 없이 목표 RPS를 처리했습니다.
+
+추론: Redis warm의 p50·p95가 낮은 것은 cache hit 효과와 일치하지만, 표본과 반복 횟수가 작아 성능 우위를 확정할 수 없습니다. Redis p99 한두 건은 p50보다 크게 흔들렸습니다.
+
+다음 권장 실험:
+
+1. 동일 조건을 최소 세 번 반복하고 실행 순서를 섞습니다.
+2. 안정 구간마다 성공 요청 10,000건 이상을 확보합니다.
+3. 20 -> 50 -> 100 -> 200 RPS로 높이며 p99, CPU, Tomcat busy, Hikari pending을 함께 봅니다.
+4. Redis cold miss, warm hit, 동시 cold miss를 분리합니다.
+5. 결과 내용 동일성과 DB·재고 같은 비즈니스 불변식을 별도 검증합니다.
+
+원본 machine-readable summary:
+
+- `k6/results/local-smoke-normalized.json`
+- `k6/results/local-smoke-denormalized.json`
+- `k6/results/local-smoke-redis.json`

--- a/k6/product-query-performance.js
+++ b/k6/product-query-performance.js
@@ -1,0 +1,286 @@
+import http from 'k6/http';
+import { check, fail } from 'k6';
+import { Counter, Rate, Trend } from 'k6/metrics';
+
+const VARIANTS = {
+  normalized: '/api/v1/products',
+  denormalized: '/api/v1/products/denormalization',
+  redis: '/api/v1/products/redis',
+};
+
+const PROFILE_DEFAULTS = {
+  smoke: {
+    executor: 'constant-arrival-rate',
+    rps: 2,
+    duration: '30s',
+    preAllocatedVUs: 2,
+    maxVUs: 10,
+  },
+  load: {
+    executor: 'constant-arrival-rate',
+    rps: 50,
+    duration: '5m',
+    preAllocatedVUs: 50,
+    maxVUs: 200,
+  },
+  stress: {
+    executor: 'ramping-arrival-rate',
+    startRps: 25,
+    rps: 200,
+    duration: '3m',
+    rampUpDuration: '2m',
+    rampDownDuration: '1m',
+    preAllocatedVUs: 100,
+    maxVUs: 500,
+  },
+  spike: {
+    executor: 'ramping-arrival-rate',
+    startRps: 20,
+    rps: 500,
+    duration: '30s',
+    baselineDuration: '1m',
+    rampUpDuration: '5s',
+    rampDownDuration: '30s',
+    recoveryDuration: '1m',
+    preAllocatedVUs: 100,
+    maxVUs: 800,
+  },
+  soak: {
+    executor: 'constant-arrival-rate',
+    rps: 30,
+    duration: '30m',
+    preAllocatedVUs: 50,
+    maxVUs: 200,
+  },
+};
+
+function integerEnv(name, fallback, minimum = 1) {
+  const raw = __ENV[name];
+  if (raw === undefined || raw === '') {
+    return fallback;
+  }
+
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < minimum) {
+    throw new Error(`${name} must be an integer greater than or equal to ${minimum}: ${raw}`);
+  }
+  return value;
+}
+
+function numberEnv(name, fallback, minimum, maximum) {
+  const raw = __ENV[name];
+  if (raw === undefined || raw === '') {
+    return fallback;
+  }
+
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < minimum || value > maximum) {
+    throw new Error(`${name} must be between ${minimum} and ${maximum}: ${raw}`);
+  }
+  return value;
+}
+
+function integerListEnv(name, fallback, minimum) {
+  const raw = __ENV[name] || fallback;
+  const values = raw.split(',').map((item) => Number(item.trim()));
+  if (values.length === 0 || values.some((value) => !Number.isInteger(value) || value < minimum)) {
+    throw new Error(`${name} must be a comma-separated integer list (minimum ${minimum}): ${raw}`);
+  }
+  return values;
+}
+
+const VARIANT = (__ENV.VARIANT || 'normalized').toLowerCase();
+const PROFILE = (__ENV.PROFILE || 'smoke').toLowerCase();
+
+if (!Object.prototype.hasOwnProperty.call(VARIANTS, VARIANT)) {
+  throw new Error(`VARIANT must be one of normalized, denormalized, redis: ${VARIANT}`);
+}
+if (!Object.prototype.hasOwnProperty.call(PROFILE_DEFAULTS, PROFILE)) {
+  throw new Error(`PROFILE must be one of smoke, load, stress, spike, soak: ${PROFILE}`);
+}
+
+const BASE_URL = (__ENV.BASE_URL || 'http://localhost:8080').replace(/\/$/, '');
+const ENDPOINT_PATH = VARIANTS[VARIANT];
+const SORT = __ENV.SORT || 'LIKE_COUNT_DESC';
+const SIZE = integerEnv('SIZE', 20);
+const PAGES = integerListEnv('PAGE', '0,1', 0);
+const BRAND_IDS = integerListEnv('BRAND_IDS', '1,2,34', 1);
+const REDIS_WARMUP_PAGES = integerListEnv('REDIS_WARMUP_PAGES', '0,1', 0);
+const USER_ID_PREFIX = __ENV.USER_ID_PREFIX || 'member';
+const REQUEST_TIMEOUT = __ENV.REQUEST_TIMEOUT || '10s';
+const TEST_ID = __ENV.TEST_ID || `${VARIANT}-${PROFILE}`;
+
+if (VARIANT === 'redis' && PAGES.some((page) => page > 1)) {
+  throw new Error(`Redis 목록 캐시는 PAGE 0 또는 1만 저장합니다: ${PAGES.join(',')}`);
+}
+
+const SLO_P95_MS = numberEnv('SLO_P95_MS', 500, 1, Number.MAX_SAFE_INTEGER);
+const SLO_P99_MS = numberEnv('SLO_P99_MS', 1000, 1, Number.MAX_SAFE_INTEGER);
+const SLO_ERROR_RATE = numberEnv('SLO_ERROR_RATE', 0.01, 0, 1);
+const SLO_CHECK_RATE = numberEnv('SLO_CHECK_RATE', 0.99, 0, 1);
+const SLO_DROPPED_ITERATIONS = integerEnv('SLO_DROPPED_ITERATIONS', 0, 0);
+
+if (SLO_P99_MS < SLO_P95_MS) {
+  throw new Error(`SLO_P99_MS (${SLO_P99_MS}) must be greater than or equal to SLO_P95_MS (${SLO_P95_MS})`);
+}
+
+const EXPERIMENT_TAGS = {
+  variant: VARIANT,
+  profile: PROFILE,
+  testid: TEST_ID,
+};
+const MEASUREMENT_TAGS = {
+  variant: VARIANT,
+  profile: PROFILE,
+  testid: TEST_ID,
+  stage: 'measure',
+};
+
+const productQueryDuration = new Trend('product_query_duration', true);
+const productQueryErrors = new Rate('product_query_errors');
+const productQueryRequests = new Counter('product_query_requests');
+
+function buildScenario() {
+  const defaults = PROFILE_DEFAULTS[PROFILE];
+  const rps = integerEnv('RPS', defaults.rps);
+  const preAllocatedVUs = integerEnv('PRE_ALLOCATED_VUS', defaults.preAllocatedVUs);
+  const maxVUs = integerEnv('MAX_VUS', defaults.maxVUs);
+
+  if (maxVUs < preAllocatedVUs) {
+    throw new Error(`MAX_VUS (${maxVUs}) must be greater than or equal to PRE_ALLOCATED_VUS (${preAllocatedVUs})`);
+  }
+
+  const common = {
+    executor: defaults.executor,
+    timeUnit: __ENV.TIME_UNIT || '1s',
+    preAllocatedVUs,
+    maxVUs,
+    gracefulStop: __ENV.GRACEFUL_STOP || '30s',
+    tags: EXPERIMENT_TAGS,
+  };
+
+  if (defaults.executor === 'constant-arrival-rate') {
+    return {
+      ...common,
+      rate: rps,
+      duration: __ENV.DURATION || defaults.duration,
+    };
+  }
+
+  const startRate = integerEnv('START_RPS', defaults.startRps, 0);
+  if (PROFILE === 'stress') {
+    return {
+      ...common,
+      startRate,
+      stages: [
+        { duration: __ENV.RAMP_UP_DURATION || defaults.rampUpDuration, target: rps },
+        { duration: __ENV.DURATION || defaults.duration, target: rps },
+        { duration: __ENV.RAMP_DOWN_DURATION || defaults.rampDownDuration, target: 0 },
+      ],
+    };
+  }
+
+  return {
+    ...common,
+    startRate,
+    stages: [
+      { duration: __ENV.BASELINE_DURATION || defaults.baselineDuration, target: startRate },
+      { duration: __ENV.RAMP_UP_DURATION || defaults.rampUpDuration, target: rps },
+      { duration: __ENV.DURATION || defaults.duration, target: rps },
+      { duration: __ENV.RAMP_DOWN_DURATION || defaults.rampDownDuration, target: startRate },
+      { duration: __ENV.RECOVERY_DURATION || defaults.recoveryDuration, target: startRate },
+    ],
+  };
+}
+
+export const options = {
+  scenarios: {
+    product_query: buildScenario(),
+  },
+  tags: EXPERIMENT_TAGS,
+  summaryTrendStats: ['count', 'avg', 'min', 'med', 'max', 'p(90)', 'p(95)', 'p(99)'],
+  thresholds: {
+    product_query_duration: [`p(95)<${SLO_P95_MS}`, `p(99)<${SLO_P99_MS}`],
+    product_query_errors: [`rate<=${SLO_ERROR_RATE}`],
+    checks: [`rate>=${SLO_CHECK_RATE}`],
+    dropped_iterations: [`count<=${SLO_DROPPED_ITERATIONS}`],
+  },
+};
+
+function buildUrl(page) {
+  const query = [
+    `sort=${encodeURIComponent(SORT)}`,
+    `brandIds=${BRAND_IDS.join(',')}`,
+    `page=${page}`,
+    `size=${SIZE}`,
+  ].join('&');
+  return `${BASE_URL}${ENDPOINT_PATH}?${query}`;
+}
+
+function requestParams(stage, userId) {
+  return {
+    headers: {
+      Accept: 'application/json',
+      'X-USER-ID': userId,
+    },
+    tags: {
+      ...EXPERIMENT_TAGS,
+      stage,
+      name: 'product_query',
+    },
+    timeout: REQUEST_TIMEOUT,
+  };
+}
+
+function parsePayload(response) {
+  try {
+    return response.json();
+  } catch (_) {
+    return null;
+  }
+}
+
+function isProductPageResponse(response, payload) {
+  return response.status === 200
+    && payload
+    && payload.meta
+    && payload.meta.result === 'SUCCESS'
+    && payload.data
+    && Array.isArray(payload.data.content);
+}
+
+function assertEndpointAvailable(page) {
+  const url = buildUrl(page);
+  const response = http.get(url, requestParams('setup', `${USER_ID_PREFIX}setup`));
+  const payload = parsePayload(response);
+
+  if (!isProductPageResponse(response, payload)) {
+    const detail = response.error
+      || String(response.body || '').replace(/\s+/g, ' ').slice(0, 200)
+      || 'empty response';
+    fail(`[setup] 상품 조회 엔드포인트를 사용할 수 없습니다: ${url} (status=${response.status}, detail=${detail})`);
+  }
+}
+
+export function setup() {
+  // Redis 비교는 실제 측정 전에 캐시 대상인 0, 1페이지를 채운다.
+  const setupPages = VARIANT === 'redis' ? REDIS_WARMUP_PAGES : [PAGES[0]];
+  setupPages.forEach((page) => assertEndpointAvailable(page));
+}
+
+export default function () {
+  const page = PAGES[__ITER % PAGES.length];
+  const userId = __ENV.USER_ID || `${USER_ID_PREFIX}${__VU}`;
+  const response = http.get(buildUrl(page), requestParams('measure', userId));
+  const payload = parsePayload(response);
+
+  const passed = check(response, {
+    'HTTP status is 200': (result) => result.status === 200,
+    'API result is SUCCESS': () => Boolean(payload && payload.meta && payload.meta.result === 'SUCCESS'),
+    'response contains a product page': () => Boolean(payload && payload.data && Array.isArray(payload.data.content)),
+  }, MEASUREMENT_TAGS);
+
+  productQueryDuration.add(response.timings.duration, MEASUREMENT_TAGS);
+  productQueryErrors.add(!passed, MEASUREMENT_TAGS);
+  productQueryRequests.add(1, MEASUREMENT_TAGS);
+}

--- a/k6/results/local-smoke-denormalized.json
+++ b/k6/results/local-smoke-denormalized.json
@@ -1,0 +1,195 @@
+{
+    "metrics": {
+        "http_req_duration{expected_response:true}": {
+            "min": 12.033,
+            "med": 30.8245,
+            "max": 240.148,
+            "p(90)": 34.6235,
+            "p(95)": 36.6638,
+            "p(99)": 117.4342999999999,
+            "count": 62,
+            "avg": 33.420290322580655
+        },
+        "http_req_blocked": {
+            "p(99)": 1.6519799999999982,
+            "count": 62,
+            "avg": 0.07999999999999984,
+            "min": 0.005,
+            "med": 0.013,
+            "max": 3.532,
+            "p(90)": 0.0159,
+            "p(95)": 0.028549999999999978
+        },
+        "http_req_receiving": {
+            "p(99)": 2.599529999999999,
+            "count": 62,
+            "avg": 0.7661290322580647,
+            "min": 0.182,
+            "med": 0.711,
+            "max": 3.714,
+            "p(90)": 0.9191,
+            "p(95)": 0.9472999999999999
+        },
+        "product_query_duration": {
+            "p(95)": 35.634,
+            "p(99)": 37.6424,
+            "count": 61,
+            "avg": 30.031311475409844,
+            "min": 12.033,
+            "med": 30.71,
+            "max": 38.978,
+            "p(90)": 34.322,
+            "thresholds": {
+                "p(95)<500": false,
+                "p(99)<1000": false
+            }
+        },
+        "http_reqs": {
+            "count": 62,
+            "rate": 2.0475084035359017
+        },
+        "http_req_waiting": {
+            "p(99)": 115.1711299999999,
+            "count": 62,
+            "avg": 32.60035483870968,
+            "min": 11.586,
+            "med": 29.9535,
+            "max": 235.87,
+            "p(90)": 33.7172,
+            "p(95)": 35.7666
+        },
+        "dropped_iterations": {
+            "count": 0,
+            "rate": 0,
+            "thresholds": {
+                "count<=0": false
+            }
+        },
+        "http_req_connecting": {
+            "p(99)": 0.2510599999999999,
+            "count": 62,
+            "avg": 0.01111290322580645,
+            "min": 0,
+            "med": 0,
+            "max": 0.345,
+            "p(90)": 0,
+            "p(95)": 0
+        },
+        "http_req_sending": {
+            "avg": 0.0538064516129032,
+            "min": 0.014,
+            "med": 0.042499999999999996,
+            "max": 0.564,
+            "p(90)": 0.07289999999999999,
+            "p(95)": 0.0829,
+            "p(99)": 0.2730299999999997,
+            "count": 62
+        },
+        "http_req_failed": {
+            "passes": 0,
+            "fails": 62,
+            "value": 0
+        },
+        "product_query_errors": {
+            "fails": 61,
+            "passes": 0,
+            "thresholds": {
+                "rate<=0.01": false
+            },
+            "value": 0
+        },
+        "iteration_duration": {
+            "p(90)": 35.064416,
+            "p(95)": 37.321375,
+            "p(99)": 39.3488168,
+            "count": 61,
+            "avg": 30.769470606557366,
+            "min": 12.827584,
+            "med": 31.366291,
+            "max": 39.969167
+        },
+        "data_received": {
+            "count": 385160,
+            "rate": 12719.65059203045
+        },
+        "data_sent": {
+            "count": 12342,
+            "rate": 407.5862696200016
+        },
+        "iterations": {
+            "count": 61,
+            "rate": 2.0144840744466133
+        },
+        "product_query_requests": {
+            "count": 61,
+            "rate": 2.0144840744466133
+        },
+        "vus": {
+            "value": 0,
+            "min": 0,
+            "max": 0
+        },
+        "http_req_tls_handshaking": {
+            "max": 0,
+            "p(90)": 0,
+            "p(95)": 0,
+            "p(99)": 0,
+            "count": 62,
+            "avg": 0,
+            "min": 0,
+            "med": 0
+        },
+        "vus_max": {
+            "value": 2,
+            "min": 2,
+            "max": 2
+        },
+        "checks": {
+            "passes": 183,
+            "fails": 0,
+            "thresholds": {
+                "rate>=0.99": false
+            },
+            "value": 1
+        },
+        "http_req_duration": {
+            "p(90)": 34.6235,
+            "p(95)": 36.6638,
+            "p(99)": 117.4342999999999,
+            "count": 62,
+            "avg": 33.420290322580655,
+            "min": 12.033,
+            "med": 30.8245,
+            "max": 240.148
+        }
+    },
+    "root_group": {
+        "id": "d41d8cd98f00b204e9800998ecf8427e",
+        "groups": {},
+        "checks": {
+                "HTTP status is 200": {
+                    "name": "HTTP status is 200",
+                    "path": "::HTTP status is 200",
+                    "id": "b99cf5b69b226f5caf2d6bf2ec0a940e",
+                    "passes": 61,
+                    "fails": 0
+                },
+                "API result is SUCCESS": {
+                    "name": "API result is SUCCESS",
+                    "path": "::API result is SUCCESS",
+                    "id": "8f96fd1eee4acc683bb3cee9530befe3",
+                    "passes": 61,
+                    "fails": 0
+                },
+                "response contains a product page": {
+                    "name": "response contains a product page",
+                    "path": "::response contains a product page",
+                    "id": "4556e169fa04ca3cb2450fed75f34c10",
+                    "passes": 61,
+                    "fails": 0
+                }
+            },
+        "name": "",
+        "path": ""
+    }
+}

--- a/k6/results/local-smoke-normalized.json
+++ b/k6/results/local-smoke-normalized.json
@@ -1,0 +1,195 @@
+{
+    "metrics": {
+        "http_req_duration": {
+            "avg": 36.40917741935484,
+            "min": 13.652,
+            "med": 35.688500000000005,
+            "max": 90.271,
+            "p(90)": 44.4478,
+            "p(95)": 45.66305,
+            "p(99)": 63.90740999999998,
+            "count": 62
+        },
+        "data_received": {
+            "count": 385180,
+            "rate": 12781.652292866089
+        },
+        "http_req_duration{expected_response:true}": {
+            "max": 90.271,
+            "p(90)": 44.4478,
+            "p(95)": 45.66305,
+            "p(99)": 63.90740999999998,
+            "count": 62,
+            "avg": 36.40917741935484,
+            "min": 13.652,
+            "med": 35.688500000000005
+        },
+        "http_req_tls_handshaking": {
+            "avg": 0,
+            "min": 0,
+            "med": 0,
+            "max": 0,
+            "p(90)": 0,
+            "p(95)": 0,
+            "p(99)": 0,
+            "count": 62
+        },
+        "http_reqs": {
+            "rate": 2.057382112668616,
+            "count": 62
+        },
+        "iteration_duration": {
+            "p(90)": 45.061916,
+            "p(95)": 45.331167,
+            "p(99)": 47.427883,
+            "count": 61,
+            "avg": 36.05244806557376,
+            "min": 15.882834,
+            "med": 36.068,
+            "max": 47.739583
+        },
+        "dropped_iterations": {
+            "count": 0,
+            "rate": 0,
+            "thresholds": {
+                "count<=0": false
+            }
+        },
+        "http_req_waiting": {
+            "p(99)": 63.13374999999998,
+            "count": 62,
+            "avg": 35.90890322580644,
+            "min": 13.42,
+            "med": 35.302499999999995,
+            "max": 89.44,
+            "p(90)": 43.656099999999995,
+            "p(95)": 44.78735
+        },
+        "vus_max": {
+            "value": 2,
+            "min": 2,
+            "max": 2
+        },
+        "product_query_duration": {
+            "med": 35.646,
+            "max": 47.052,
+            "p(90)": 44.176,
+            "p(95)": 44.657,
+            "p(99)": 46.7472,
+            "count": 61,
+            "avg": 35.52619672131148,
+            "min": 13.652,
+            "thresholds": {
+                "p(95)<500": false,
+                "p(99)<1000": false
+            }
+        },
+        "http_req_blocked": {
+            "avg": 0.07612903225806442,
+            "min": 0.003,
+            "med": 0.0085,
+            "max": 3.783,
+            "p(90)": 0.0159,
+            "p(95)": 0.02759999999999998,
+            "p(99)": 1.602249999999998,
+            "count": 62
+        },
+        "data_sent": {
+            "count": 11350,
+            "rate": 376.6336609482063
+        },
+        "http_req_failed": {
+            "passes": 0,
+            "fails": 62,
+            "value": 0
+        },
+        "product_query_requests": {
+            "count": 61,
+            "rate": 2.0241985302062186
+        },
+        "http_req_connecting": {
+            "min": 0,
+            "med": 0,
+            "max": 0.182,
+            "p(90)": 0,
+            "p(95)": 0,
+            "p(99)": 0.17773,
+            "count": 62,
+            "avg": 0.008161290322580646
+        },
+        "product_query_errors": {
+            "fails": 61,
+            "passes": 0,
+            "thresholds": {
+                "rate<=0.01": false
+            },
+            "value": 0
+        },
+        "iterations": {
+            "count": 61,
+            "rate": 2.0241985302062186
+        },
+        "vus": {
+            "value": 0,
+            "min": 0,
+            "max": 0
+        },
+        "http_req_sending": {
+            "max": 0.402,
+            "p(90)": 0.0466,
+            "p(95)": 0.05579999999999999,
+            "p(99)": 0.22387999999999986,
+            "count": 62,
+            "avg": 0.03579032258064515,
+            "min": 0.011,
+            "med": 0.025500000000000002
+        },
+        "http_req_receiving": {
+            "p(95)": 0.7597,
+            "p(99)": 0.8274299999999999,
+            "count": 62,
+            "avg": 0.4644838709677419,
+            "min": 0.195,
+            "med": 0.41700000000000004,
+            "max": 0.85,
+            "p(90)": 0.7095
+        },
+        "checks": {
+            "passes": 183,
+            "fails": 0,
+            "thresholds": {
+                "rate>=0.99": false
+            },
+            "value": 1
+        }
+    },
+    "root_group": {
+        "name": "",
+        "path": "",
+        "id": "d41d8cd98f00b204e9800998ecf8427e",
+        "groups": {},
+        "checks": {
+                "HTTP status is 200": {
+                    "name": "HTTP status is 200",
+                    "path": "::HTTP status is 200",
+                    "id": "b99cf5b69b226f5caf2d6bf2ec0a940e",
+                    "passes": 61,
+                    "fails": 0
+                },
+                "API result is SUCCESS": {
+                    "id": "8f96fd1eee4acc683bb3cee9530befe3",
+                    "passes": 61,
+                    "fails": 0,
+                    "name": "API result is SUCCESS",
+                    "path": "::API result is SUCCESS"
+                },
+                "response contains a product page": {
+                    "path": "::response contains a product page",
+                    "id": "4556e169fa04ca3cb2450fed75f34c10",
+                    "passes": 61,
+                    "fails": 0,
+                    "name": "response contains a product page"
+                }
+            }
+    }
+}

--- a/k6/results/local-smoke-redis.json
+++ b/k6/results/local-smoke-redis.json
@@ -1,0 +1,195 @@
+{
+    "root_group": {
+        "groups": {},
+        "checks": {
+                "HTTP status is 200": {
+                    "name": "HTTP status is 200",
+                    "path": "::HTTP status is 200",
+                    "id": "b99cf5b69b226f5caf2d6bf2ec0a940e",
+                    "passes": 61,
+                    "fails": 0
+                },
+                "API result is SUCCESS": {
+                    "fails": 0,
+                    "name": "API result is SUCCESS",
+                    "path": "::API result is SUCCESS",
+                    "id": "8f96fd1eee4acc683bb3cee9530befe3",
+                    "passes": 61
+                },
+                "response contains a product page": {
+                    "name": "response contains a product page",
+                    "path": "::response contains a product page",
+                    "id": "4556e169fa04ca3cb2450fed75f34c10",
+                    "passes": 61,
+                    "fails": 0
+                }
+            },
+        "name": "",
+        "path": "",
+        "id": "d41d8cd98f00b204e9800998ecf8427e"
+    },
+    "metrics": {
+        "http_req_duration": {
+            "max": 79.8,
+            "p(90)": 15.074000000000002,
+            "p(95)": 18.7028,
+            "p(99)": 64.13445999999999,
+            "count": 63,
+            "avg": 12.693523809523812,
+            "min": 4.878,
+            "med": 11.222
+        },
+        "http_req_duration{expected_response:true}": {
+            "med": 11.222,
+            "max": 79.8,
+            "p(90)": 15.074000000000002,
+            "p(95)": 18.7028,
+            "p(99)": 64.13445999999999,
+            "count": 63,
+            "avg": 12.693523809523812,
+            "min": 4.878
+        },
+        "checks": {
+            "passes": 183,
+            "fails": 0,
+            "thresholds": {
+                "rate>=0.99": false
+            },
+            "value": 1
+        },
+        "http_req_tls_handshaking": {
+            "med": 0,
+            "max": 0,
+            "p(90)": 0,
+            "p(95)": 0,
+            "p(99)": 0,
+            "count": 63,
+            "avg": 0,
+            "min": 0
+        },
+        "iterations": {
+            "count": 61,
+            "rate": 2.0255408077737203
+        },
+        "product_query_duration": {
+            "avg": 11.517868852459015,
+            "min": 4.878,
+            "med": 10.917,
+            "max": 54.533,
+            "p(90)": 14.034,
+            "p(95)": 18.242,
+            "p(99)": 39.652999999999984,
+            "count": 61,
+            "thresholds": {
+                "p(95)<500": false,
+                "p(99)<1000": false
+            }
+        },
+        "product_query_errors": {
+            "fails": 61,
+            "passes": 0,
+            "thresholds": {
+                "rate<=0.01": false
+            },
+            "value": 0
+        },
+        "data_sent": {
+            "count": 11915,
+            "rate": 395.6445692561291
+        },
+        "http_req_receiving": {
+            "p(99)": 0.9154599999999999,
+            "count": 63,
+            "avg": 0.4068095238095237,
+            "min": 0.104,
+            "med": 0.346,
+            "max": 1.112,
+            "p(90)": 0.6368,
+            "p(95)": 0.6757
+        },
+        "http_req_blocked": {
+            "p(99)": 1.4691399999999988,
+            "count": 63,
+            "avg": 0.0659682539682539,
+            "min": 0.002,
+            "med": 0.007,
+            "max": 2.959,
+            "p(90)": 0.014600000000000002,
+            "p(95)": 0.018
+        },
+        "http_req_sending": {
+            "p(99)": 0.43849999999999983,
+            "count": 63,
+            "avg": 0.04306349206349206,
+            "min": 0.01,
+            "med": 0.028,
+            "max": 0.64,
+            "p(90)": 0.0458,
+            "p(95)": 0.052899999999999996
+        },
+        "data_received": {
+            "count": 391196,
+            "rate": 12989.892817013904
+        },
+        "iteration_duration": {
+            "avg": 12.035721278688525,
+            "min": 5.056083,
+            "med": 11.339417,
+            "max": 55.057417,
+            "p(90)": 14.716833,
+            "p(95)": 18.863916,
+            "p(99)": 40.75466679999999,
+            "count": 61
+        },
+        "vus_max": {
+            "value": 2,
+            "min": 2,
+            "max": 2
+        },
+        "dropped_iterations": {
+            "count": 0,
+            "rate": 0,
+            "thresholds": {
+                "count<=0": false
+            }
+        },
+        "http_req_connecting": {
+            "med": 0,
+            "max": 0.447,
+            "p(90)": 0,
+            "p(95)": 0,
+            "p(99)": 0.3161799999999999,
+            "count": 63,
+            "avg": 0.012777777777777777,
+            "min": 0
+        },
+        "vus": {
+            "value": 0,
+            "min": 0,
+            "max": 0
+        },
+        "product_query_requests": {
+            "count": 61,
+            "rate": 2.0255408077737203
+        },
+        "http_req_waiting": {
+            "max": 78.712,
+            "p(90)": 14.026000000000002,
+            "p(95)": 17.8738,
+            "p(99)": 63.52075999999999,
+            "count": 63,
+            "avg": 12.243650793650795,
+            "min": 4.382,
+            "med": 10.66
+        },
+        "http_reqs": {
+            "rate": 2.0919519817990877,
+            "count": 63
+        },
+        "http_req_failed": {
+            "passes": 0,
+            "fails": 63,
+            "value": 0
+        }
+    }
+}

--- a/output/pdf/loopers-performance-experiment-workbook.pdf
+++ b/output/pdf/loopers-performance-experiment-workbook.pdf
@@ -1,0 +1,1904 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2+0 129 0 R /F2+1 133 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 191 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 190 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/Contents 192 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 190 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 4 0 R /Fit ] /Rect [ 537.452 746.1102 544.252 762.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+6 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 4 0 R /Fit ] /Rect [ 51.02362 744.1102 127.4236 756.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+7 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 4 0 R /Fit ] /Rect [ 538.608 725.8102 544.252 738.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+8 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 4 0 R /Fit ] /Rect [ 73.70079 724.1502 109.5568 734.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+9 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 75 0 R /Fit ] /Rect [ 538.608 706.8102 544.252 719.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+10 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 75 0 R /Fit ] /Rect [ 73.70079 705.1502 90.30079 715.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+11 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 113 0 R /Fit ] /Rect [ 537.452 686.1102 544.252 702.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+12 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 113 0 R /Fit ] /Rect [ 51.02362 684.1102 140.8736 696.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+13 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 113 0 R /Fit ] /Rect [ 538.608 665.8102 544.252 678.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+14 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 113 0 R /Fit ] /Rect [ 73.70079 664.1502 117.8568 674.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+15 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 113 0 R /Fit ] /Rect [ 538.608 646.8102 544.252 659.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+16 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 113 0 R /Fit ] /Rect [ 73.70079 645.1502 109.5568 655.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+17 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 113 0 R /Fit ] /Rect [ 538.608 627.8102 544.252 640.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+18 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 113 0 R /Fit ] /Rect [ 73.70079 626.1502 109.5568 636.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+19 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 114 0 R /Fit ] /Rect [ 537.452 607.1102 544.252 623.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+20 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 114 0 R /Fit ] /Rect [ 51.02362 605.1102 182.3536 617.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+21 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 114 0 R /Fit ] /Rect [ 538.608 586.8102 544.252 599.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+22 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 114 0 R /Fit ] /Rect [ 73.70079 585.1502 109.5568 595.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+23 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 114 0 R /Fit ] /Rect [ 538.608 567.8102 544.252 580.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+24 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 114 0 R /Fit ] /Rect [ 73.70079 566.1502 101.2568 576.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+25 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 114 0 R /Fit ] /Rect [ 538.608 548.8102 544.252 561.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+26 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 114 0 R /Fit ] /Rect [ 73.70079 547.1502 153.7128 557.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+27 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 114 0 R /Fit ] /Rect [ 538.608 529.8102 544.252 542.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+28 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 114 0 R /Fit ] /Rect [ 73.70079 528.1502 109.5568 538.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+29 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 115 0 R /Fit ] /Rect [ 537.452 509.1102 544.252 525.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+30 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 115 0 R /Fit ] /Rect [ 51.02362 507.1102 227.2736 519.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+31 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 115 0 R /Fit ] /Rect [ 538.608 488.8102 544.252 501.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+32 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 115 0 R /Fit ] /Rect [ 73.70079 487.1502 134.6643 497.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+33 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 115 0 R /Fit ] /Rect [ 538.608 469.8102 544.252 482.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+34 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 115 0 R /Fit ] /Rect [ 73.70079 468.1502 176.1643 478.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+35 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 115 0 R /Fit ] /Rect [ 538.608 450.8102 544.252 463.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+36 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 115 0 R /Fit ] /Rect [ 73.70079 449.1502 134.6643 459.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+37 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 115 0 R /Fit ] /Rect [ 538.608 431.8102 544.252 444.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+38 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 115 0 R /Fit ] /Rect [ 73.70079 430.1502 123.7083 440.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+39 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 116 0 R /Fit ] /Rect [ 537.452 411.1102 544.252 427.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+40 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 116 0 R /Fit ] /Rect [ 51.02362 409.1102 189.2136 421.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+41 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 116 0 R /Fit ] /Rect [ 538.608 390.8102 544.252 403.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+42 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 116 0 R /Fit ] /Rect [ 73.70079 389.1502 137.1128 399.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+43 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 116 0 R /Fit ] /Rect [ 538.608 371.8102 544.252 384.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+44 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 116 0 R /Fit ] /Rect [ 73.70079 370.1502 109.8473 380.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+45 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 116 0 R /Fit ] /Rect [ 538.608 352.8102 544.252 365.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+46 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 116 0 R /Fit ] /Rect [ 73.70079 351.1502 199.3047 361.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+47 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 117 0 R /Fit ] /Rect [ 537.452 332.1102 544.252 348.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+48 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 117 0 R /Fit ] /Rect [ 51.02362 330.1102 191.5136 342.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+49 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 117 0 R /Fit ] /Rect [ 538.608 311.8102 544.252 324.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+50 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 117 0 R /Fit ] /Rect [ 73.70079 310.1502 106.9008 320.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+51 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 117 0 R /Fit ] /Rect [ 538.608 292.8102 544.252 305.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+52 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 117 0 R /Fit ] /Rect [ 73.70079 291.1502 128.8128 301.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+53 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 117 0 R /Fit ] /Rect [ 538.608 273.8102 544.252 286.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+54 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 117 0 R /Fit ] /Rect [ 73.70079 272.1502 137.2622 282.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+55 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 117 0 R /Fit ] /Rect [ 538.608 254.8102 544.252 267.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+56 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 117 0 R /Fit ] /Rect [ 73.70079 253.1502 101.2568 263.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+57 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 118 0 R /Fit ] /Rect [ 530.652 234.1102 544.252 250.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+58 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 118 0 R /Fit ] /Rect [ 51.02362 232.1102 167.7736 244.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+59 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 118 0 R /Fit ] /Rect [ 532.964 213.8102 544.252 226.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+60 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 118 0 R /Fit ] /Rect [ 73.70079 212.1502 109.5568 222.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+61 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 118 0 R /Fit ] /Rect [ 532.964 194.8102 544.252 207.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+62 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 118 0 R /Fit ] /Rect [ 73.70079 193.1502 117.8568 203.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+63 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 118 0 R /Fit ] /Rect [ 532.964 175.8102 544.252 188.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+64 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 118 0 R /Fit ] /Rect [ 73.70079 174.1502 168.8271 184.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+65 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 119 0 R /Fit ] /Rect [ 530.652 155.1102 544.252 171.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+66 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 119 0 R /Fit ] /Rect [ 51.02362 153.1102 174.0736 165.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+67 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 119 0 R /Fit ] /Rect [ 532.964 134.8102 544.252 147.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+68 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 119 0 R /Fit ] /Rect [ 73.70079 133.1502 139.7688 143.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+69 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 119 0 R /Fit ] /Rect [ 532.964 115.8102 544.252 128.8102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+70 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 119 0 R /Fit ] /Rect [ 73.70079 114.1502 117.8568 124.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+71 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 120 0 R /Fit ] /Rect [ 530.652 95.11024 544.252 111.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+72 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 120 0 R /Fit ] /Rect [ 51.02362 93.11024 174.0736 105.1102 ] /Subtype /Link /Type /Annot
+>>
+endobj
+73 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 120 0 R /Fit ] /Rect [ 532.964 74.81024 544.252 87.81024 ] /Subtype /Link /Type /Annot
+>>
+endobj
+74 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 120 0 R /Fit ] /Rect [ 73.70079 73.15024 156.6095 83.11024 ] /Subtype /Link /Type /Annot
+>>
+endobj
+75 0 obj
+<<
+/Annots [ 5 0 R 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R 13 0 R 14 0 R 
+  15 0 R 16 0 R 17 0 R 18 0 R 19 0 R 20 0 R 21 0 R 22 0 R 23 0 R 24 0 R 
+  25 0 R 26 0 R 27 0 R 28 0 R 29 0 R 30 0 R 31 0 R 32 0 R 33 0 R 34 0 R 
+  35 0 R 36 0 R 37 0 R 38 0 R 39 0 R 40 0 R 41 0 R 42 0 R 43 0 R 44 0 R 
+  45 0 R 46 0 R 47 0 R 48 0 R 49 0 R 50 0 R 51 0 R 52 0 R 53 0 R 54 0 R 
+  55 0 R 56 0 R 57 0 R 58 0 R 59 0 R 60 0 R 61 0 R 62 0 R 63 0 R 64 0 R 
+  65 0 R 66 0 R 67 0 R 68 0 R 69 0 R 70 0 R 71 0 R 72 0 R 73 0 R 74 0 R ] /Contents 193 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 190 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+76 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 120 0 R /Fit ] /Rect [ 532.964 773.8969 544.252 786.8969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+77 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 120 0 R /Fit ] /Rect [ 73.70079 772.2369 147.9775 782.1969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+78 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 120 0 R /Fit ] /Rect [ 532.964 754.8969 544.252 767.8969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+79 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 120 0 R /Fit ] /Rect [ 73.70079 753.2369 170.4539 763.1969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+80 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 120 0 R /Fit ] /Rect [ 532.964 735.8969 544.252 748.8969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+81 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 120 0 R /Fit ] /Rect [ 73.70079 734.2369 184.5473 744.1969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+82 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 120 0 R /Fit ] /Rect [ 532.964 716.8969 544.252 729.8969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+83 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 120 0 R /Fit ] /Rect [ 73.70079 715.2369 120.5128 725.1969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+84 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 121 0 R /Fit ] /Rect [ 530.652 696.1969 544.252 712.1969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+85 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 121 0 R /Fit ] /Rect [ 51.02362 694.1969 140.8736 706.1969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+86 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 121 0 R /Fit ] /Rect [ 532.964 675.8969 544.252 688.8969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+87 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 121 0 R /Fit ] /Rect [ 73.70079 674.2369 151.505 684.1969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+88 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 121 0 R /Fit ] /Rect [ 532.964 656.8969 544.252 669.8969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+89 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 121 0 R /Fit ] /Rect [ 73.70079 655.2369 162.1373 665.1969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+90 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 121 0 R /Fit ] /Rect [ 532.964 637.8969 544.252 650.8969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+91 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 121 0 R /Fit ] /Rect [ 73.70079 636.2369 185.6927 646.1969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+92 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 121 0 R /Fit ] /Rect [ 532.964 618.8969 544.252 631.8969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+93 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 121 0 R /Fit ] /Rect [ 73.70079 617.2369 137.1128 627.1969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+94 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 122 0 R /Fit ] /Rect [ 530.652 598.1969 544.252 614.1969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+95 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 122 0 R /Fit ] /Rect [ 51.02362 596.1969 117.6736 608.1969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+96 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 122 0 R /Fit ] /Rect [ 532.964 577.8969 544.252 590.8969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+97 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 122 0 R /Fit ] /Rect [ 73.70079 576.2369 117.8568 586.1969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+98 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 122 0 R /Fit ] /Rect [ 532.964 558.8969 544.252 571.8969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+99 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 122 0 R /Fit ] /Rect [ 73.70079 557.2369 109.5568 567.1969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+100 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 122 0 R /Fit ] /Rect [ 532.964 539.8969 544.252 552.8969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+101 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 122 0 R /Fit ] /Rect [ 73.70079 538.2369 142.4248 548.1969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+102 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 123 0 R /Fit ] /Rect [ 530.652 519.1969 544.252 535.1969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+103 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 123 0 R /Fit ] /Rect [ 51.02362 517.1969 114.4736 529.1969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+104 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 124 0 R /Fit ] /Rect [ 530.652 497.1969 544.252 513.1969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+105 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 124 0 R /Fit ] /Rect [ 51.02362 495.1969 147.6736 507.1969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+106 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 124 0 R /Fit ] /Rect [ 532.964 476.8969 544.252 489.8969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+107 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 124 0 R /Fit ] /Rect [ 73.70079 475.2369 109.5568 485.1969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+108 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 125 0 R /Fit ] /Rect [ 530.652 456.1969 544.252 472.1969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+109 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 125 0 R /Fit ] /Rect [ 51.02362 454.1969 147.6736 466.1969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+110 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 125 0 R /Fit ] /Rect [ 532.964 435.8969 544.252 448.8969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+111 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 125 0 R /Fit ] /Rect [ 73.70079 434.2369 105.4898 444.1969 ] /Subtype /Link /Type /Annot
+>>
+endobj
+112 0 obj
+<<
+/Annots [ 76 0 R 77 0 R 78 0 R 79 0 R 80 0 R 81 0 R 82 0 R 83 0 R 84 0 R 85 0 R 
+  86 0 R 87 0 R 88 0 R 89 0 R 90 0 R 91 0 R 92 0 R 93 0 R 94 0 R 95 0 R 
+  96 0 R 97 0 R 98 0 R 99 0 R 100 0 R 101 0 R 102 0 R 103 0 R 104 0 R 105 0 R 
+  106 0 R 107 0 R 108 0 R 109 0 R 110 0 R 111 0 R ] /Contents 194 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 190 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+113 0 obj
+<<
+/Contents 195 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 190 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+114 0 obj
+<<
+/Contents 196 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 190 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+115 0 obj
+<<
+/Contents 197 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 190 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+116 0 obj
+<<
+/Contents 198 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 190 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+117 0 obj
+<<
+/Contents 199 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 190 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+118 0 obj
+<<
+/Contents 200 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 190 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+119 0 obj
+<<
+/Contents 201 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 190 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+120 0 obj
+<<
+/Contents 202 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 190 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+121 0 obj
+<<
+/Contents 203 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 190 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+122 0 obj
+<<
+/Contents 204 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 190 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+123 0 obj
+<<
+/Contents 205 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 190 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+124 0 obj
+<<
+/Contents 206 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 190 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+125 0 obj
+<<
+/Contents 207 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 190 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+126 0 obj
+<<
+/Filter [ /FlateDecode ] /Length 1393
+>>
+stream
+xœu×ËnÜF…á½žb–	²É¾‘€  Ù$/rAœG”- 	#yá·Ïœÿ l”ZÝÍÅb‘¼n–§Ç·ÃõïççãÇýíððxº?ï¯Ï_ÏÇýðiÿüxºê‡Ãýãñíý7þ?>Ý½\]_üöú¶?}8=<_ÝÜ®ÿ¸üñõíüíðCåç§úòò×þóóÛ—ÇãW×¿ï÷óãéóÿüùãWýú´ŸÞÝÕííá~¸ä—»—_ïžöÃõ×ü3ãÏo/ûaà÷ÞÐãóýþúrwÜÏw§ÏûÕM×Ýn¶íöj?ÝÿëoCÊ^óéáøåîü>·»üÜ^âþ·R¢âAñº‡K<×0*Ž*ãIqzÅYs†šæxíx‰—´°vÒxnMqÕx—‰g­]Föiw ^={®žƒsÓÚ>(îåŸÛ¢ù}³NŠŽË¹ôg¿(–¿®QÇíñO}2ó“œ}aÏž9ò·na­üs W}åæàoÇ’ŽÇß5l«ŒË?¯QóçÐžCïXó‡Áñ 88Š£cÖ&ÇÊÏgÅÅqQ<:Öy“cåg¨Ž«âÙñ¬¸9–sXëÜ‡Õñªxs|©°›`?×"ØO=ûƒüÁþ °?ÈìòûƒüÁþ °ŸÚöùƒýAþ`?ØäöùƒýAþ`?ÚåöGù£ýQþh”?ÚÏµ‹öGù£ýQþh”?ÚåöGù£ýQþh”?ÚO}Fû£üÑþ(´?ÊŸìOò'û“üÉþ$²?ÉŸìOò'û“üÉþ$²?ÉŸìç¾Hö'ù“ýIþd’?ÙŸäOö'ù“ýIþd’?ÛŸåÏögù³ýYþl–?ÛŸåÏögù³ýYþl–?ÛŸåÏögù³ýYþl–?ÛO_Êögù³ýYþl–¿Ø_ä/öù‹ýEþb‘¿ØO_*öù‹ýEþb‘¿Ø_ä/öù‹ýEþb‘¿Ø_ä/öù‹ýEþb‘¤NÌ{zà¨ýÇÁ=MÇéŸãÆœHŸoŒÓ?Ó¬séÿ³çÓ?#ýÙ‡ž0ÒÿÓÂ¸üÕ=v”¿•I9å_2õ6.Ì™åW÷gl½wVÞ¦Ž=¹¿&ú‡gâù•¹¯'ü8ñü*OÞS†	™Ãó«·iÄ°2Ÿþïzž*y˜8þžž<ÑÿëˆÍ~žÓj'sèÿ…œWò?ÒÓªŸ¿Ì©ƒó@ìç/5S£s¨=«üuáºÔÌ±¨ÃŠ¿Ñë*ùµøGü•ü/Ôy}Ýuî¿ŸÝu±Y5Vñ<#*ùÏæÏö“Ã™ú‰ŽÉ«š?ÆÙÆ?âœÉ™Ÿ9wò6ã_WÆyþêaž\¬uýpî3ùÏ\÷¹Ù¦z›ñgÞfÞJ#Æ_xF4êgâÝÈÿØãï8VÃXÛxX¨‡æúßˆÿN†VÈ'=§Q?+ï?mbÎ«U‹µø»Êxs²ü—wb¿?ðlö3é|ïhÎ‚?Ñ?ß¿¼§-ø‡Yk—h›Îe¡~ïTùŸ&ÕÆBþGÎe!ÿÜ.øÏš…úŸ°-Î?×}!ÿ9\œÛV×ûãOäaí|uÝ×ž\ñ.±’ÿ‰{g¾˜ƒ¿PK+ù¸+÷o­ŒÓ=sõýKý¯ôŸ¡gœ÷Ï¾²vö}Ä8ù/Þgq ¦~fò¿n¾vòoù$WÛ{ýè7ò?ñ®»ùý“w¼Í÷/Ï»Íý§cþ‰kº‘ÿsßÈOýo~ÿäÞÙ\?Ôù6ûXÄôO÷™Íý‡úßœÞý6úÏ$ÃåáýK@ß
+úÔùþrüz>_¾OøâÃCŸ§ýû'ÓËó‹Véßß[éTendstream
+endobj
+127 0 obj
+<<
+/Filter [ /FlateDecode ] /Length 58758 /Length1 100672
+>>
+stream
+xœ¬½|cW•?~ï{zê½=Y²dÉj¶lY¶dIî½Ûã2nÓg<½ÏdZ&Ì¤ž!	!B	$X „²É@¨»–²8ÀRÍa7ÚRÂ²âçÿ9÷½'kØßÿ÷ÿüglß£§§÷î»÷”ï)÷ŠPBˆ™ÜDxÒ³çØÒÉÞ;úD8òUB8ïžsgÂÄ¯÷ïøgÿÉÇ´‡òeBèéG¯Ûß»iÿB4Û½;¸oiïŸï&ôÆ›àüÂA8 o xý¼Ž<væüÑÿhú5¼^!„×=±g)õàÝ ôf¸>§9¶tþ¤Fc¹ŸÐ[áú$||éØ¾*O{”ÐÛôp÷É§Ï¬=L²„ÞU‰ïŸ<µï$\¸^wÀküR‚ÏƒO¤åŒ„€žNC¢%:¢'b$&8ÃB¬ÄFìÄAœÄÏé!^"© ~ •$HB¤Š„I„T“(‰‘8I$©!µ$÷¬'iÒ@2¤‘4Ar¤™äIIi%m¤tNÒEºIé%}¤ŸA2D†É%cdœLd’L‘i2C6’Y2GæÉY$›Èf²…l%ÛÈv²ƒì$»ÈÙMö½dÙOƒä9LŽ£ä9NN“ärŠœ&gÈYrŽ\KÎ“ëÈëÈr‘\On 7ÂÌ¾žÜLn!·’ÛÈíär'¹‹\"o w“{È½ää>ò&r?y3yy€¼•<HÞFÞNÞAÞI"ï"ï&“GÈ{È£ä½ä}äýäïÈÈÉ‡Ècäqòaòòù(y’<Ež&#'Ÿ Ÿ$Ož!Ï’ËäSäÓä9òòYò9òyòòEòäÉ?‘çÉ—È?“/“¯ ‡}üù:Y&/oo’o‘%ß&ß!ß%ß#ß'? +ä‡äßÈÈÉOÈ‹ä§äßÉ—È’—ÉÏÈÏÉ/È/É¯È‘_“ßß’ß‘WÈïÉ“?ÿ!¯’?’?‘?“×È*‘Ècàaà“úñgHÅô¦§(½wó3tí¶gÈ@ðY˜m~çŽô3„Ö‡Ãƒ‡ž¤»àWR øúðÐ“||hã¦èæð¥ð¥Ñ½—ÂCáƒK{ŸÔÄYoì»´9~’Ìn:ç6EžìÙ(‘û6onƒëhð:vK›á
+‡•+fW€¬ÂIBýxøI>1½ifÓ“7žìØˆDÂƒO~nzÓ“ŸD6o†³´¥žB{ý!ŸÒgôY›B/_evÓ“='ÉæK—äWÑÈ“7]º¸Ï¡¼~†|îª”\} G9 #WäãƒÏÐ›¦Ù[7E#<D#ÐÏÍpoCýøì¦AèidsDšt¯}šŒO‚üéH;t-§À¯Þó±¿øh~F~	ÐºàÌ_w® @ÛØ$:"Ž$üvóGºWü‘×èâþkÕ	g‘Ãkïãgùzæ HäVüp’}8¤\…›¯{†¸àê6¸«îêZ\–[?´þŒü~ã
+°Š^2—AÊ5ì&ìmN&¢ÕZ[ôæ²Åuk=.«9Ù@“Å¬^ê´Ñêd"ß\,ä²¢—¾šKÍ5d&gjÃt«V³ç)å*Å°ô+±¢ã¦óù¶î“gºÚéÝ×õ¶^îšþþ=ôU¾ÂôÚ³zúÜ—gj©N:Ôw8±´4ûú›f6-LÂˆô­=Æ/òuð´§És—a€¬ìéGx>#Óúey¼­@›€6)´wYnÕ§ÆsÏâSã‹Jø5Â“ŸÝ‚O¾ š
+[/hJ¼‰NvÀ½Ð:¡uÂ¹=pÎ‚ÃÙú‡£#pt®² ôF 7}èÃ@Vèk€¾&ã	È{¼8œÑ.ÚI“º|ˆæŠŽæD†OÐê¬T'ÿ‰Â'ØÿæBÿwQü·ÔSªå¡ÏµQå=øQOë ÅhŠšùE-Gáß4GÎx›Ã»x.J¯rTö·îOL§»Ì:ƒÆ¯xŽºô~ÛîáœÛâ5éÍB´£¢±Çpê½¼ÁlòzâG[*5XiòY4¼ £|ä=£~Úý^¾‚óé¤ç¿Õ}¼iOö|ë8®ã8šõÖ:y~_Ü3x.wls¸(VÎÃqøx½®vÄ_¨t¤üÐGA¯Ñk€_ô¡*¥¼F£ÓÀi&›»B§óØ8½ OÁõrÈääÜÚGùà	#°~7ù
+N–M\'Â6'ÐÃïZ–[ä¦$tèBG€Ž Ý	tÐ5È@×]4t=ÐYh mÈÈtè¼r^•£ÌÀ!Š ÁjbëTXÅ[–/®².ÒZ µ@×:tGÙnºy(©se½b.[(R¨æ€arY¯ÇJ=·WÑ¸.CuðBÞÅ³à­‡®œÿ §úÃ3QznüŸýÝþäÎåñ$¤oÐÛD®Iì.TÔŸlá¹.Ž“>ÄÞü2OŸç‡9îÃ…a—3h»Qz|Ó›Z[÷ZpòÔÇÿ¹0é«hqŽkßcp
+dFÃ{äj
+l=>‰¬uLþ …'¤ð„T¡5@kÚŠÒŠB¬¨1”GŒrÆ·äð2 ™jlŠG«Éj& yo6ÒÕ†bÁ»µ6
+#Ä¤
+´–,BÉ‚,4ð?CçÖi«un+çñŠø?DÅ,ÿÁ‰ìsg{ï›ŽgLnãÔó×MœN¼=pð•î°eê–œÝë°5Ív›«\iõ×ØwöV:ÃYž²†H$Û»Ã^ëç£A8n„†jêåìBB0ðþéa±&éË×x€û;9*˜…H¡}¾¹Ù ×àUŒfŸ)4'}½ÀP_×Ú'ùyÐÿÀi{ Í_f0L„áñÀðøÊ8FîÃ˜W4¼p¶AÄðÁ
+8)°|p]	Ê#é.)÷.
+œ%za=:—ÎZK,¢àqåqåa\UÍ„#Û@ó…’^ÊçäÑeºËÃ¸\ÌºÀf\øù¥ù·Ü3·kâÄðàñÔQNÏqcÛvîÞ‚öãeŽ´š€Ýo¨j¨öu:^àªŠ®†J£ÏÜ0J]Íx4Õ¨6è(*<Nçžh5VØÞ7Õ{üTËó¯.´OlŒ…#ñÑmI»Õj¯á^Ç{õoÞj¦Vžïäù—ÁöLñ¼ çÃ&§NL×Õyl.­Q(öx|z·% ˜A@´¡r4]¼kPkÔë9­Ö q[-aOÛÑ„Î¢—¾^ôy\¾Î——°¹*®=Å¶ Ô]Za’¼ç2L›¬F .c«ƒv„™† 0{LF29´Ó8s=0sf<½J™ÁQåã­ÌV?C¢pr>”ÌÈ4*¬z [NVèÐ…Î¢RShY×À¼—l>O…D¥ªdæ‹q°-Õp0ŸÅiôf™j™N
+E¦ƒÜÚ ÈNWäþ{zàØu'£¹ÜBlj´núôÈÐÉú»7ÞöÀüÞSÒÐÈÑxl°£Éîš®«®ž¨¯ÛpºfæÿÖÕ÷pœ)”Ô¯å6ö+‹Š–tC¥Åd2êc-	·ÝV3;“ŒD“á)HÕ"n`ÞH/Þ§5k¦û9ÊsÚŠ¶µÏóÛÁVÔ€¬ÜE»Ÿ!—à‘ß ¿—}-ËãŽ(Á‹ÇáØ˜ƒÊe\(“$TFÑùØ8v†©z/9Ãfžƒ£ç”Oú¼B¿>u#¼¾^¿^ß
+ô­
+}Ðwdþ‘u"Ó{pi+ :œá‹à›ákÊt¤õ<²~”i×Êú£!ÜCöRÍ`e(ÂkÇà½*ø­†cÕp,Ç@'‹vÓBœ!˜|P	Yä<*\Ð¶b.®ã@{Ä,Ó¹:Y?0Û$ÿÈÚ)
+<š¡…¦2ð‚ÌÌ£C\éQ”ê	¸GçJWhÎòìR ~¶K_ø’žJ8¦:»Æ­Î¦ÿcæCCáéwÒ6°WËOf~õHooò+:LZ³hëEM0ë£`OV¸ƒîYë·Ð ;lÞ/ê5ÖÕ§8¤±ÙòñÊB >û%A@Û8J‘Ó¸h¶ÛÏm 6ë‚v÷§áçA»ô>FO5F­Åb²%<¾ŒWï4™\z±ÉçN¸¬ïÔþ¡ÎàÐ7\¿#œÆ‚UÏ›v]mt ,ÖØ8­†^Ï9ü+'œQo÷ïHôÌ{=ÌÑ×‘…µò€¯- ÅSà‡o ËºDw"xmbŒc Û:?.ÃI”1…‰­‚‰­R¼‘Ð1 
+þIAÛ
+mkF¦»€îÊÈŸC½Ô£Ð}Ër;¤´cÐŽ)ŸÙƒz_àMƒŒLO]ÿ~k‡ÉlY§.“< $lýàÓ`'©.-C´LhQÏ…—Ñ²É7ÅÎ;•Á±¾ùõ ¼€×³@O=©ÐÓ@O+ôÐ@½ô¢BozÐ;€Þ¶ÜØÉ§ DTGƒ`ªS]$4}QWLŠi@û 7KÎãj—®˜ó™CÄª’IAÅ”m<ƒx½Èk5¡PÚ&ýä¥®CéWùH¾©ºX[ÓV¬©£»†iÃ©îÿ¤£<ÿ{ºKzéÀþ½Gær#Ò³´
+ —fˆ~läÏé+S¯ŒÌÕæŒ=¯ïm¾ÐBƒ¯¿íØ±ÛTý(0îƒ-›ÕÓRï«}Òï.öóo{ˆã>5<:6´¥ÚãŠÐ5èmzÉ Ù~œëáèõË jAÅvÀ}:x~ÀM­}œß<h"í€ìv__&Z²È&R“‡í´bïzÈP	£–Ñá5c_×´Õe\‰tè¸B«¨¼è ;€R8°O¡UîCzÐ”ów!'â‹^àÂ­`°3¤ŸµEYTæXçêÊnV:tN¡Û€nz Äaè!ËÆ&¿ 2Ç&°&:yL[5£ºê@ÍÇÞ‰VgÀ4¢µÌÅ]Ì.FaÎ2€†`¨«Ä4œ{dd`nv°wê~EH¤ý9¿3 ³0†š'u¸]c6xoÛjÎÄb­"M|TÏóÿ²ó¦™ê¯v´ï<|f góbÇ 7Xè(¶æ[;ÿT”–æmG“ÖVírW™êºÜð »FcêäðŸ‹~œZ^û²ægm ¶NŠbÂ¦ûáx:½09“©Ke0ÒØBjø§¹ÃÜï$²¬¢O£UÂfø-ddEÒ¡(ûŠŒ7WÖý|Ý	t'Ðv GUè	 '—¤#¢ŠK„™n00Õ
+RerÌ–ä‹‘E'@¶Rñ’áyøù§Í…úºùÂ¸xëK­o^¢í§Ósž_ÿN¯©Ùj‰¶zFTÿÆ[«•~Ú09Ø2·¦Ó­fúAÀiÁm¶é@K;ãî\—©F… £¼`óé£)ým.o‡ìÌ¶xA±§Ü›`è‡à,>Zð¶ïO·.ÕZÃ.üŒSá?XQ õ½€zœ×VÇ„Yë Æ¤ž2ÕˆÑ¼,5Òª£„çø€ö)ÇÕ¡Fºtèî2iê.“&¤Äé,›^™¼ö,´³Êõ6¡„ad£5ØÑ9E§‡™w!›Ö6{€ˆ}ÝçEÚ°,óK¸ÉT”©‰p™šˆ”©††2iEºè:…nº	è¹²‡™,u$7Ÿ " ?é<E]A^3Tjk²2A]Ïü1.È§É~uQ…»mpÖË}åÅï|‹>Ÿ»®åé?¡=Lñ[é§ÁáÈý_Ú5ooÜ–i­¼û_·ÞŽôué2ãTŠ>íw}-íí[ÎzŠãNñ/ ë\Ë¿é¸Ùc¤¦*·»Òp# üåz@‚ácà#>¤q	7¼—ãŒaQ¬ó¤ÛíŽJÕ›5Ú¢ã:ÐÓm€ãkˆ‹ÔÂìì¦EŒòl2pVUX‰q/Îæ&x±­üîf¸ô20ã›E;`lkw`[ ¯/„ðXjèÊf¥Ø¸,ûùH[€¶(4†f\@íë¸i—Ë,|­}=Tƒ´ŒMAÃØ×£&¹2.˜(ÓÙ‹½‘V#xÝeFd+Ðó+2@z'´;k„h1ÉÜxA³ ÂI©jIÅYæér¬Cyˆ‡™Þ’Õ‹Ix’:¼À\|’½¡Ähxï$ÏI«Ý›*1gg*5•¸ô¨ïhWåyR×MNíïþ×m³§ÚÎu¥ŽÎwfìŸµø'7_“¼½a‹ß4ÔÑ±+Q¿˜ÞÒõèÚbºÇ_ûòÉ3†ÚªpL09«M›N×¨—éªt™8Õ³Äs¯ë¶F’£=Žˆ%Z?ÇOãY|Ç‡»ý³FC]×)ë9%ñY~ì¿“ÄÙ#ŸBSZÉØb3¨l1#›ÚI²™yJ‘Ë`@÷Â@úÐ§Zö«äsÎ#'žažÈ.1KXQ|àkÈÑ’g„q5.ƒ·9J®a·Áˆì_C{GíëÑY¤O }Bñ|ë¨æØ\ ï«ÓÂ¡ò(HÒÍâj0©Ü©‘'ò…F”äØ®ÞÆþw¡¦€Ÿ¨«š±Š®¸1†›ÓÓž¥–ÛBs7{F?VyçØ¶cñ#ƒC‡c'ÿÝ¦Ñx“üÜ/µZ‹àˆ»}Ù€Ák5Xu>JON¾½¶õåOPª·FÍ?3ðƒ´¦/’Ð-mæÂ³v­Õ“ïõúJOf8^_Ÿß\mºús¼Mc°‚^c‰ù¢9ƒh³Š†@£[L8“Ng‚&µyéâ>®\:1žiwùèßÑ*cö¹ÆeŠNQ;Ç}¡AÃb³]kïãç«€Š€ÞÿÚ±%jgmÀ>N[^±cëŽ¦¬ÔÒYåý6ä…zO˜`ž›³ˆ-ÏœÙ ©þ£Ló í^–s!»&ó(´j(Ceš'T¦mTÇ}âŠOA÷ÕÃ;¢]L‡â	{Û©—çÑd$˜
+1+[
+p²Ü?KcÜÛ"ûöGG`øm½¡à¬²~æÍ±Ñ£±‘óáõ”R:	bÖæ¾ýcZðÒŸÝKïû%Êªôˆ¾µë'”9ZŠ˜ü›.Û‘/ƒ5hð‰FÁ¤qq“<Š²¸ëÅµÇX¬°à÷7Ë*Ð°re>J™V-C™‘FÚ\†Åhºœ‘i5ÄÐ[6“8`8pÍlÀˆ¬Û1:^£DÅ‹ŠG˜QB÷v%çbW.-¿X™ŽG,Þt3Ë¨èJ)]¾Èü'Ù,ó%™uíâÅ¸½ˆZ×Sž2áç©À¢Gãügvîäy. F¿°xd¸ûX£Ámæ¸ià_Þõð£ï¨*ërwÕ×O'¬!_©çEôü7:5-	?ù	ßÐhK{©nõ~P¥F'è`n,´‚ò]ücÌoú¥‚Fc d&:»ö~3‹ãzÁ–öïn»LÜàÆËî±‹µip¬pP0ð³ÖŽ†rE~­ÆtÙà¤ËäÏU¤÷5ÛåT¾î†¶[qsUÃ·Á¾žÆBØ¥ºÅx¿Í@oVŽ«n1ßº,#‡íËòý÷¨1K‹b
+â,«y¥•µÛ•‡ó²l›œ]Sjn;»(ÓÈhXU÷´*ÍG<"eITÊ]\.âäÀ4
+ †¦Ñ¿.Ê< à |“˜Q$xÈ£Ä¯­gCCÉù3““‡‹±iéÒ/nåü&Þ3»µañâä†ó&-å†a&Ÿ{îòe°’U¿ô-Èáwÿó[bHËÝüf®Êí›)º­Ñ]¬óU˜M>:ûðÃ¼´+Æ]ÑÄX4s9cyîýÐ×ßK¿2‡}|+÷FÚÁow§ÝT7&øøÏ$¦9îk©Þ\[g|š¶Ç=Du¨SÛÁÏ~‚7òò“~EugSò]¬mÁÆ¡´Ø×%i„5*ºÔVÆ¶²aÇÜW;Ð-Žpþð`‘ùqj6ô2XÝvÖö’@Éîª7CeÎ­ÈUÎ«Šðöu÷i5Êˆ4âù€}Ë£Áä¶j»÷*ÆVc×H«Á*<Gö#Q7à™K‡|”tPøÁ…LÎj«ÑL³6_‹qP×6ÊÒkÙ"÷M©ëÅû=‰=0ÿ/Kß3:t­[ôÇÝ³µý³'ûöF£ýápÆ.vÄmâ# ›%^³j‘ãnMëóÅ¸ª§éS aVßÎ‡Ç¢s|@'á|l£œŒüiRmÜn¡ÜÃ—8ÚÕÆ3xR³sícüE>ã_EÁË^$¯\&z–íA…)GVê#)6-±2Ý€´šH•ñßÊeb
+}Âò¸Ò*xÆ&)}™žÀ{lFžÁ0Î–dù
+·’QŸaíamëäeÐÖÙûz¼ûÐS½•|µ«¢lE÷U… Ô˜õŒº’QÍ3­ÈËÒîÈñr~]I·ÃÌb Áý¬?ÜÒ	TUÚCCm…þ©b¡#;2ÑÜJ¯ÕqÜ8@bÍ8e{þ"Z‡@Púäo~š½¶Ø~sáôÑÓ¾ŽÀIj,T×Ö'Ò9ðª¦ŠMùæ……l]Sž~BÒK-KÏMPÏùs?:X½P(ï fƒ6 —§1›VþçÚÐ°ÏpØ^ÁPó¬æa9M¾‰Ã¥gÃUY&r8ªç¦/³ÜxÎ. w)ôîeÙ‰Ãsö ½G¡(óxlY>UEàÅ®É¨7¼hú»1ž¨ðd;Ðv…Vei
+ ]tEýþCä(ËÔvj»FÎ# \bDDI×b¾•<ÈlQÇ»U4½ž9Ð®cì¢š¹ÍcÆÀ†‘m“œXôÊ)–ªÌ+E ´‘¼üäœLéµÄ¶‚+ñõÔ$§kã3éô\‚þÚc2óz³ÐžvøM<+=¶¸‚FŸÝ)º8€ÝÁ”X‘‰`¾Á½¶˜+LÑœ^´¾fàxà‘M[¶q\¼q“Áõ¸ýÂ,Ý;D™—ÎÑ/Ð)Ái4qŸhóÖ‹z‡IkÚº<u^ ­«Æi÷u%Z†{´z£F®š¶FR¶úÕHß¦ñiß }D;¨äNóèþ¿#˜2™W¢àÛ?¼âL¼•<p™ÿ•{öØ:”Ö¥´Ûq®Ñ0ð0?›ÈF6×n¦PÀû·¯ããöõXÊ¦2ã±©¤4¬ðÄÀ|.<{ŽÎ)gÌ=íR&VPq‘EÄ•<Ìfv”gÀ¤%•zÅ‡fé¢õ’ª3Í?ñŽÓ€eC<ˆ(÷é©@°ó³Öí8¬@ò;BVOÄjõèõ†·y€×Ã¡ÆX´R£3hVA¯åaÎ«ržhbq«6(ú"FÚ{VZáÛýÕ&ª7ñ«™¿í%­YüÀÌS×è@8Ž§AW7Ü‰Œ$kzü\/Ï÷':eÚÛÒÑ ` ^Òh©`ñBÃµý³”ëF@LÞ¹ö^~ŽÍ×nÄä(è	Ë0ùÕ"ªCƒ´©‡›ìëé¾=e{~å2I‚ªg“‚ùäÞeý#Ýt?žUÒáD†ò&6—rd<ILÄÉ>Þo_— TTÃx\…HË¾¶\å$× ˆX,¦Àqw©V ,¨x¾¬„‰ÖäLˆèÑs%KýzÙ Ê8?§G©â¦°Éï«þ‚C°tÆÚ°¯Ænñ›5Fmýù9Ž³kíf›+`
+7:+k­1J¯=óÇ?ú\¾ï>O>›r¥D½ÓÌôfÞÏLÒéÃÝ]×uhès¯Ì¥z}€æßª3ñ&½Nô{jÝŽ”_ïµnºµ¨ÑpF^kàÍè—×‹Õý‘©	Á$ òÀ˜–¶8uÞ)s¢ Ö:³Žê=ÚôQðÉ>ó6½“ÿäiÓ«w¶ºÌN#=†r‹Æ¼:ƒ%r€XµµíJâ/Ãâ¬ë6¶I‘[ÄJ²ç´î¨`dÅÐ”füÿl{…(CÞ[óÅ4‹ŸªÑ,ÅÔÅÑXÍØhM´.Õ3PëïXÜßÓ=Ô±iwg=øn‚òÆp{³ô]ééW¡¡TªÛÜrKûûoºQú†Ô[U'#õñX2ž˜jªolš_L'ë“Ò÷›îå&uf­_+ÝOïæùA¦w9~l*NÆª¬}‰ÿŸ*Þð=UcJŒAazyô72°"û½&e@Tãg(“¹%#'ÓjÀ:i_¸H#Àý¬ÆJ3ôÎe!oW—šÙX6AjRéq Ç•÷Cð…‘•†¡±€R-"Gè=JJ8X[ÂJHå›¡â)¯#Àp¿êì—§°2´"wºkeý!ZË:€õˆ;únñ¨VP;_Ìñ1›Ê"ì9À^]/æYÁiJ©Ôß)ÒÏI¿¾—þIzËý…`(í¯†ìvŽwtôjir«ÿý£™Ç‡¥oƒ¿&íF~ZÈpæÝšˆÇO¹[Ø a Üåî¦»t‰“|À7»p‹à8þèfªá¸ï	í[?joU5:F¶„¨Î óÃ”k§:éÏô<õd‡D1fÑ›´áûì~äÜNFÉ9r;ùÏËäTÍ’yÖn 'Ù°£×­êþ%µŠÅ>z2Æ”0U¡ñI»ŒÁQoZ–ƒõH£¾U¡w,ËÁ{¤—€^R‚ ûÞ¯Ð‡€>¤ÐG€>¢\ûè²Ü^»,ß÷Nä(–§¡K7+T3¹ÀÚ#
+vÀº¤ÓJå˜6ª+iˆ×6i±
+$ñ—áR¥ªH®À±zÑFÝJñW”ÙA—·•r3`Íù¤|*¼—+2vÀ3¾¼V®ÇŸ~Û›C·Ì>¼ñžñkgÓÒ3œF¨öY3Q¯Ð•`ä-!‡%á×WØŒA‡ §{úûí•a€vŽÓ{¬5~gˆîB×ÿÊ2.áýþ Ö­ÞÀü6¡*512|ô¦§‡çæ«§Æ'Æi89»z’­¯ Ì«²Y•õz—ÉìÖûD{‹È¿@ŠÀuž¿ö AÇ·:ª,5þf¿£‚¾_SeYý“f™Oi¼½õé!¿¥6lpñ¼Ñä4_8²ÃÙY_—áu«u¢¯.×¨0Y ÓÖžâ/ð5¤ƒl'ÿƒü5Ê&¥F	ÀI-ã3L› "ÄVõjËðÒFå}cÔ”‰?Òj¾
+×Á¾L«Sxµøìo¥ÓGËôß‰Ü†@OŸfPH¦•|“£$,ê¦í*„Ax~šE%éEîé PÑÜ©¨@žŽœ#Ñœ,€u*¯–-çJ/æ
+EOøn=Nxaƒì¬_âøa°,¢†y¼‡£¼Ã úy,çá¤g=K¢Ë—Ùš¶†ÿä5U»îàxwØÒwó€Öfœà­	EÌêúÂIƒÑ¦»ûëüë×Œ>1¬C iâ¥'èKÂÆkÍ¯Išl¹~Øß÷m€‚ô˜Ð‰ÀÝºøï|3ù6Å:7ŽÖ>ÄÏƒ¾qáÚÖ¬G„Ô(Å¾ž`EZ]`)S÷Õ†`àëlcDKL²Yýº‹É"¬=É|ª°Sä»ð0gR‚õÝ™Œ£P+0þTŽÕòÜ”œh¢\´é9@Và7[µC¡ oÔWŽN,rV«`1h4<¨Œ`ÖSÕàpÁ©¶hA˜õ[bƒ¥Ú«åE^4I×K]±ÖÛ[íTØ0Yg\ý'˜½P!…âæTŸ!ä]Ús°ŽšŒ£^ƒõ¸•îl6ÓÔ.Vh5fAäŽj‡¿µjfØ\éÐÂØ¶-ÿ÷ ·nÔã)%#ß¦”è5³¶=Qõ8FMÔ¸zªLÞÂ
+6ÀHlaYNh´Ù×ÁgÕäö©ÕÌþfðæœ+þEÎY6ÁÎ²	F:XV,X:52,Ùn¬4tU”&ª£˜S½o%ŽÖMË«=#ZTb«bÒ£õˆhÍ¹¢ÒÇ-Ó/»£ÖYÜØ¼ŽÕÖ¶9­>}÷ þ›`“ÿÌójý{*d^=å%žÿtál=þw|Ûa^z”ÕÛ1,·þò×ÓüðûZ˜JíÎ-mT0hÜüÃ¿£¾í!NàQÚIÌÓGßÔ“Ç1ð,–jŽðqÿZå?¶Qh£Ê1£ylÌÉ5™X™V©(U±„•ô0¦Â²Œµôec¯/{}™-WŽ¨LåèfcSZÍai)?C,Ä=qŒc£es{=qÌ?!Üò¯;m©@þ=›šâ#ÑØlSã€ûÖÕ·Ã@-Rô{i•¢ãëí¹«£‰jø%ÐˆÊãþÃŸ¦|?åM.}«µ¶Y°À°3|\½öyþqÐ2ENÉ=XÈ±“=òIhç9‰²"—U¨Øc§}=7€ô6 ·)´{š+Ãs%¼AðM¬pU«ÒÏ*1§6Â3öuôø—õèIwIÓü¬¸Ê§LâùÈž%p‘‹GQ60%s(ë'€éqK¹t_ OtíyÛ¥ù;cÇÇû&N~Û\ÍY}†Ö© Æ¨Ó[´îLÐÂXŽÞ¥9³SŸž
+{CF5ùmUN‹;PpÕû“<4çÌ˜|e!S°–pÚLš>¾14W¸Xn<s¡epnSÄKŽlMX­süŸxc…TbbS°‰³Êí
+º«í‚I§1ë¼FgB™POuC&Àq#ï=ÙúŽ‚«Úá+ðBm­…ìØö†´£Ë¸ð¦÷uøzWEGmÖábùÂìÚãl]‡l%ƒ¨bŒ¥bL5hT°ªEB£áfz
+S¼:¥ªSGŒå6Ã¥Ëç”µ(òZ B]£®<  -…ø2´ ¿åC+"ÏŸ¼‚@ñ8‡üŒ–ç'4ßÿr¶ÉoýAoƒÿö”·Ñe2ÙAì²ÇÜŽ°#îÐj„h¦>Ôä˜Åé}Žj	gtè¼‘Æˆ)V_ãÑKŸYý³†þ—vøüa½Þ$pœ°úV`Ô›µV¿Õ•ØkýþF¯Ó<>ç©q[+­f¶2QLÌgúö9R•Þ ±k¢>«™t÷WÃüÓÝ°ö~Ž¯R^ÿÐûŒ³Áê û!Cê*6ÚÍe
+Ý\f½ÍeJ¥Ê¾‚EZÁ"­*y¤Õt6ÒA ƒy9Ñ_j<Ù‘S½R¤1î°¾ôH¾¼’oŒìcÏ)…ÅX}“YFË©¢èÍ)‡"'£÷N*ƒuæ×ÑHYNcñIÕ€¸½ôëTzžû»èíZ^ÃO–”W•',=/5ãv8„Š‘®wð5n7p:sú'0“­`¦¤fîþæ&®r¶Ø²ÞŸž«MmLÍ&¨nõªÝ{±Ž7ÃIwÀµž¥ZïÔ|læaÆ÷·®­’—x;K«Ùˆ\ïddZ©±É•ã£"ÖddswÏ¼±¯ÊWá÷‹ üì«ŸüçZ¨¾ÎB»\ÁYéu¼‰­ÿt‘õz~ŽÉ^KÃïu[îKQí–ûêxÓêêª¼FÊ²ö÷>ž‚§^Eöõ3ò»Y6ÕªÔªKÁ	d5ioUìŒºèAúêF…°­TŽ‡–±/ÅœŽýz¢ì7Zd¿ ¨Ñ±<ÛÐÙø?Ù374|ø™ÆöÆWÚ2§¦ÿö?¯r—à_Û÷Û±iÿþ÷e]{šÛÁ÷“4`“r²†œî¡JdÅI:‰¼ê¥S	/bQÆV°Å0¢ØêT,Ác1å½å\äJ„5}+Ê8û2xY!,ÓV(àÆ[ÑåaÕ!/2@Eâ‰æ«QíäáÝœƒUî€ëPAµJè@”n%-ôv«j*Üñ–ì¨8ßšmîmËûâSõ#¾mO.Ô„›Íûg“U-Q¾Të3W,z‚‡IúµÑcmÚ·¹;3NÛÕ¾M=všÑ»ÍMû6µJÏPÁÜ¯k«2:¶J/º›}aÚã¾µ¯òŸç‡Ãd,’‡ÑË	ô&2¦Ä­4Šæð(QÃVbf+Q	8'È¨zøTs”d–±Ãê–hf=ìØ	¶[½R¹9¤”êLÙ×S€µ+xÑ>R«\T¦Àÿ*‹
+âr¯d¶‹Ë—E]9•¡q=¢|NY$Q6³Xu•onà¢ÕàªÁ‡¸Õ-m-mmóÛÛ:Û6V¤«Ý±xc&V‹Ñ1©v”ÞÎÛýŽ|@Ðrú¶¶¹ùÖ–Ö¶ÙÚÍõƒþÎºœ´˜ÇÜ‘úŠŠºˆ+Ñu´/nmkkmÝº½£ØçŽçª:kkªk{º“5¼ùµÛ¸óF‡É¸(ÜÔÞÖÖ¾eK{GÌéTIOÔÔt‡óq·;žÔDey\{…û$Pà3¸€Aö´Ì×Æ¢5‹Âù!beCeT(YD»pÝw+ J¹ÌCŽª¸àu«Ìµ¥²\tá
+:Ä:b4)—˜+Q°‹¥eY^“Â·,HËõL†æµ Âåj¼n÷˜˜rÏŸŠV¶8Cq»»£{KtŒ[^ˆdëšóîµµõõî¤Cz¢áTÏæ–ö©G÷ˆÕæºî¾ÃÅÚZS¥-SO§ì«÷Pw®º¹¯¯±¹Êwè¼¦óLŠ$rŠ¦û7Ðr ààœ¬ÝGßÍ€a]8B¸”M9×‚žFN^(c³¨R[ÇüÐm}mQt×pÉX·;îöE-á9ês×ð…Ûl×¿ûÈæ¡Q¡»#X¬LŒÇö9º=6šµc}ú^¸ïV¸oïKXý‘CJõj‚¨Š›ÕtcNñPéÖ°¯Ñpu»nwÈà³Xa;îìs'Ý¾˜©Šî9²{dC°w‡ãCÑÅíûÒÕÃpóP¨=˜nƒ>èÃô]| põNUÊL¯h4ã²2©å@¿ËL(Qúe*QÖåP(sOQÔ‰º$¨6]Lªø•¶‹•.T^l»à¿xÑÜ3˜jyãGš††3ƒ8Fq2ÀÝÆ½×p I§%§R§hZÃ²bô™ËlWuù=Z-{ ¸wÄ‘sD<GÔ‰SG'uJÿÕ)ýš¾‰é·Ô†÷Ú¸vŒ|ŠÜ|ÄGÐ+¢grAdß‰ÀÌˆQ•¹£ÓtCÓ©ñÍ°»&“ÎõæDgÂh¶cé\$Ør$áB5ägôÍ2^¼,ï„‚úUC‡¥givTÞ$eìý—È]p–*/ó…V½{™µ£¯:*z£Õ|M0T‡jÙç­kÒS/”ó<E—ë–~ÐÍÛ_»uÄèˆÃÜÿ°\ÏV8E”@)[¿²'¨´_Y5w¸üY-bt3ìMÖõµœ6úkºW6]ªî¥Ûn›?ÃðØ†‰ëäk3ù{sétÎr`ÿ'>ypï‘ÃþØÁƒýûæïxãüæs÷Þ=·=ç'àÏÜÏAu.³meJrË1k+ïVAs0ë€Pï}²fKÔÍý|ÕË%[²avý0aªIÓR¦R-Cl¥4O—áYììzE˜/Yúñ!d7“ùÊÓ¡²ø0ýôªt4·7w,+Â™ºÞÁÁ#ûe÷dOö÷‡oÜ‰OMvEv³»ic´ª9·e÷b´?:Çú3ó2ý)~Œ8•Át’8ÓÏ¸¬²Æ½{§QÊk"Ê
+\ÛZ ã‘fbcrWÌËÆ+Ï*ˆa”±×ÊÝ^Ÿ]™Ýk ÍÇ;ò-í¹…·Ü{ª®atFsK¸èoëÚÝÛ—5ÇZ<ÅÉ©³½}ötó\².›ëŠ…»†û‹ñ“Ù›Zpøô®\vóXcÐ%ˆŽ†¹¥¡!ŸàF¾+ÂŸkØ¼YÈâ•ZGP´ŽNiMË%Î_/Ð(ê‰g' ÀÐ*ÚÆ¢PlÖ5‚ª‰ä#J½óÎQéAzHú)÷s©©ÿ»ßí§'¥ûdy[‚ñ^à~ò¹$ï©R¢ÃªŸƒ;¢ â³@^Y÷sˆf±#IäüJ¥ÞWåƒâƒ /bµ p§|Ô£*Ì[Ÿ%œ›èýœt—­ÚQì:5Ð=;{®¥ÛÚm¬÷„fÚ{3ÙÅô\l”ûYÿšÑ¦st/w.û\•ÓjÍ6g²þ Žõ<ÛµÀK	õí²§„Åh^xŠÌ
+vÔK2Œ«ZÊ‚?V|×¾MÏØÕÄÁ›~ÎéÐœ“åÌSZ…Æ¾pÅ#®ã(ê•Q€¢ ¬”ësV;Í~gÜ9T×‘©žÞÝ7<>~äš»wlCsÚ—.ZsãM¹¦Æ¾©!w‚ûÒ¼Õ¥·˜´ú`ï¶·füu­Ý‡ŽÎíùä'®¹Æ&Ø¤ÂBG_SÓÄHC:g‹ÉsƒÛ<§eÖ•PE?ÀŒ€bŒl§ÿ-=7I»¥íÜÏ[W§¸Ê>Ã4Œßaü"ð”ƒd‚"‹’RJ*å†IRÅF+„´ä"0vt–(¨VvgVd5ŒÜ©¤wlµŒãUð˜EÊ€juŠîQ(|@…(ÊÈ6Pú/µmÎ‰…ùo›˜;á´µ}pððž¾‘áG«›ì-õ#£õégOmã 8ÒZÜº»½}Ø3@4û­…Å¥ÞÞžÖ¹Í9»Ïdñ[²“›ó…tãÆÖ­ZK…©¦‹D£‘–¦¨­rÆ²6tv&“ÝÝ5¦
+{n[û5w+÷
+L¤/“Fe…¶-)‚¬¨òÌõJˆÚ%ëVVï˜ËªTWíáS’LØ••Þ¾É±ç›ê’UyOÂfÌ$G¦÷ôm=rzãî};nijµGèÝÎžö¡é¦l:=:t$²`õê+œÖL¤m ÓŸëZ;ìïÝûÔ§Ïuvúüþ–\¶yh°!Ý	Ïó¥µUšä`D´†²µI6ÅÅõ¨zÊŒè²ÌBóeô«>_…èñûD¥¥oTÍ¶t|Ý€säkÇh=ÜÏ\W…JÅ[²Hr¨V±r2áó*	q8B¼z?ðe~™4ÚŒ·ÑÍ.³Îgî¬ò¸ýUgå›=±p•C†(V_ÈÞÞåzý5©`8‘dXèIzß2bRð•ŸŒêT¼›jbÒKÔ£§¤-•ôô•lÞGÉ7¸qJ|AEcW"ü?ÊíZ}„ýVô|¹S–Ï½p¿GK÷Ã:?ïW4Ð$Ý£~é¥Õð¾J©Kêª¤Çî×»¶Ê‚S.ç”\p‹ù;ÜF ë•°rT-Ño(«Kj°¯/ç2ÚÕT‘}M‘Å1p¯Å‰)iä+m%üç«¯`LÚ0	.úÂ†Öb~¶÷Bk(ë9:9	Ïl+¢¨·*¬F§ùŸvåÓív¾¡¥gê6ÛD?×²½-U×˜¯IH?¯÷W8+.Òn•å©imœÿ*<ç$h±k/³ôë"–¶1á‘wê†ãÍLÛL*”­Û‰Z¦BYæÒ¨X¨-d€µãl¥û3dK¸(Ç°`ÚS^çVÔË–_Qv“S7Nø+âÊŠo¨úƒ¢®¤½d—ðãÃ{y›idpÆdŠŽlÇ?\8wæº¯¿õX[{«Õg°T:z†·ûém.ÞþÓï]³u×ü‰p5O9kØÙÑ·cïÜÜ¹ÖÙp ¼àÝ¹±þ¥ž6.%íô˜L#‹·&#»[Fn½ñ³Ÿ¹î†Øˆ'b²L_øM·}}ùÎ.÷C{·…Â¯@!KêÈÎ[víÌ¶ih88·ulh~‚¿þü=+Àë±/Ä$z%‡èšðQj¢thmÛ!}{÷"ýÚu· Úþ5K¿§3tIzmJ#\o\üÐ‘K8£2`Ó‡V`ógÖ½s¢xç%ò„^z-ÎlDˆT©³WzQÁ%hêUf%B£	òH±im¤–}íƒMÖZÿ†èøÈéTÿì[vU×n~ü3Åâ	Þ^Û´u¢Ùî7;zš:÷ôõr_‘^™éÉÆÒÒWë†G&P–`3oæqÇÆ v ‚•[©ûRp¹'¡  µ,ÂSÆ=^îæxãøÄÙ¹TíÜìµ-g;o?vÏáS‡>ÜuŠûÆ¾˜¿fOÓ™¾;––Ò™¥‘cgŸ|üÜµ	6W-ðçï`û“tËñ¹°aVÑú7e;\ðúÛ‹#é,ElJlUY`ëa+í\¥’w?kùôÁ¡`³Xl;rôÓO¾kòõ×LnÕé¼-µ…f¬ØŒˆÅwÌ}êÈ!î««×Mn}4ÜâŸ($vŸzè£}4¶4Œ”¬‰1¤AgCÊZTÖžå·ž¾, —¤sô!ÉÃ;¥ßJ_cþr®Þ2ä_\[ö‘ÿæu£yvÕ;¥óS¼}Púaô6Y7§`>æ‘W7È±xÄÈÜ¾‚!H+Å”¡ZÙoP6·ðá©+mbÊJãØu(é‘NŠh=š¼Jp·sÝ7ÎM/ÌìŸ)vHÝ8hŠÖtÝ±÷À‘#õG¹olò…íºýÎ½[›[·wJçwÖW$OŸùàG®½ÖoN¢Ïq3Œ‹‰ŒË•r%gPÚÆcE>Êî‡WÄXj©,ÛÊ³à rˆ#Qø-NÒNNJ3“¼]zŒ.€ÐŸ—îdã7 ïgþ¸Kõv®ˆE9¢““¨&àMÿÚé
+œëAË¯S\°,bDTÈ ¼4ÉX	yn¾îC vz¥'Ý094¸¹wÄ‘òû›*ºû“µEnhõï§zºý‚ÇºÕQi
+àœÂxœgã‘¾Ò3¨ñu¯#‹ûhKQÍ 0ëÑÔ½ñô5:v@ú·sÀ3Òy`ž¯Hqúð9é;pÑf¸‡î!ñŠçV=9yü<‘æ)z‹ÔÀÛWóƒl¼ÒpæNøœ™çÉš¹ríê>íŠÌßZyw*EžÍê*2[Z%r…§R%^¥R&…jlgÑÀâð`ŽôÚHÛ–†¥çª¥/@¯®åîzí7Ü‡V¹®nÂþeá¹ÞÇdlVfSæÊ-aJÔÄÄú)÷Ž_þ‹žýµ^±¾Pä)êÈŽÐGF¤ôá ÷6èÃƒ«‡PÇÕ€<þäcïírÌ¦Z‰É¨q›ê²øºËÁ•+â2ÿK\¦L&éíwî?yhÿÝ÷î?tjß]'&§‰‰“'6LL[Ÿþäç¯9qöégOÛ¾óÞÁsKK;ï}ËöE³ Í²9Qâ|¹dÁW6JŠ´¹WÖëÉq­+JÔÑÄ´•¬“íÌK’u²WÖÇŽhI#'µ>:¸}ÃÐñg§þôøSC¹Öþ&Þo>u¼£EzX©ÆSÃÓQ¿Ò·µ§¹‡ñó€ÌËE\Ä•P$¿®Ì¶¬àÂƒI°Iò”¨”BLfb”Sõ‰å^ÆÅ.š¿z}`ÒÅòWºr"}xÛàÄdr[ËÑÉ‰ÙÑ=6óègë£IÛKÇ÷ïÓ¥ýÇwìízíoßzçî¦ìž¥{ïÛ9Ï	ÏHŸœÔN?óÄÙ³ÇÎ~âº';Ž#NTp…švŒJUó„]öQ‘Ýd„YY_Ç²[+Š7ƒBçe3àS|5·Â=n(ÇràHtEÑ(â´ÈØ¢È† ÑDùƒ;v:üú¨{ïææÚtrË™)êüâù‘=Už@æ©ºñä†ÝAEj“~÷¾‰˜ô LÙJ äj	c5L'ÔÏÃœ5áŒ©Hß±‚{ža$Êž1¿ºÚ} \¦«fŸSëXÝw9)Õ XA½(s¨Kø¡™rGœóúóþŽ®É\ó¹â±–kçgÎOÕµo˜òg+¦‹gZŽÎŽMœŠqßÛç­6U&kŠÓ5®¨³õšãýÝUŽäþÁJ£¾¦~x!íˆ9
+'w´wúÍ²½E¼y-Ã›U—ÙVÙLojJ¶[N€k—ÛÖÇÏm—þ8)½
+v{5Ï}uŒ×G™)Êùvôv¼WÙ;Q‰iÕ,%Jœ–yL7«…’•Iä³“cýû·÷ŽÏîÞzñ›¶ƒÒ×jkÎu¤¯IÖKs&¦îaÏà€gøÜ_ºfÝžyaÕ–6;6¯ýi«ô-°€«SÜS`ñó ›ùß1ý‘W·)ß•†S¢~†eV(æ¯DM Éñ.þ}“/M|áS¿Üøùg'¾ˆ––{|uî·{çê>v?°oÜ§™=LþÅ^Aëö¹_[Þ{°„pšÙùÂ{¤×húÀþ°‡ÖÁ¨|•6Ko‘¶Ñ#Òô}p}'\ÿ	¸¾ž°,œ:ã ÕÊZdýŽWZ[!˜açŽßür·ô]ÄÄÜ(½›î.ó]Ì¹ˆÊ,rÒBma¸šFº¸:)À	«wÒßJ¼½oõÚÁ4÷n™ß–__'ç¡”8º<æ¨ËtIGQÔQî^ïcyïmYJžæÞ}ºVŽÁ»×î§?ág¯Î¯QÍÐ§Ò$?ûÚ¤ºäãÇÔûð*PïãJE‡.Yü|îÃpŸÕÝ§k–ØgíôÀAx>[é>rL‚ºt&š¤Æ×ßþN”J/)/­p¬Ý@¿öö«ò- ¿—Ìx]7M¾ÎoPúÏ)9Ðe¹¯§îÛÂM¯Â§Â Kn.
+~[79+ï0×«HS@ää\‘÷ôR×Y þÅ>\<\\A› E¦¥ð&DÆJh,ÍâÄrA‹jÂE»zyÔNl/ŒGxR–lÅ¦ØV_¬’)']žaÝ!Žå=¾fskõ,*‰sv‹Åoi-´l‰›hôçüÖj÷üî½…Ìhõõ¹{emÅ@®‰nyÍQA)§¡-Z!àhñFLµàãmNÙ}FahÊbÕ{[»‹Ÿk,Þ@§3â·Ñý"i//Ó=IŒË¨CÍUÚ#ì¸^Œ*:š*ÑtDMá)V*«»ul„˜Vº*zžHê¢.7,…EÓ£Ö€µyð`ÿààØ‰Ît0à*ŒZ+Íõ-²Ù–Æî¦ˆÒG<!SÍÔô©³7ì¡}§Ão¨êîÝ¶«³¹­…ñ]píú"Ì}Xöe+T_Ö£”8¨Ö#q•±÷\iêé‹-íŽ˜s6Ÿ/g›êóõ'§'7LžiÏ…èË;ò¢NèêÙ´¥§3Þ©œž={zv£Ûci„ûÿÆÒKd³¼¸ªF?¬tT™×ñ¨V¼êª…¸¬ŒeT‰4;”õ6^hj¶äÊô½ìùzòå|ôÞƒ:k¥5Ûw` xäh:i‹™¡ÈÆ\c¾©¿¯±Uë¢»Ê”˜ž>unvÞ®u[_~Gmå`ïÂ¶Î–¶6xžðãé—³m”~™æ²)Ñ‹*%J@ä‘¸•x°çªþy…ˆÜ;Ž—Yìët$¼¾Zgw÷±‰cãÇt·H§i«yª¥«®†FN_—2E¼‹Î€!2>uÃµÓ3“ÃýÉÎ±þ´ƒn©$ÝëËLÕ=éåŠ"WðÊ&1%$«nv††ÕöX]V"*¡Òœ'ÊûÕ3«Ímå+Lm*qï½#[9ßþáxŽrZMŸFà¸Æôþ^©–~§WÆ©UkXN†ßvQ$;×s7œ2÷˜±Q7kd1¢J_—ûìZÆg©$\éH5ŽM‰É†K‘w9GK‹`ã1B—TCðàk¯fˆ¼’â)c‰gÝù×ÝÔ¼=î
+EãSõ…DK¢aO_×ÈÉ–¬-h…Gw§¼ãMÅ†ôÈpSýA‡TyýÍñä¦P­É«_êëö;§fžÙ0x_z³Ëo4ó»7·µóŠ/HüïÃØz~Ås(×$~ÅÛ±¬¨Z„ÈN¾¨Dé´JŒŒ„Pòcr(Òë>ªáHG4=R+¤ú+ÛGãñü†\ó(ŠÔj}bó0»›Újj:»g¤_ÈsF„\äþÈjóšPMÉî
+æ€tòÈ+}DÞ±BäÜ´\º*ûþ.5VŸo.ÔŒŒD=•~Q¬ Zý÷ÇJ¿¿2ì‰xÙ½èÚ0ù¸—¦•yÉk'Ê“‡Vˆœ•å\,!9:·õ+¿å#õñ¶@ÌéŒ:5Uë7ÿü†XØhè3˜ÒI>XÖeN~Ç°RîoÄ®Žà—EŠ9@3'šýÃþŸPºç[ƒ£0Ê_.KÏR±ç;ò=ÈÙÿ5f’Qb&/9I‘ênã—ÙWÊ¬‡Ñds*×›¢+ãc¡QT‰V‰&÷¿^È¼ƒK.u¥ ¦^’,ø
+ÒrË”“9QI|ª-?6šŒ¤ûóÍ£ñhº7×2:ÀMÍ	£;Þ64ŸÉÓEéCô`k4ÔÕ¹Ez…,D¢m=;¤?pâ|& ÖG"ñP]®Mw	žS$ƒë5òj_™0—, :Îò–žÕ‚N–ù¿Ñu*ÔÖ¶N‹Ý| Ö>¶ÐÖN÷Kï K-±xwÏ´ô+NÜ[¨oÎ1õ
+…>aÉÎÿ¿jHôü©#I˜œ?~l|lzìÐHK¡-?4’k)æ,²ÊŸ™>wqf¢¯£sÇX£ží;º[‰ŒWæ8;<â•Wâµß´dkÑp,T##˜«kJú‡²ì@L±fE-8H¥\•áÁgU#r|YŽáýŽ9=Ô«‰,tîí«®?Ø\o	¹íSSv:×Ü˜oªo\á¾¸T(N&—:.ÎÌx÷Ÿ±ytÁî¾›ÚÛ{ÛåÚÝ9ú;x>'ØÜy¹²:VfGð¹ÐO–—‡\f)8Ùj`&M­ï–mŠ’;·)¸µJå¤"Ï®°ÎâÕØá1Gq¤÷Ø®¡Ñ¡‘cm™Ê`xcr*×ÜÚÔÝÑÔJRXí¤ºƒÓçÎÌÏW˜ÿp)‘êéÛ0,Û±®s&¸J˜#¸“¿?ÃTâ¹ðÅ¤Öia­¢\	æ*‰óñù«˜ÝK'LV£É0š©é*¼énGGÀÓáÞii•·¥œqNîC°Ø×`›‰©1ˆ¬}}j“°Ô<Åüjœú[l £~Ü¡#…Ê:´L
+«R2àå• ÉÄp¬4¢åŠhW+æê¬©µy¶µµoª	‡[|©m¹\<±%µ1µµ»ggª¦§a1ë„ÊPÜíñ{Îš‘þºzNt,FkE1Þ4ûÌÉ©þ\Ö`eþ÷Ú«´ûH^?vÒ]ÂDê3biU‘¥AÁEå:¸ü’g ŠÕþ!r_±(ëhß=÷T%¼U.{ZìˆÄ·lá>ñ®^éÃ©˜Qß+•]ôp¯ÿ¡æP¹wÿï8À¢dey¼"®áþ+q2Ø[;‰õMZFº{ÌÓÒ¿­XäDéñÖdº³gõ­þl«7j©nm›UýnúóŒoðQÇÌcOŒ|{®•§_Yý™ÌKAPmø|’Å7ˆbsª”`w0#•l;½%*¢PˆØ‘	äÒP\À3d–—ó°ð2ç’ß£×ÌÚªL¼À™DÓÆñõï´»8Æ`ÑX¬ÜüÀÓ“÷²çuœøZÓ¡´ÑªKL¦¨võg´¦±htøŒ”-]0H¿‡Þws>GÌ%÷?Ö ÿÿ7ñì>xÖà®·¼þ–¹|qÛ[œÿN|þù?J/þâ4×­\›],Â\¹J×-þâˆjËÁL7­œ~æ]S?ò%ª3¾°ÍµF“63t·ƒþÃêã=Q§ÔcÉÚõ~ÿ’]¿—\fß=·¾ @MÕl­/+B(*Õ ¼Ñ~ÄCÑ7i§cacm¦Iow§½Që¯`¾÷ù›++ëìô›Ò.žÒžvúîÌÆ¾	ïkûè3ü q‘C”õL–\¤^©²fÒ^ªÌ®õ §²µ*‰h>+÷¼AŸtØìžÑêŒÉe1vWûŒ&OŸ(Z«t‚à
+íá'»Ãá{ö&‹	G] µå‘`°§'µídc—54ª7WZ-ÑÓ™)è×/×n§©ÿ{ý²«°×9xs7<Ãix†Zö…w]ðò7µà–¥A,e†î²ˆ0t™)5|€"ª5x7 ÍÑÓ}^wEìà¨U«szGÆ<v›cÐ±+l441oœæCÁ'·×öô„ìÛ§6§òÑD1¹÷ÞpU7ª˜nñ"nyŽ{è÷ý1+ÑÂ¾T*•‘¥&¯’¸oúÐë”{){5>Q£9üŽEUÑcÑDÚSßh¬ö»Ã¦|SÓÎíõöH¼¾23Zëéi‡Ó*\V·¶2Ý s„|ƒÑ¨ÞÀöÆûGþÃ<ÇÖ$¤¿×âæ®¸Ÿ¬ºAºÂ}Ì¾noí=6[Ÿ÷)vÌ.on­ºÕ¾§îƒ{&¨Û–á9ÊgÔ5‘x®ºÒò:H"/’d‹#3WF$J~c–ì&r-¬¼ÚgŸ²Ô£‹U¡Ê2£vV]ñãTn‚!Ÿ}}*k5Í¢µË J]ø…ðQ-ÝA«nWÞGZÝiuÿ½òãpC!u3Òê^|H«»€ ­®+Ä±²Aœµ«{½Ë´ºÙ."[YØ}ðú ÐqÅ¢:
+\…ûöýõï!‘WÒºRò6Cêw¢eÙv¼Ùv¶ewéò~Î‚zy³@1îÁ½ ø”;bÙzmXú!Ç­ßRxµÿþÎà@í%Šß‹õ‹ÖùoŽì‡âÍ¦æÔÌ¡æQï¡ûÓõ£!}m¸÷Ha{ÍG\Ÿ¸[LZ÷Ÿ²J/rœ·'•êvSý«}÷u˜ú®s­¸}îê¿ób};.sÞ¶Ø0ÏqyJ¹…yªá6É»ˆMPeÓ@®M¦8Ú‹«£g÷âÁIøD®gŸßÂÏòCß;Ö>Äö q’  v²…!çq÷ï
+RPDU®±Ì([rö“AÖö€0!»õ•ÙÿûúŠ¬òob´¯o
+5¨L#n¥n¸Œ´º_<^7ÃVýšÄÇ>®\÷uè#.2› ×0žeû<_&Kd;kÕï)lU0r@©ÐžW:éEõ‹Jä½DåQ–ìëO/)|„­ºùÉQ¥#gíê®Ð2-oP­~7.LÂ /nGÊxÜò·#^;ÃmPªÕlO,]1*ê\åÇ{t¹<.;’º¤²¥Ì²ªl	Î6ž¯èÛŸ_èª®î\Ì§úýû¤¿Ë3·ÞÒX™£ï_ÜtçÎéÛïÜ=q—ôöý‹¹–#‹óèí0˜ø" úµô¢ÆJHÿþoi =É:*Ò¢Xã<xâz¡Ò'FMvß@ßg£"ü˜­Hïkó˜·.š<ÒÁY“ÛFRµÞÄ«#ÃÑøÐÄø8mœüêŠæWËz²±Ûf˜©ÖÄ{õ/¾ý>í·¾CeÕÏË[†sr½oßÚóü‡ø
+@_dw+Q·­šP¾¯fTYƒ‚[TaÖ·¯R×¥"­î‡…tùvVê:Uôq'´Ñ2õ‚ôFä+<¹[ÁQX«S¡$Šz”ý¤7(zX`Õ|òÅ°È¤êv'åzw#Q·zBZýn‚ž2É:´"º¼cËê÷Ð¸P,ãˆh+^Ú±æ…f–æ]_¡®l"­|ÄJ=¨£p»…ýéVèé²ôŒu@j¸ÿØøÞ¹]ÒÆÚ›·†7µ§ç¾(ý^YK«Ök~ü"qû5 o¤?ÿCîXš¾|/ÇÝË¯¾Èso®ÏŠToÂÈÌÛó<n?ÀÑk)‡;‚év›#`Ñ5>T×ª3ðNÁ?Üô8CÃËq»žµGùðNÑEòÏˆrD]¶ªÖ"¬ï1K
+
+ Äá’7“#òi¸ÍÕpw|Á¸°©ä˜ªŠÉSf‘VF_½s•\’Š·âÉ8Ã'-
+%WaN¬¬o”7`_ö²Ýí".å‹]Š6*[“å_1˜ˆ–^‚í	¯~Õ`Q§~wVÜ“Ô•¾kÿ€t{Ì\þ‘£Ö¿¶ÝÙ°½»Ï§ñùSÎÊ–`. -Ÿœ¬ê‹šBŽ
+Ál¥¼-`ºaCW§¿ÿaS&‘èðÐ/¾áÊÙ;:w¥évÁ•ò‰	ë4\7³<;o‚‚Ig
+¹#Mõz‹ÐÛèšàÒ‚ÁÀi8žóÇóÖßÑ=2²­­!Á€A™ókO±}I­àrß²^×Á—í]ˆ©º-Fù–¨”Õ¼ZúÊ6ÿ]Y¯i“÷âP"Ë‹Ê_lè³_¹¹š,eòîe_IË—ïá’——{t"Ëêñ?†[ÌÐJ1x[t,Ñ4V‘ØÓíÎ…9¡Í¯ã¸dåÅïã+ø îµÏsô£êþ/ë¬zðå´ZÚ§Ûx§FÔ~þc”ÓÕˆLŸm[û Û3Á
+½-’¡–÷d®!ê÷ñ†Jµ*úê­æQ…„ÊÔžÛŠú*ž‘ªÍ¥ïæ•³
+!–aú«ßÑ«î‡îŠ–í¹pµy¢?ÏÖMlÌ7õõÔ7µ`­L	ŸzÛxƒô“\Çõg»ÅÎ³§»:è×w_wÝ5Ã=ôO¸MÂ»>ßº?½E ßèùs¨ÖhréÒ¹›gvíš¿éæ©M38.¯[ûðJžíwÐJžÇÐEƒb¶©‚=‚% Š/n@Sþ¥ åÖ¨ãÕ`ÿ¿û
+¼~ûŠâÿU±±ä-oâ¶XÑ²7—] iy{À Ž¤ÎÁ¶&sTR€@“Žù‡låh"Š¶>©ë ë:[Æ•Eýá›î¸ƒ3p;ÂIe_Ê	¡œ´üŒ¢–Ùp¸ÆøþOtàÊ‡8.ÃWš¤ÃÛnŠÆºÒ~ÞûÈ[vÌœO¥&¢CÚÕ;yµ'›mÑ&|¾~‡—æEÙ¾×žã?ÆSðÍšÈ\P”#rõºìŠkáuSzÌ.ËÎ:¸¤º*	£‡Ä¾&Eµž¸IQ—â½ Œ¶+»P•Œm¿‚Æ\ÊíØ6²ç‚7û{8I®ê\¼î½U]Õ9ÇéîéÜ3=¡{¦§»'Ç´³»3;›sÎA+­r\å´('‚A „`„L4&<°aÁ^ÒûmlÞßØ<ÛlÏÿž[÷N×¬äßÏ‚Ý:ÛÓiªNðs¾c5|¨9À‹p4òŠÛFxÂ†uŒà…E
+ÆÂh8„Y¬î5ÙŒQ%ãåd8•fL;•¬²œ?0_Ì²¸²ml™TMÇòIww@ì½ôçöLÒ“Z³°­‡	‚ìõKõßÅ&ZïGÓÔ½þæÿýïÉCÉd-x[nÇŽÇg¿qäê¤÷Ì·ÎÜóýç/=ëí.˜ók_˜ú¯ú¯ÿyõWM€^ì=ñVz©’,Ãd?Öiö"mÐÀ€PK½™‰ŽŒ`ò$,»”¥k–Þ$gI•ÞZaiP:†^‚¹ô6Þ¬[£u|‰Ê4Û4 ·ƒ?jWQ#€@Fð]fwÈÂvYÆÛ7Žq…È"ZƒÏ™4@<½ü3·%È"hY$‰ º7XàYƒ¯§ÇõE#Q¸þsÁ|²`>Y0_ÃïI "|Æ	Ðï#EÉóYÏ~nªòµ*×e¨V·Â	4î-†jµ(WYðû'^Û–7;CDÈ4±µÍYž®*Y°6&‹õ’Ëv¥¶"Ì²§¨&_ïn¨ïtäª“ïß…ðR§YAÏ^y•{0Ñ:ˆ~:Kpý¿
+›;;6äÐ´¦~Nå«?Á”,ê¨Æ1zP'ÊDSèŒgØ"@Š4ÉäQ„#Á0zøãœ>\oGWuŒyÙs'L}EˆØ<ZÏ*×WZMtŒù|Y7R­rX]ðH­*!“½=™˜Îµžóµxð×n"ÉÁø`,qî¦Ù„_»v÷íÏ Mçoý"¹›ñææ¤yªÛ Ï~^j÷ñÄP_Qµ…%Š:š.<ˆq‰è¥ <@…køåÙâjd¯[ú²`º‚ÄRlÁ Y =»¸~í2è×¡_ðÁç’ä«aÞQfã)ù,MÆÅ–4±š³h°]Êèä¯lÿàJ÷¯ÐÜ³S}‰¡,[d@Ø
+U(åÕË[<èÿºY¡ZRãn­AÙºiúS‡+³jhMsvÕ`K}³þË#]GÕ ÞEdä™¼¡Çú&V<‹†*šÇÜwrg__­¶w¾'ç‘U“ÛãÀí.ìiJ¼¥RÕa|šDiê@¿JÔ‚}›7ŒJ=õ8µmMjNU6›íÖ1¬¤ZÂ– ùd=¥ ÂñvçÖ‘‘­û‡GºÓ¡ø<ä19I“¹þ×³§rs²o¢T:T½¢²&ÒÕ®0®í×ÉÕTg:¨J|_àÚ™ýÐàã {|«ÁexU–‰øÕ¸]Ï¸LÈmÐ±w²ªÁ6ª½S—]g¤(Aq¸±Ö©VQ‹S`®ºÁtiTIÃ
+XÌ­2ªK½)˜ßòQzµ}þ`ÍËŽ*¾ËIÕUš‘j+¯chô´Ñë9ÑÉO•P›…¡æÁ–‰Ö÷¨ªµ-Þ1ÞE%SjÄäÇjªÜ‘¨»šdÜû‚3ã%1d¶øLü†	}P®?iÊ]3¿ðÁ›ö»óEÃaN'ÝîOäžÅ¦«C‰êÑžùÑÎdö¤«²fÅŠ/ÚÒ4–[8àj#…f%ôº–—^!/‘vÉ#–þR7ÛGy"ï¡Ï\¬Hs¤‚	ÿˆ«ÁŸ¼‰ÑÙ¬â\é«Þf“á”7¸v¼ùsl¥)L5‰*ºÎƒ¯g˜:#þœ«±adkNLÌ”«ÁbŠ¨ån0åCöRSÄÈtwùå\ƒ*EgÙ,rì€E'œ>ÝÈž—îÃxbþ´†ñ}õ_#ÅêüÆ­VE¬!‡bÓMv7y»4º'v-¡`{£ÖÑD_o|¤ë†ÑØês§O3_ Åì)¿·-¨ùìÈå@ü7Ò“‹›ªÉ!ÓÃÿ€¿c’U»›T‹Ï:[›Ìa§Õ£fb¾ÎˆÙ©a;±™BoxG@+·N?º¹É“ËÀTè[bEO±êŽ†
+Å¡!j^ë–þš¼ÆüA’úƒSÒ-Òh.‚Î05Çè1ß’&ùÅ9Î÷Ò†èÏ5vi ¿CÜ¹`BWßñËn3±Ì`‹ÁÚƒ»ŽvqYX~xí]%ð¬<x|èï?,ÝÊ>úFéJIh'¼3¬çt½Ë	¢0A '.®§Œ”¡½\zù†¨ˆ›OÒŸ]éj ª _Cåk¨|£«±¢ä[¨|•Sù•Ïé…/Áã—Ò¬íÕÀõ©kï…M±§ ,VNÐ3RXèšÍæU XäùP®'ß“áH3ªe!´Öº2}ÍÃV<ìêŸ‹T"Ù5Sœ§Œº*_Ëÿø8Á®HVÃ…ZÝÕãÕäú®PgP‹u[á=8Õª¬ë™žìž[ÓÚŠQl<}R‡ÐŒX²ƒ¼‘”£‘…ú?ô=2ï¹¹»xíXpþñç~rú
+ôëX³Å‘‰ÅÅUwÐûâÜY“•jîm—ˆ	«&Û@ÔL«Øe‹•F#OÓÈ@TÓÐÕQ{/!?‘ƒàP¾¸»\Þœ]£˜åzßçþ2¦Öq‚»ú 
+¼^Bæ/xŠã'¥ÿxS:UÔ/:6q,å”«wkœqS(ÇFƒ!YÄÂ`¥€}sAà¨K$Ý@Êíg|ðz|»š8äDŸÍeØ!me	½bX™_:Ênœiƒù„gˆuËàBÅÂ°=†›dŠt‰b˜ÀÓõ–å}‹ËÜáô‘` æ²ø~ÅeÅÖ*³u>@ê÷¦+°¸RÓbõµyòBÿþ+GOl[u<¾qpÃÔ…kSm:tjñÞðM×ÿŽ†¼Š×–¾n>ÚoU‘ÃÞ„H³÷š£±N_ÔAM_êàä½%_Ÿçz€þk<1>žüjr|<}jÆ¶°-²m0ìuDVõ7ùüÑ¡-…J·®ß™%[ñ¤=dÄæ¯étGm.dµ°L÷¦`-Q*Z|fŒI?eº‘æ±ÔÉƒ„ô¡[Àèá ‡ÆÝPéß²ô!ò*)ÐëuØÄº(ýR¤#pÙt×ÍW±BwLœÏç—.èÿ0&Q ƒŸ Ça~ÜÖòrØê²žsÁÍJ£¼Ê¢w ¸ŽŒ°8òþ”$öö‰ €=–ƒ,v€,óQƒAL+vŒÌ/k”Ýc„ÒµJ¶Qëf «>ñ]^q¬0ß¹¼æ-XîXi[`©F©ôÜêéÓ¨c®ÿzö}ã¾¤mÇõ‰#šû»SûÏ\1›iëZèO Ãç1žÅØk¥>ò|ýoë?{×@áÔPç¦g&ž½òü£'Ñ§3pG"ÛÞV·Ÿƒm°î“_OÌŽ&vw²¨œ>Ž~>o² ùŠkw`°X‘;Ð !`F–ž#/’$õ ša>ˆÞû¦tžž‚wÑ?å‹zÇÍyƒ€Y>¸–"7‡R@) •°;b¸ 8dŸ‚,òwÅÕ(ƒ,âU!^…Ï1®Ø…àˆ«±s{¶Ó¤†wDž-ê¾ÇÆü!€¢˜[ž*ÓFpj€aîJ0*_¾‚Æk'Å¯hÜY5¨8È¢]å_ŽãÛe¬KmÚô¨9À¯âå{ôÒ°ž¡UØõéDiã2ènÖ0ÖÛ…³ô¼ÀŸ-GìßÍÃì•+d9ù­þàJÂtxœÅnŒö6ÐåÃ_ýmuW¦ãDïÂÓsò_–Ï”ÈjÝÉQß­|æŸ‰7Ù$ãw{“Žï|xìá…Øê¢wsÛGnÙ÷PGç\sKÞæ×º¶F
+šÓlvi]3ã3¶˜›ÍÄl2Ù}æ£›û=‰fø¤ÕcqµÖfŠÎ–ÑÎQå¦ä(N9J#ÃD‹¥sÈéj²[¬*ñeˆ¼Ñb!aóÕÝ»ÑÕˆ-¨Æ£X_ŒŸ YÓálr:#æ¡–œ—(;ŠÃLèãëÍ(šL6 íA_³ÅjŽZh@ó›‡–¾Âã½V×ß[ã;†Ó<ÿ±Þ8§­ôL€»:7è0àR"µYTA;
+XµZp÷aAŒ Þœå˜gƒ ^hbûò‡¼}‹R šDÆ]&lotYßì òr&G‚µ,o1o`øÿÞÝ>1ÙÝÛÖµ8^*¡Í—^Ò·Ù#­¦íS;OÝ×t Þ‰)3°^Ž¸â/ÖÏO®ÚSÙ˜˜œXuäèÈúýt>“k¯µ¶g³õfkí
+¥Š6»ŸÆÿ8d}
+zþ£ÊPÿÊß³}Ûž‡»<~Vç­ÿ„è–Z%îÙ»§ÖÛWcûf_ ×Ók—JÒm€Çè|?'\ êÐ!^èÈ16³€­Ñ¸âZ¹fF”~ŒXÛ¬OìÃaÂ+Åû<ùÄ^J{U²\:õ“Z_B#‹4)ë÷¬_õ„{½E™Dd-H\C¢*
+&ê/íùÛ£ŠšÌc)[>´Äq³ó_PÐõ{dü/¾„Ý¤‘ˆµþy<y~òXZ¹ô†?€þQÖ°æw÷Õ¿êõ	\þuò	¶Ë±…ÆWÏöêéãFj-udV×^7}1‡ Â~7·ÐnnáÈ˜¸Á¬{Š`[uíìåHüFî©[˜×sa7L8ÈzSÆÛ5ö<éÆnùlª,;UW¤¹
+ÛøPÖ©uW&ªŸþ rlkïX5ßÙZl]½Ø–AÏŸÇsÞÆX’†ËøüÓýþÉcÙòýÓšK3ÛÞÓÔêiæx—·:3¶ûÐØÄ.WgÂ¶D‹¾±w¨¥¥%70™Iuæ?P?“<63s[íÌ$5“Ev;Íïúþk…†ñª¦P³Õš Ãt—YkòT6m¯kµÝ§Jš]½}½Nå¥—È+T‡çhÞvRúá[Òi;m°aMäƒ ‹Pw›«ÑË‹|äÓz/ÀN°+ç(¯ˆ”yÔ­GX.z<È»O·ð%éeƒYT4@=YÆŠ†ñ*\f¢)‘@ì­C’4önPå‹½+·˜3v0X“
+!T°ªTf’M ”e­}ôg$¨zIYt& 6­¯_Ä·jvÙáD6k¬·©UÌŠÅên	ûJQsÐ‰œ®8¾rqóñœÅâÔeïíÅ#-eÅ®Ù‚ÅäÍ¾HOÔpTräÃ(VXù‡‚‘„†ðäêzõÜÉÃ÷¼¨Zd«©ô^NtÕÌ~{Ìïo
+²]‹ÈböÊrõÚëo‚ÂÛÃèQºÜ>Å±&ªÁXÙ§Ú5òØë‡ê_ÝgB¿FÏ(fÔs¥¿£žæpC˜Ål3KM>H%À:il|?ÜÉ}¼‹Jor¸VoB p¨ãlçýc¬Õ.~¿q¸[0#„×#ê¸¡ú”€·td€{ˆ“—oYoVqó5†h@ @¦¥«L9ïSu2æÆ¼ý²“{¯½gÓÔÉ““«gêß­Æ•N›dÿd¬Ù_ßV_ç_?<|÷ì4ì:¸³pfjâLç™c[¼ó¼-Ú±U*½M¡HÓ¥×©#²Éò¸µÇX`¢b<	0â¿-vø}noÇ–m…LN—IZ½ô9òq’“ìôýOÐ;`lÂV9s¸¨[õpDu5<D0EëM (µ¤Cò¾‹œyÞ ¢Ä"l¤ÞÉ-åjžÓˆ¶8ÙPÓÔ¯ 2" ‡¢‚¨AAt#‚\™!ƒ…Õ;IV&îËKxW£ÛŠ{.¬Ìƒhô5ì^é‡¾± ¾=­‘h.…ŒbåN3Ê.“GêûùXE€ýÉÜôìÜüÔl.ŽÖ?Qÿs$Ûâ-&__.;Þó¡Ñú/Ž9ub¼i¦ãàYtö~LfQ$Õz þÓTÕ7¼/3ñÈ`lªPì{¦ÿÕð@ìÖÛÎ :šš«­ÅR<\? àƒçiÜ4ß¦—2ï›ß0±:ãr,ÃóÈøUB,$h9ýE|Ã1orÄx2dVß¼méûd©PåHQu8€Ž d¾–»}=Æâ%»</£ B§\hì­€KŸ7„ip7Š®aGUÑµr3¶H(Ö’„µ†KÜØÙ¦ËØ…¼I † @>ÿØ² µ…maE¼Æ8¶Üy&ê‰ÈÕXžeÜ7“2(}Ê"€l´"ðÏPâƒŒÂsŒ"€1Ã/¸uùËCm’&1z¿ZÅÐ‡ÖOÓ”n¾³—ðµŸ,re;wyÁº]í–»"ôf^½\Þà†.FYxvÔß¨c,aqôwtôZÓ‹ÅÍ-VÆk1úÌõ#Š#V¨ÿµJÚô”n¨ðå‘`\;üˆX­þ4!ŸÆõ‡0¹+S	šÌ$b¾Cï¸ š³ÔÿòÐ³ƒ8¿;ÿÆèK7i{äfËç Êæè/vöZKÓáH»©f9dºŽ>Ø™Lfˆqœ"_ú8YGã»” Ñÿ6é$:=ëy1¯‹§·ºÕÚE<\Ì]í7,ŠÃ ‹o—á¢llÝ
+²ˆ€A»¨Ç/®¬Hd†Co3o@nº{Ÿpùø½W^Ëbø5NðfÌM«îä]ý¼QØÌR¯•MMPÝa;È"lÏ¹Þ¹1^+Zàù¢™Ó¸dÑ"`ìÚÐé˜A¤—P¥jTä`O¹IzÂ”tðCÞn0{j0¯úyÉÄë[A› ‘_oñ£šÓØÁnô›Åµkç7O¥úÛBhç4ÍOO¦ûü¾ÞÂK°Mú{™Pn6kÏÄi€r¶i0ò;w.LX{71Þqÿ™äPÌ°gz¯<~íôèöâÚÄj&2žE,Åvã¡¾±‘þžQW¼íÒ}èç-m>jû¨Íûò¾¼G“iðŠÑõ'èƒ;H[†Eð‰­H¾Ž³‚wÏ¶—¶¯Ù\îËç-.sý ¦9þµ;»¦”]f|Ð)ò¾ 5ÑÈó%ý$W¸?Z)|ªƒûR#~d(€¹1D2­Å…50†(Ü¦AÑT¹»øöUå6± 9ÂŸ²)ƒå7¥QjÊ¥ò¼‚›žxd©ÁQó%Oµ¼ŽÉk›Ÿ¯^=¶álzr½ïÏŸ'@b@ãEôÕ«š¢«dÖl˜(á73§W?Ùó‡+o¢9]Z­ÚTâÃ;eÂûoøí=_³½4®êˆ!žÄ¬¯ubéÛäy¼DÏäíè[@ÞÈ³¬­Ë7…Ô˜ö¸Šþ¹ºØ`O/q{V:Í;ú²üÎÒyŽ°æ†Æ~¹øvDL NW#‘Y
+@ÒéZÙ~(îÔ¸áNU`Àøòž*Q…*¹Î³d0G%ƒúŸÜÍ ‹ dÑð²hÛ†B­p² ‹1Å´Èi—Ø3®Ë"v:ëj¤bð¸X?ò•`Ë½þ>¢ò¥@T%:*/P;@ü˜£«ù,‚RØ1{š·ÀK²|¶Ä”R+l•	WÊžÚrÄ5€ôÚ»R­ÁŒ,},X67jd´þ«ú›U¶w,¤ß×oº÷^On$ªÅ3÷­Ý
+<Á¡\n<¶$¥W·*ŽõçGÚÊ--ÛÊåiÿÎTr:›ëõõnéèV‰	»½2B¡X¢7/|Ôbµú­hM»Í•j«é±ÐûŸ ÆG¶˜+Ø÷u+øáoƒÄ5XG¥íš~Êpwìƒ8L&èdøo>ÍæÓöåT‡JµCGÖ”Ë‹	tç=ì¨;B–Øhº©+¨ŠŽƒT—þœ|ŠØ¤0éÇ¥ïCë}+~Me™Øj.TäàE}e!ÄdÀ8 O¡Hz€&zÇø[vq(]\Ù¹1è:È¢×dÑ¤ÑeÐû.ƒÞƒ,²pçƒ/¥¢§axÕ´¼ó>ëM/álIDÂ€ƒöñ HÉ’ªÞMøW`í#¾fXV^GÁ[vU+«ëï¨ôì,øví˜Ë-–îù^¬¼³þÕú0Î·Ù„šÙÎëèh|‡7lAª†Ì6y†¾U¹±pÑç3'øÆ{ÌV9bºÖ Òë3²ô²Hã›0m®Eù7¥ëè/y=ýsÁÂAºn°‹ÐÙÔJ¾]{]¯²ÈÖà9Àm
+é1€wš´‹]{l0€Š²<[ïœ0ÜÎ Ÿ¹ o&YÖá•akÛ8oÇi6Q¤‡Nâëþw«Ö|†¯Þ ïÓë¨ô}NëÕ¸~J%Ï–ŸëK­y),DÀ*—7p0¨Ex0}Õ]Pvè½eÄÁúOÈð*Ð¡„Ùjp†d±þ™ú?‚M¿¯ÿ¦yMgÇˆRÿæ_ý`ú…ÅGŠËMŠ3¨•S°ªÎ¬8Ê™p)¨y­f‡Ú¤¨Äê6­¯•½Ô`„š"fš¨'#Ùî4¦ÞH‚ /¼lSñF25LöGóP¯„XùàŒ6ÒÝƒÉêÄfEs¨™6w[Xó9ë[›:ÜŠ]5Y/ý~ØdUúÖLïræÃ4ÑSÜX9:æSÝÉ0ºUöï‰¹G|·KµïßK&Eö|AÕãí—^gúè•BRõºûpt ‹7±5Ô:N
+³éÃÍ7¨€Ï€¡P4`Èí28¦!ƒ6.rG)ƒŸ„˜y#Gˆ±/Râ_h_ñåØŽ¯…ZÏ†ùQ‰!@	2 {/Eyÿ›èp‰VDVGg}œ¸@ïÛp'½Á·Í¤±i£`–ì‰î0€	 e´Tí©éÎŠZ*Ãó*A =czfßÚ¼PX³6±©Ö¿-±X«þŸèA,ïÚüÌùMûŽlyôñõÛë_ª'¿ø[‚Ñ„ÊMÍ„jÉ™ÄÝã…>Å¡]»š†°žxj®? ™Ýþj-bµh–:†bõ_âú÷Z2éÖÅùl*Ûò"þYyoãoõE¯)aÅQJ%Ç“s‡"‘¼+ŽH`=Æ#ÌnŒ -Ù‹Ið¾L¾ÎtføÜ±aŸ Ôà(zÁÞˆPdà8WÖÂíG+(AO»´Ü4ýNÍ}.ß@'—;í5–xüîò-·2 µŠ~ÇëÿÓ©¼ZM¾þ‘)vú‘få#õš+tíbóp¢¨u™
+CåÕÕ`Æaq@¥ì¥ÂÏ×lKll=”@åúxíúc¡P)¤XHH©_QóÈè‘ÏÍDÚ<á>_,ß·69™t…­>ké…æ`÷7,}˜|‚Õ×²ô·½ü±>¯‘ã¹l’yë©"À¶‘¿F¹J·Ãsø ² È@®Á«
+Õ›îåŠZß7ú. ´<sÉ ¯lÞËNjNô×H-{ùpËïÊ­Ãm=›62èK©sÌÝÉ±6¤<V¿£6ró5ÃýãWìA÷Ý26ßÝö¦µ£1Tß~1º/9±°h²š°×o•mw®ßµsãí·.îØº†ªÒÞ¥×ÈËô<…¤íúzò
+¯9–8”n åÜIôšZ\ItcíËbp7 NÜ­B¨AŽ\Ð‡á½wÂÙƒÀe€nÄA=,r¹CšaÇ §LÞ¸ÃðÆ†¸dh)WŽWk¢è<Y b3²À9Öd=>‡{Â«Â²Ö
+VéÉsgGoŒF“OŠ&ìº¥Qw…”T”k&¬–†aîKìÓ|DC­#/?€V³&ÒÕ¨ÿÄŸu•V3;û<1»Ûc±ÞHe1/ÿÊ1?Xú6‚¼.÷Dµ0Ü‘´gp:‘ìtjµ£Sõ)yKíÓG¶ÞS*Í†c~B¬Ä«Õ?‰ê¿—l²)@_ƒÞó—ÌþÆÊ8}3«G={¾Áß±1Åf’˜jöÕTgØnå¤4+By¸\ºCèƒåô8Ï†~z¡ßkÞvÀc"E†ÜÒãVÃåé3x²yÃe˜¿Ìyˆ>öMÜƒÁq/?
+„^sä"ßÌlç}bU^AŒó»t/ÇËÛyác‚ÿ2;ø/Q¼ìË‰j#Œ‚‹±ñ	ƒ›Ýäj4ÖC §q¬èã~­v¹KÓË òÔ*:ÞCýxôNÞo¡Æ±Ùˆ¼îä*Ì½mÆÿ¹®ïŠ»Ê«6$¶ô•æš¶®Ùµù¾¶œ8¾îþw¯ÛSÿ4.} ã‡¾øxn #åøÒ÷	¾ý›IS4@­pa.m8QÖº7Ñ@b*ö…/ž^°»)½¦âsº¼Õ€Y3i‘¾u-ÙDëâÆL´9ó¼¢`U%wÞCÈ}ô…ý„Üpá'@{HÈÐ$¢Öÿó™pWPÞÝ‡q¾÷ÓU@ŸÆ–>C>F|’Cj£ñÄN4°ñFn¥õ D‚å6Ëüxs¾² }¦º¼)IXò Á’ƒ<JÐ°¼»agÞ¢ÌúIÞà¬óþ¬,øáÍ.ïýGFW åkh¸yVÆÕ@Á Š<dcÓ†ð¹Æ¦Ë(„®,º~@ŒŽ[ Yðß6QéÍê³a¬rÖ=ŒË0ñU³aŒ=‚{î~¯ws°€j^ÞÐ°¡o¯Ã¿¿âŽ[wºbdz¢þÍú·Ù¸˜zéþ{®ëß³v$ú«ú>y8™ê^ípßü‘¶Mwuwo/h­‰á+zwçû¶%S™lÍ{ÕÆ…'&ONj95s~ón|¶—‹cQo°éÒMm=‰ñ¹—Í~‘zÍe'ÒD†úÕb>ër¶lßÖêtåÛX¼]]zƒ÷ÙIÛ¥CÒUÒ¿@, –y,°•Omå^i­áÿOª$ðº«A³ L2J5ë
+é°¤òèä‚v®Æû©MÑãj=ŽÞÎš%VN+o y}Ü&'C’¹ßÕƒ~gh‹½ÂÕH#AÖû§™¬ šêC3z‡C'-‡FÃ^î“à>®Ñ,á®u EÄw+°ÜãïnšNŽuw¯Y÷ZºßçBßÓšSSÍ2ÖÛÒe÷áuãÛžÝìh‹%æòþQo›€‰Ådù|ýõïÖÿnæÑÁØÖ»_<ù¨)‹§”BÕ…žÊÍšÙ×SkßTLØfQ¨ƒ²ûÃvðƒ²YÍoÉÄgG×µ¨VSÉ²s·è¤®ïïß•†n
++q;Íõ'ðŸ2	ã‡=7ˆdéþ¥Ï’cToL°„Œú…_6V'ºù8K×ž(Ÿü(XÄá0á+"Å˜á‚‚,LCŒ›8
+Ø±Ûàj òd“¾Ïw°­:»C…c­9Ž±šx¬”¤úfdy Ü‰ÞU£Êñ/Ò°7TSŠÈ‰‚YdÀnøÀôAÍ!¨ÿsZ¬ÈÅÉjTô|î6Žþä¥‘œ+š‘4|n"œöYðjüÖ¾m_:²!â‰åê_¯_åÏVÏvaôËg0yô^¹¾™~Ž&ïëôÒ,µKWà;OÁ(èýhcw9=™6Õ5ùsß¥WúÄ÷Û—^"×’½³"Ò”ô^èZÐÛP–ãûAžä—K;¿	^vRˆfRƒ(EÜvƒç2äÐð~lŠÜLÀÕ¸7±ðèbUÝ½G‚X¥‹Ð°:KT†ÀP} ý±ØÄû sëè…Žd­/¿ku"‚¾ƒhÄ6+#w$õÓÚ9ùlÂ®|uË‰R¾§²wWµrµŠ¶X}ðºîLgõÌfúÐ_YH¸~k}}ý…Á~­us©´)W?‚npÆ“C›&ïºqzõôäÙ/´ö»½Mbi`é×äü3z"¥ÇÁ=¢ËÔLâ];EÅÒÇ/AŠS : Ï@†DÁg¸—ã÷—wˆdxüÞq±}¤zkG{ÇPÀÀ;ãÍê»%SéJ0Ë:P“ªf™‰c|4£—îÃ¡¦&‹$±*“Ý—Hô…OÕŸ©îÊ­¾¢º&ðÏè{Àj­ÿ[Ûá!_%ñÐÇ‚VŸyGkÖá'(¢ÉqË'89êÑiŒúh>Uÿœ—õŒ"Òqmÿ¦Fp.«4—ü§F]Î	P’IvŠ€iH”­'Ú&Øˆ@ëæAÛ`”k˜i›ž ­býì:ò"bcíúÒÇ¡çÂˆÎ‹é†áõcæDéiÑ¤ED0‰KàÞÏ«•ržñ/Ð;·C/“ËìH"Smô´õªôþõ¹dŒÌV–Ûâµpf8BãI¿Ùäk‹¬/­òûs.ü{“Y¼÷¶Ÿ?æÆ¯9cŽôªdÇºta>ë¦{,08%ËÝ_l<—œÎU«ú	=-Çåúê’vék?u,ÕnØ€E2³ô<ù$i—æ¤§¤×¥Ï£ð[Ò»¥÷³Só~z
+ÞKOÇ{‹ºüA*ËÏSùy*¿›Ê£òÇ¸ü
+•_áòkT~Ë_özd>B¯Ã[Òì:Ü,Ý´"·xMzZÒ§ébÒGXxZ4DyÆŒÂØãëˆDŸú+ß¢ÙÉÓÒkì=nv‰
+Ï›ÒMT¾“Êwrù^*ßKå§©ün*¿ABB{‹ÊŸ¡òg Í7ÐZCÇ6çwÑÕ¢G`¸ÕŠ^ˆLòmJÐ0|ç#&ÿ2Q{;£Šñn¼žêrQS­(,ëñóN<†	‹¶»¼
+{²ùÖòBô¹ª<¯…ÃízTÆ²/€eìËùÚ»
+ÕeÑ¼–dwl8mº3Š
+÷œ3’wíêo÷ZBS¥½E4Ò·=•×ïñ·Ç§Žt(ø»©ˆ4U›ü‡Å¦ÙMÞ¶ˆ¯š´Æ<&Ùê3ì%î˜uÕñfúwäíÜÙ™,=hXµ©ÁNoW³¥ÉmG±¹q´†Å¦§‚QhÇí{ë-×D"‘ÁX¡æŠ™°ìñS¥¦¯óÄ#%Õgw…­™fOÔ*›äœ¢Do…¨JSw¾%ê¢wÇ Ì“Q4”m&í²¦8nÂXV2ªŠí© »%èˆ8æHÑïNº‡f–•ú«)%~h$EÃô» e^êËú
+­®f‡bSÕsÁsížñÑh9„T³*krÿ&,#<ÍJw¬-ýù$þ>u¥ýÒ¿ê)/¤Pzr8š$}‚q0ÂeÑNŒV®:»€eZ]+	õ’“¤»]°ó`Ï.¯Å[ØüVj¹&jñ C-^|(Ô=lnô%Ðe}Cóì5|‰^—¡î•3hbûºyrøÒ¾@3Ã5óŒkÑëù³
+6°„©F>YÎìH&FÃ‰?ý	ÁÎ¦VU¡:ò©Úåëþ€å@Æyè¾4Ê×ÿ¦þ¯<=•˜nY7iR˜¡›!èìyÕJÂŠ¶?S-&p+A„?ûU cÆ0ºévæ\ØušZz<Gˆd£×é¿ Í¯™÷†9ÙÀ‹Å©‚ý†"á€Ó»¬à1á^á±A°umÜ§xaŠ<VÞISâc5FŸ®OnŠòÈ¢ëØ 9‡£¨á×xV3øc×åŸqPG\¯Ú²%¥×K…¢¿µ•ÄcÔ²pòš,”µô‚VVÍúõeÄ³šàKôÆí›ÎÆQî‘úº¹»K[[ª·¾»þŸôT»»É¢M_Q?€1®ó6£ú¿¿{|¯³5¼?°E²ÃY= Äò194’žG·™jdï>„ª5|ÜDc\Ø/¸ôyÿ‘¦ïD_g¤ÞØ¡ŸH‰w-õjpŽ×fº»ŒóFPõÃ†ˆ"'ÑY²€f»\¸d#Q‘Žl Ï)MT8wiv"qÕPÛKçÒFÈÜG¼þÃ¯!¼†ž±ï}eò…µm_nKÈ&ì“-¬Êíõ×Ëç¦Ñ‹Ô~[ÔÉšügh+Aßú[¥ç–þ/)«°Œ°+hžvÆ-aQ&¨º;#Öáíb“£ÉA^•ö.=G¾Äf†©ß½_ú¤ô5é/Û´|';5·ð ôi^¶zˆpª¢¿ÚôW{ “ÓwJ0÷º–KoJOÑŸ?FþñÀ¾›ËÏRùY.à‚îfEô òT~¡¨¿Ç‹ô#Dð™ß†;éÛÓþ–ôö¥¾"}ŠïáXÀ‹ìKÂízŽC4›ûÿ‚ºDý¾«Ñäò3T~†ÊŸ¢ò›Tþ
+=~–?[ÔåÏñÇ¾H_\‰èpð¼A`2úìF0È¼pI_YA—Sûâu+*¿'Ðë¾ðzÑÒ«5‡$ª=T¹ÞÎ$Ycµ¦
+£“äM¾+	%ƒ5ô­²;ïïLV&ÆJ±ò	‡)SZ,TiU½V•êœ†]óàjÕ¶D—	Øà,…ˆbE¸4¿Õ­ú2î×d6™e[ÀÍª.«æ—­4FEÞ˜u8è7S-–cEZ<Ñ~KÄ]_{pÇîc'v´¦¯F'LÓp¯ßŒ§¡µ¤) ¼”`¼}‘xý­ÿ(]Óí+'=pçT(Üá»ãø¡ÃÇÐs=AMs+…¢=PÿœÉ­F½±æ	_{n(A=¸ÕOlš¬9ÕÂñ1kÄ­:4›ÉâRÒ!Ùœ"-­ZGÂŠ[f§É—td“ŠS³d³JïGÀÒKã5ÍkÕœf‡ÑWf’Å´bUÑãSðßŒCnÅCê’â)ÆbÍJÇkõuMxÜÍ¤Xå€ö“1ßX±³‹˜þJÆxDp^ÒhˆpÄÃK¯’OÑüÅG}Íg1àª`‹¸]:_…ÀBO…›ËÂÐ\²pÓ —vˆZ%,OèâÛ‰[y%M¬Û‹ëŒ=^­Ü_@Yr¡w¦×d¬@³×‰Ãµ5EGÞõ’5xDa„Ôüéè§®ÛäSb4Ã:m­qãGë?=ÕMÉÊá²»æx™úOµ}ókÔã‡-S;…-EgÆ¦nªÿ=!=¾ˆÓLTUËOÿ×dÆ4h3Ñ³LmŠÓS>„ñO_ÀO¶¨X‘%MZXzyõçÆè˜“vHû¤«¤'Ð½P›;ÁN‰Ì—F<À‰¬ô¨Û3+£ÍH2û—ƒ»ä8ï()"È¢²è Y´·¼Ê@(	ï³ùÐ'(€HèµÜOŸó€«AÒ òuô®›[©|ý½ûä›¨|—o§òí\¾‹Êwñ×ž¿ ÏÃe~
+ôâ.¶%CÇë¯à[zDIwožßÃë9J×°c„¡±úä¾ø…Œí`Ò¤¢+ØrÏ^Ð{o5|Ÿ òPÓi «4u!—OFr“Çæ¹Y¯‰¨Ñy®+W@Ù<GT—­\þò9I…ùdµSO–„wëD¾ø‘±x¸3ÞYèþEO×Ô|g[­kf¼³Œ¶ïß|xËg“]Ñúþµùñ˜Žš[#YS²âóuFÐ·~ÑsŠ¬ßèõEÍgî=2ýÂÿš=6°+52<uÍžÉµèºµ«`6\7©’a“Çç5ùóî!¿ËŸsZ"±Tý` 9Ù’-÷¥“‰T½£X«9ÂÙQÍ>¬Ù¦¦ÞxŽ¦î6¿¦˜å¨ö/4¢†÷&—uH·"Ü…ðn+µ5Åzfga*ôI‚WÍ’@©)ÚáÞpª)ÚâP,$j¹âjÚiˆÚ¦—H^•¶ÓÔÿðûzÑØA±{ ¼±È=@Ý0Pî]}á-é$&Õ´û‹:¿ê/è|ÌðfAé~öfã.½ :#ú7AµâËõJŸ‰Ñßá-z£ê]¹kÍ‰ùµ#ÔìË,:šêSsk^¢ÁÀI#§û¯å—ÓýÚÂá7:¶¸ÏcñæÜqwÉ® Ékv©ë6µCÂm1ÊÝŽ¤WÑÕ"k6Bµ›ØÚ¡åŠ’K`b9|Õ´§œ¶Æ½‹_þ>âÖÑ ùêø©êî–Óëo+íÎx¢æÍ"›¬¦@ÆÑ¾>WM)vÕìÒJ«bƒIkØ4'eÓüöè\S+õg&g,èÄÐwÕÜ5ºÏEm-¶b¯¹‰*Œ VÔhJmî¯¦‚ô	T›$@1!¬àæ‘Üæ¸f&–}I»¯à·z-D•Ñi¥Ó™qà±’Ì])ïë¬Eóh²*Û3áL—æ·;#–Á¬;b¥¯ñZšdÌ&Àýew{ÄÙC²fÂ’A­šêÑÏ&ú|÷käVwj–ÖP{ô[0[:WáZn®Z9·—åi+j#A3È-¸eGáî²\n¿¨wq	ýnç¶ŽSü(È›à³X-ÞÔÏ˜DÇÊz^ày]Çr'X”i}Íà"*à:„ùâúôòrÿÊ°“Oeu…|Š±téMÈ€4ê†ŒfÜ ƒD,;âÕ)ôzK¶§7ßÖ™®ö%èÏMdâ/l‰µ¼|ñÏâÁ’Ýä±Z8±ô+nËkÛ"ŽÈ»+»wU›"½}[÷@?9ÖÛ?~ìÚþöBý#	›ÿøUúÕìµÅÎMySÔ„-6™ìx¹>¦îþ
+–™Õ{‘ft^Va\ê¶ÙusÙÃcw®›öIH*yÚ× aÖGL
+ÜY5s`/¿ÂpˆI³áJƒÜ)öì’âÊIÛt©×Ó¼[A¯bë!V›aÁT›!ü5¹œCºÙPoÆøtÐ£ î§œ_æMc£k Ìú³äWÌþùÏM_S*Íƒ)ëï>‚êÿHo $RêS¿„¯¤ùð¥ýKË–-²õ¢÷¨:Oì*ò"¹õ1Œï@x$2¿<QÓ(úÞ·ôGò*þKªu'¤Û¥?H:¿ÓôÏmE=DçƒQ×±jƒ•#°:¯þQÖèµ}0v½‚ÐcüÑ¢q–§Ó,ÚQ@XíQÃ} ²¨Î5X}E›
+È0¯¼ü‚d½ÅW—õ°	¢
+j§	/Ò²‚E¹H-3CCÁTWø"mú£,kÆx§X¾‘Y­Ö‘8Zñ*Q ð³•ÞFÿö2Mw¼ªÒé¹­‡‡:OŽŒ¬u»’îgîvGÆ=(¶n±¨AwsÒŽ-^Ê¶ù,÷ž)ÍœjY[=¾ LD£™“B&¼4Š5ã¹²Ùô$âˆ¦aš]u¬]£9Tëº?Ýœ˜/•¶¼	ÇÎ{;¶=5DSEÄg$ue–ì¿;’¯aì,Äö—T“…Ìí[Ú	›q¡Ï'V—êKX-šÙc!æ¤º&×©ÁÓ#;»L°¥H1+‘žHÅï,ñ·  ½—ijér˜Úé	é.éCÒ'¤oAÔðì2Zp½ ÷ñXáA*?ÈåG©ü(•Ÿ¥òÓT~šË€Àñ9z|Ž?÷¸‹áÐ(Ûn^‘>Ì4õ.¾žâYéÝ¼V JÏ±¸`/}äYfm¡ tÛý(‚ä»¨|ÿ QØø0•?BåW\:üð¢Žô_CRvöPU»GÈ÷+z$)`ù@3
+|ø·Jï÷^ðß1½p^xñWšÁ¦Ë\®T}&ª¨zÏ·Ž§*ynú™2’Ã2¶8±*{âÖÌH“/å0ÛdñTÒ•~sÄ¥¨ÄíA;¬Ž°9VkH”,ô’ºG#}	oÊ­üáôQ„Ì1_)nir›Í-!w¸à‰z‰Jc’*µôYBÅeSœð*Î‡3áVQð™Sõ¥ÿ­C¯VŸ#AÐ§®GØÉÔ=sÆñzb¶µ·)lFÖ“Eqe‚Î´×P-$ÒÉèg(q[¡•N!&ÙÚäm;’3kJ+¹Tö¥ìšÕ„ñ^B“øj{¬Ë«Ú4©j»ÃæÎúšÓ&§Eµ)ýmù´bÓd»™Äg8¾bSqÈvÁHÊc²—øZ[¦âŸ±ÚmçnÅÃmü{uòuöŸ®×ƒK/—IˆæjIoA_…Â´žJ»X›@£ý<Àï%Wc¬ÊbðL²,pF¥ SNxåm ÝÞ÷¼E”uÚéÐóÒYÞ£GS|î²›3Cú(`E;)È> ÄX`™0¹%Ú›A>.ÁC§·ópE}xž@ ½B@Üÿ“}@0£)Rãƒí1Ø{ÅH>p_Š”dÑ2¤Ë;¹,0<˜ê<‡ žCÅÈ:Ï!õ|8‹íªy³ô/?úÓ@¶MƒåJ~y"ž×"  /Z~ÃÃ¹9 ,Žz(fÀ¤©Á³8a™P>×xK,¿Ë7õ®õP“ý£ßü¨~üÊgZ÷ÛÎbtïoU®î²Òqíàð™žÝçr«·ú;BÖñókçN¤Ó£q_§´‘:lšÛ”#Åã)øvS×àpÇãfœüS2ØöÔöÑ½éôxräÃ÷½>Ó»Žìóô¶ìµÜŒÐ³=eWˆà:ýq|’ñ0/º3op ±Ø`Y³+ÁR†FâÔsMôÛk{jÊa¢·ªK¹Kæ½íõúI¿ä¤1ÇG©Zï—¾
+À«^Ê°‚$½lq»]
+é9"4‚Ád~0ß°¾ØØAgç%í®•U¡Ë CÕÃn¸µ`éÜ4ó \ÒiœJQ4¡»‚˜(Y´Ä‚¬“¸ðø¥¶›ƒ*[[H+¡SA“j(ëT)"ËÌsŠ/VÐb#„¾€!%|ww¿±ª>ÞzåÌ£­ÄÖälV¿P>ÝÙÛ}¤3ñ©µ‚ª)?ÈÛÓ~"c«ÃlW%ï©¾LË¹Ï%ŽôœêŸ>SØØW;uº†£6qÚ[ŠSïMÝ³Iž¡¿)•°òhBEÑdGÒ_ öÑeîõ%`’D‡jÁ²bU’ÕôB+&ãú6©i¦¶¿º*¥ØØ²¸ŽúúE¶Û¢OZ¤>ö¤ô@Ïr<ÁÑÃÈ1†¼½\$ø ‹q `sæðqzýŽIû¸½Ó'´vIØQã]ìmÜäBeKÔÿa?t”ïr5HxvlìtºwX 'FÆ@Ü7Èˆ@åsÈd 0êÄ•TI-÷lô5 ¬·yuòp''ðÊ1†.•«½}¼µÝ?Yîîé]³®§€,3…ñc-†Î¾Û6ô­NÎµw-4•&3…ïe“–³XçMFŸ®·þ[ Ö	Æ·Þ5ðâÉ»í¥pÒ’ëw¡ïü™Žp «Ðê÷ÔÿŒ&à&ÖØçðGlHÈ¶®É¹]^_vt°¥ÙZ¥šáÂ3TQl^Ó¿%'æÚÚïÝu÷îb±—òB&Yw(ëë£±q@ª'—>Îö›Dè½¶“jÀèÝ£âÐÎ(¿lúÂû«XS‡Þ^%¶«\N=Eº ?‡‚$4Ûˆ” d‘Ü ¤bð×Áõ
+^¿õöhN¾I:ÇÀUg òÕôÑkx¶ÀYAØ*È·RùVþü»AC¡c„1°Ò—Þ*wŒS\õsL{uc'*ŠVƒ‡Y”'AÞº±VW-Íkå6?ff'#«¼~íÅ†%Ó='pBR“jCÜã-'(Ãˆô¬äóÒé	ƒj>™¦ÚïD:<ªãÁn6qØGPü]æ€û†3?ýÎ¿ü4BÃ¥RM[•ìr»N›_ë[%6TÝ?Ûµv®««»}~U{?šÓšÁõ¥ýy¯iRwLc";³yú…¦ö'¢õ?Î­Ú¿bntøª³Ã£HÖ my/[k]­GogYrœmãó--cS©D4{­­õ¹‰¡ ò´…ByG÷˜ÛÝdÅ«C«Ðwè·:l’‘s[­TêÙ¹½·Vë}‡Ì?üP&ªÙÛâÍCÍÃ;b%“Þ;ù!²ŸÞÍÒÒÝh(„™WnÄ>¸©\Ò1<&`x¼ù"4Ÿ™¥f¦£B?}Y`ÿ7p„#¤.wðŸßºyGñÍ·m„=ÍÙÅ¬|+Þ.Îeäå›$o¥±¥qæÕáZÙü/ô~äài¡¡VôÀÜ¼ Ò èðv¶ÌÿÞ"$ˆ¬þ0—Edïy3è0k¤kÃ4:ËVØ¨†’e³´zh†)TƒÄ¾”ï©– lJ7éœÎ×øˆ­¨PÓ­SryD9˜e“Ù^•eX5Þ®Mö;†º»ÆÜÛÞw5§æ‹«Ÿ§wTªÿâ~>¸“Æf±ú?Q[iöÇK±‰BÏê¢YäÕ';vG­éµmíÔÂû6Œ&º½&§ÃŠ4‚TÅänÍFÆ
+ŽLÐâ¤!×ÂÄûSÈäu?.&^'£¯ÙK°?Ö²tüê#h·Œ1ù.ÁØýA$[È>P]Sm®…1¯¢a·J$ÉS&ÒR6Ó\MQ|Xà÷z™6ÍN?"*@qUbs8”Õÿ€×nÄÃÙ_ô©zþ³uéE²™q'¤Ai­ô0ŒMO®À_Û8i+ d"A YÔ$dåUƒåY`¬  ÈØÈ¯eýšðØÒ;Ë™bÍŒ	RãT»ÀÌcÓ««¯`ór"ò©è6I¯öÀ½Ìvùqçû¶u¦7rZÝ:v¬¥®ÚU›ª¢¶™›+ÉÎÍ®ä¼„À=Þö«‰ñý†Æ&FöÅ®;gúÇ²É\²þc›I3›ésšš|H£y(îQb¦úu‡®ê3ïŽoîïÛ9òdGÇ†œVÿûår©{ûÞž®žžlÞ~xéÏXŒ•¤÷ëq4ÆWQõivú¾“økÝE½‚(¢n«á¦†­7¢r¼Îpƒ[ù.®üLßy SŒn¾&D¹dÁ,ò
+Nq°C2c\ÅñððŠÉçÞÂpò•³õ´7öPCÁV1ˆ,&¢Ç‡‘Š¦;ÍÑ~fc m™k*=˜½w‰{ÄcJS—ƒøtN,Á0˜´¨gõ­,All˜ŽÐ¸9I²X|ÍÓzRµjá†ŽK_~Üúw*MMåÈ¥SÏÕÿ&ß¾vh:TMø‚TCèKJ´Ã]ÙÞ2[P¦×¿mo-U›pQG;s]ÎÃùû|[ŸëØxÏ>× tG|¾ˆz€àMry¬~°‡ærøæÖohO[ýV“JdÕLT‘³â,Æû69²AÒO£¹>ÖêkðAªÅ4a@G0L’á³.¯MÕûˆ4ºô:ù$½ïÓô>Û.½ ¯JÝÉOîr—â>SQw@R7r±QM”^”‚ÜmÐ/€Ä@È¢ÁÀ$—gEka½ü3ÊÊõz«ƒØÃ˜5ôÍ¦™ ×pd¹?!¨òÕl'J…³éÂKŒ‰£ÆÙXx/\õ}ø4v,ÜR*nkEifLÍ‚LöíÁØÔÔnÁø•O"×cë|Ë8ŒXŽùXheE‘ïÁBËçv&>K ŸSd:b0Ž:üQ_yÄdV‚êÍç=¾uè½¿#îr2½s`ð}¾ÍØ5Íâpš®þ/„F})‡c¨XpÄ²vY[¦OÓÐlõðÒ›äe¦wVQZCÏÓÿ3©'Ný¼F&lv„>®¯"TÊ¸Âô˜ÀAn¹¸’´
+ÿ;û±m©‘yð/âkËSÆšA»A	lÈz=L¸ƒwpíü5×;3Ãƒ¬'•ËSzÑP/4×õ£žËw¥òÉ†\
+æ†!}ƒŠ¯
+±Á23¼/ipøÿõ®z gcróæÄÆž;ïZßÿã¶úçØåö%¢Ú¥Ñ}éôPÓ{K´©Ýýsê`×aüÛ@©£Õ9ý…›ûñôÉú'Úºÿš­7Þ¹åj|EwSÊb†-ZùÒÍ„Øš“	{4kµzÍ²FBæ[u„R9KÅk”sÇXÛ>½ïñÿ{¶0¿³#™è€<ìš¥/1Þ9'Û0,í‘^‡8T'º)r#+ö97¦$Dbõ11AÞl0®ð¨rN²€šçkÒÓxãËÜÉÐ=#à™úfÎ}-¶1GyŽ4Ã?Z\­Æ‚6ãe–}¯,zòÞÃÿ;$4RƒÙÝ¼ÎOÑ¨ê©‡T¬«nNMô={Uýß[;V¯í(´´­_³­î‘™S-wm¼ãÊu§ëÿÜ;|ìØhoßèÑ½£#(l&SøãßÍËfE8è]šÉZåP$º§-µ‡3¾¿ˆþ©?_èÈõÒ«R¿oÍ¯¯míš–LS+Ú¿f`l¨:¿¾o´·úš)nªG•ëqÝLJ¬à‰o*9Mô,=O^!Nêd›¤=“‡¡û8Ã'w#¼ç ¯{îæ|Q~ûÚnƒ=“ØsQ¿GÆ??zQ‚+¦O¼lãðu/ï›Ìó©ÝY¾/ûr¢iÑYWPÀÙÐ¹!ð[#Áøe÷§qá² €@8ÈËÄ—ÍYÖª$a{^mFÞeÕàm—*BºP[Áf
+Õ±‚fÔF2GþÃÚøÎ¡'úÊë‡¯œ;ïùö—CCQŒ?ûüÜð¹c#»ÏßtçðôÔÐúü/oœÜ>ÿìcëŽé9Õßw¼ëöŸtåÃ¡„ånLbíŽ­›nZ7w¶pt½£%zÛãSå ¦…‚mý!·ÝB÷RÇªP/kˆÜ‘Ñîî@¤n_ÕRíjY½.—Œfe˜ŽL† lRìjamË`‹ÏåÌïœk¡Áç-Ha{îÞ`üÓz¿m‘®Dó°»›§vMüÂéœgx¼§÷âJPþŒ«‘~ÁÏÅtiÒÕHË@ ðZ±ä³‚ÀÉsËIîdš¹Fâvk<ø¢j`´ü§]àÿ´k%Éª¨\NÅc4S&3`sõEõ· È¢'M`$0r|æ"Tìu¶a…ÞÎ)°bÃ„‘:µ€àààžLúY§£3*yšF²¡_Ýõ@˜Qóçý5ü¦ÙÈºj¸{q ¹Øwø–žUÓ›fßsÏºý#k^}hÝ¶ÏóîÊ¡®ìb‡³%BC„×>û¤Éc³z”æŽTÄvè}óÛl„ÔŸpg|¾ÁüÉuÐ9ðØ$L7x1|G}t¼Bó!³7îë¹\žõ©h,·8”ÈÇ2U cv©áØTò~‚Ï³Aðj˜î?ó>È2e‹+rï"¨}_ë€'·˜±Õé”ßÑ{#ŽHQò"þ6u2%%~X¿ p!º`uÇEÝˆ‹¦ñøA'äqc (B}éò‡:3€qsLöâÊ-¯ïÄB˜åFŽ" Ì.ÇË}ÛÓâ…‹Þ`éë×«³Ý¼àSe;—wélØÓ‰­}çÞµ£o÷Ð¾ôâ‹ß<Þ•›KgNLy3^[¹µu{¹<ëÏÎd2ëK;[îÝr_Óõ[NŸØyÏCÛ ß/ä½î5«öåÃ.w¾~#VéŸ5hù?Œî?Ò×ƒ:ú®ºª·³2 Ÿç‰¥—É&†·¯–HŸ2}ÎaÑàÇW9 <.XdŒ¤+fÃÝo6ÜñfÃÏg,Äð}Z|D™›ËrOˆþoI1zÝö²À 1ó³r› `”Cƒùà$§*|)Yõ²¡·FÜË§òú:§j¥±=½\4)^¾åžÞPô½Ë;™wYíJ_úZ‡jè£›³î°ed1‚¢Ø”ø¾kÄ]…^aŒLøªùM¿tNU«&$ÿX‘éŽi[³O“_UaxKs»°jÉœ,»¨`¿ëe“ ,5Øæ¬Å©¶U«êjåi“]m•	Â2JlÚy„nd(íî+—4·UAè9Ù/ç¯þW“¦ÈÈŠ]kš¢å Jm{ßÒÇŒ…ÞG×IO šm=IOÛSE¨
+¶§_å']âg‚ï1¼Íp¥ïué)tÂà¸!#Ñ=È‚ÉHQ¯ª8êØToÂ’]TøÑa²hž€gäwñwÐ;:$½­ÃÉsßjz@:ÎƒÅ9/Ý'‰Ù›w"t~x<±1]¶€˜ŒÔÝ‘¿Æ}ÒyökÀ>7œHVpùšGÂsDuù>—}\]áøAAZI§œ(][I…Í „²‰^ÖAš36vüTrúr Š@éac£XÓ-ª ÃëY{?Û
+”R©ÿ[~$,…~†yõïî¾O³-¥º5•Z(•V7S¢åÛªY¶Ú°3h‰ucÍô¶1Ém%_wÌr`‡]¶k¤²=¿¨¨ÅR¬ôÝ¶·4Ž´º¶€ö£&OçŒ-á»@ÀåL#´Ó†ƒÛ"-ä6¨	ß†lN[ý›JÀäýüÐêQIP)é5æž°U¾R³ÊV'VmŠ+hê÷$-.um‡'Ä€Øf•-ªìíÜx(Æõ%Ø¿â‰YÓý‘‘VÕ¡¡g-^Ë×«ó‘r’˜¼>r‚M/'¢&…ÙÌ/½ÈvvHW »1 êWòÈÅÈWÉF¼.ê+!5Mp³vƒYtt$]+¹ÌHÕà@ îA,õê¶˜»L3nH/Óx‰¬ ß¢ß:­w0ç˜7UáŒ2ù8ýGzP”k±¨I5RH®Ô¦NRcDÕ
+Ÿ†Ø¹Ñ‡D–ê`Üï#Ô¾åÊkcTN¿‹mãe¥Æ¨?
+e”óõŸ¹f_ÂÑÑéË:©É³Äâ‹eÍk£ÖN³›ˆÍ¦áRÓæ¢¿ÙlGqXÓLŠ+ŸÈØã>DSá»î@f‹Óú>}9Ší_±µ4U}|íN¤šÍV›üGü4ñ{4ÍcŽ·ùŠQ-äL´r°ò!Åc½2–ýžÚ\zUªÔ@ªU‹„l®fwkg~8¨º4^›\³ôÙÀv)&¤uÒ	éf4 ·Õ@%oÃEÈ^~óÃµ„ÊÈ+ R”—5ƒsƒR²$A†(ŽGøQÐÇÀëõŠŽ@lãçý<gØñ0¯sÇx¶<È6,BßÚIéÉ3DL²˜ÜYBA‹jÇ`Î~±îü·h,Œ¿ OfÀîOQfùf*ß|Ù>Æw$ÛÊ;È2æd…nè…1ùƒÆf8'ÒYAuÐ›îC3vvNw«ygRw¹Z&ÒÂØ•7Nn?=¾?Q]³mñÙÇ7î?ºöá÷mÜõ7ÞþÕ›‹ßÑÜšMÓÆšZ]Nïˆ[]£ZˆII©âévó?hÏSww¯ß¾éUO1°Eþk}dÁ,qw¹<üÛl_Èçõö„½g¨m!ŸN¶®ßž‰¦ó#&™¨Ôà…cNj‹n¸Yå€ò¹0ì+ù-š)¨|Va}@n2ÿ¢þ#oÂÙSSMû¡AŒÉ}äZfõ†â”CKŸ'/á:µKk€ÇÍ©gSR;xW3”Ûí¬q”·eÙéIzv*l*B	q‚½A…½‘n_<õÚbZjßb0abk^‹k%—¥@æ.çj?<Ç˜{	DNI²ä®6¯Ézóª?¨ºó|qPŒñôçÛ0#õ‹Ók’ÕõÆSi¥ .£Ì­¿Ù³uÝT’FV‰6á™W=MÆ¦
+0å5AØB(¨¨øÑÜ–í;
+(@\V«58ÑÞ6ä­ÿ¾Ón”Ý0¢ó]m2¡°í}”à_¯ÒPPóXæIåÅL»b7 ½–k==ÃV0Zýdñ¡qKçdéøÒÿ"Ûæ–§9ï&`Â;ç’¼Ì1ÅqÖvÖö¿rÁÈ”ÓXÔ£f²Hqá9lÏ¤Vb;PšGTbçÜßoãõÝnÞ½î5‘sw®©r‡â›è'xçî¼w˜JÈ*|k¹?*(–ð*HXFæòoo@¿ïhŸ™nïÉtlžj/¢CõŸÖßD°ÉW—¾ØÔ´iòšß¹=·-nÕ.g@Í4;Hª­þë¹±M‡&ÆûÇOíEÿ4^,æ
+=…žÖB=Š‘%îóç=g	–5°žg.9¬]zFù¬Aøƒ˜ñD ü¥þÕýýÝýýÛ7ŽLôÓ8¢kéMò&#bR—´^ú‘l¸,Ç2¶Xº.6n8—áª»ñø˜¢!º’œ!´5®Æ°/_ITÕôê>|`Ë¿t6«õ\»8[¬?'0‹.ð;uüâc‹Ô¦G6OC-+7„jAh’‡`!XƒkçM“|îáAÌ6Zªî2/—ñí»µ`ó Ø£$Sc¾Öë«³MÕ¬šŒdyìë?°þª÷‘Q–ì&räÙú¤?³{j÷´Ïâ4‰N×§{6·Bã„úsß×;Ô5Ÿû‡4_³ËÄf~pã¡ëuôÊä©Â¿y6QM¥úŸ¢ÂäÄÛWuei\	¬#	oºg,TZÜ<ÈêZª´eéò)0îï½KF¥µÒ¤ ,ÚÊÇ@t‹ÜÃù® 	B€Ø°•gE ZÀlná
+H!r*x\\MxcÁã"-ŠpÜ÷7Üsì7yßßz5e5«wÃÕ›W,ü¾/ózjNºœœ"h°ñ1Ã‚v;ÎBŸ†ŽÎB>“¦©ŒW0²á!”Î§¸Æj¦~rÙfÝ|P%bgOíÖêþôoó+•­Ö¶ô&¦'PzZ¾ðe.³Xõ£a³ît;Û¬{à<™Á	G³é|ýÇõßL>5Úyõh÷ÆóÃ¹òŠ«O’÷“÷£?ÉùÃ	O³ßÖV»‰[~Ï3ß‰vŽ®Z=>«u%3úŒ«H†£¿A;ô)ŠÜ¥ïÖ%RÿÒëäµÝ~z^H?yKZà!˜0 q>KXƒŒ~BE¬hdŠÞfÄýÝÝ¢67œ|ã2£QMò“GÁ˜t5 røœCbŠftxagŠ³¶,,«töÐ,{y²lß}×%hß¯Vz0[yÇÀ•Fí¶ÏïD5wÚ€‚)Ä¨ÏæüôŒë›±Ô±\c¹0®?•œ(…ÞÏ˜Ø"~Ç«Ðµ?†‘MØáu49›fNzfÚò‡å„ÿJúDU¡¡ØÐ›e¤ë×·uÕd“Y65‘ÕžûIÇœõëÊ·®}oëÔÿX,á@²©‡ô_·üh÷4¤f¬µ‹•ªËâÒÈú»oºU±Ã¯'2‘ŒÅÖ÷‹šnxÏ•gÒ’1Ík•¡kÏÇ}¬GY#¯b˜B=	U–l­Jc=
+Xæõ$=J†þ$±9s"ö=<Pó,[YÁ²Õ°Ãª&"}¸È¢c>ÀU `P«Åƒ,à;¡ùÐ71²è€¹lã¦u€úà(°—·¬3´»ÁìÂïØå§€ßÇ“ÄæÆ2A>ÕÊUÆÉà	?Ûrm4DADg>]~[Ž^Wç¿qªgõSóÑ©¶Öc_Æøñç¶mr*Mçð„ÅFè5ÂT/vì¡é$àÌ¹šCË@UÅ3ëö¹‚–ï{0þÒ÷NøÓŽ}w¤rG'CíSŸ88w:•ªí ØÑË½Ë{šVatM¬Ã¡ºÍŠf‹õ6y3ÍkÇ„:™PÞ9ÑK4&mŸY±hZ.±WÆ3T;îA*N"þVS°êÇ²ké–Sú¤ÍÎn@Ÿ¦IRQGÅ|'÷®Faxß€¸ep1 UvÃót0Î#’Ÿ5®÷pIž­á¹¢hï) *¡ÿŽWñ£>ìÀ'ÿÀ$…‹@ ¬û•yÞÄÕÌšôEŸ nÿ²h1²»ð²Ý`ò Ïú.¹©sc~©€t-ÿ¥Ž²ÍÐ½¡?¶²j3o¸æZ>oÐlx¾ØŠ8éj ÚÆ®A¨"‰RUc³x¸å½< Û1¸¿¬¨ù,ÌiP1	{}ÈeSÞÖþ¼¾þTOTˆèôçUƒ¦ˆ|æE
+»ÊÉa6jŸ‡»ÂŽÞö¶Ší–ë>2‹ñøYào‚šSs-Ñ®@2$kŠ"7Õ|å¤5êîÁ§§§+ÌUìNdªëB¡¼{÷aÕk]hBv›<‹÷œTÂ>_TÛ‡±½©½,È|_¡Vc?ö¢çÂèÏ§¬ô|H³k4Jr·„R5sÈåÔ†{}­A“ÇZ$[÷]á¡ú?,XKð*Œ»Så®©.7z	7;êEyûÝ˜þö¿‘lfpµ«É¥—iœýà›¥k€‰Éö6`Ò±¿ç¿[«ÏQ26xP·ŠÍ ïF–,“äa,Òçöõ/X’Í"Uàs(3ÊN`ÀÉXä
+cšU¾W\¥#ûTÞ|é=°)Ý­ôdýDˆ¦6kve¤bõY­Ù³X˜o•í–°	©-}í#IW»Ø†Ì²‚™Ü¸5æ¥eüCƒ·ô¨Cóë¯mÙùù}M»Åì±?ü>Iˆ¬ÊQÅ,w­s¶„B­î‡»'}ØböŽµ–gw—ï¤Ï±(1ç8µ†ƒók-Aæû“®^úÙL*ÔRå¥ÔW Ïc  6±+â1œyE_²Çp<®•Q­ˆiÞ‰¸Ž†7.þ‚÷ÿ¿´÷€oãºÒÅçÞ;è H€hD#Á V±‰)RTïÅ–%ªË’eI–‹dK®rÇ%vÜ§9‰c¹Åö&vš“8‰S­$v*S6Y'N6›÷â”Ý—µ¡wÏ{‰¡"ïûýþI£9ƒ2wÎùNûŽHê‚,0ÈÿÀU@s5€ÆdÁZïi¬€Óf Ét¶ÞIþ#œ>´Xd@¼tuð7Ôå%;c>6Å§z!ÐÊ§”¡@ì`ñHØÂè¿tu]‰<.e¬w_¢W+¯ßebÒ{%Ðj8Ö\wj]0®PSå»D&ñœ}•ÝNõ¡ø½ë=Hñ4¤Þzí5ŒÍ–°êŽØÖÝÛq_gqUTùÕñº|½2N~Ò5²\F¬6Iïª¼Mˆkagg¯6qKYµÒ‡­ØµÓ;tìˆ‰÷+~žœ!mÔ€" ÕÀïæ<Ë^ðÑÇygÝÎ*tœËnƒ:‡ÇDxd(¾‚½(ë~'˜W·!Éâ‹¸Ë7¾)µç¯	Ò¯\3ïŸPXWc•×ãœÏg{!8-x‹ #_DJ‰ÃY_,b ‹Vã EYÀsh7è½lVoSÒk`ÞiZŸvZ®òk±.~ÔÆéúaåGy®9
+‚–0V™¤R\À@xuÊ)ˆøå_þèU4^ùjeã¸#¬¢Ÿ•ÖMGO,{×Ø/žDgÇ.ŽÃ¨Ñu¥ÒšèêƒK®¸û>“Ê+¿c+*XT~ü\O_ó/·r+yû;„¼û2p‚¼Ê}À
+à¥ëï3èy€[<ÑLô•Š¾,»Éµß%Ä–Îêo#ª`|d„£H½2DqÏ	ª×CÔv‘¾¡ƒ	k³ó¯ šA§€ì­ÆI¼€ Fù¹,ÓQg(Ã´)‹ó7\hEô,Ã/tfî"Kú	!GÝ.µp¿©Ej×­TñBbXP·¾n58¡´Ë¿ëÐ BÍ‡Lï¼6ð¹¤µªq§(þÈ®9’€0ñ×’l¶žæ†UŽ·?ù³I|ïòQÙH|ØiõXmnÍ—rZ½&¬Ê¸Æ]Ôj÷(6›Är{¨àïók©IÄM¥"ÛrI7ñ«~¥rí–“©äPCIYœÈæfÊÇ?œÉ,ðk¬©|î¥ì’è úŸò_£êÛß#5—ÙdÓ¼í!wKÉmÓÞîÍv§l3Éf"·†4nÙœ°F}VŠÒí0&³FmN$&7ºt»ß~î1rŒ®né8Úú]"ëyxB×5*‘ñláE«½cµ²¨lÏ¬È¢€4o°LyÃ
+j7¨Š¨a5½Ó(îvÃ*3Väç,ÕÒ"úYŽ0ˆ
+ïŒõgÃ¢#Ö•…Iœx¼MçY•+Û®æÒg¤Îj‘È"»2äb`Ò¤€ó ü
+ò~*ïçÇ
+üªÏçbÐÄ§ÍõfÓqfèÔŠ‹ñÞôÐ2Äª&½ ±Öœ~Ôê•°ó³Îí¬™b.aHŽ™(0D.'‹õŽá`0¨"|ê˜•O×[Œ=7ÄŠ¬Ú”èX+…•$ÆÛÆ"KÀíª×RqWæÐ‚ÜD}}³ÃÑØŠ‘».5dºI=	ÙÖÞÝõ™µÇâØ¯«Ëx†7Š‰Êýr`I±°³8s:µäbª­p½å¾žu)„&k›Ý„¼ýRk­ÁNGË–Õnv¬ÃeT§Ùå”•ÞÓ7ŸÐ1†‰^VKÍ%1|ùùåV_ÃOÙs_"²ù†éé5=  —
+ænŸ­¶Ø‹U+V-ÈtÊÀÎ6ân¾€Ñ2’í%³PD‹¤¤ž3†_¡¬ €5µBÒéoôÙ•U²ýi1¶ò&¸4ŸBÕÐXƒx{ªÀp:jæÑ\ÅÒÜH²‚â=Ï	"PuURkª ‚AoøKúÞ>ÍÖH(‹U”ÓÊûoA;C1õtå{^
+f,ÁR R¬*]"‘œ+éí²‡"ØŸ´¯lË¸­³çŽ\cú>rZ—[û±µÇÛÍ§&›Ínó­zù6,9¦žÕ!•aúþƒ2=·Jÿ¹Z‘¢ÙïtÔYºr®¨3#»<
+±×š{†úåÛûè³zãCÍE—0Ó!ªÃŽ°úªµrz6qº¦$ÿú×KSlßÍ³ÝýÔmÐOÝý´Ñ Ÿ6à‹otV»[×;«xJE±;Ès,d8^8È Î)¸áµ.Í?ø¤ž/Jp¾áœIÂÆÂßó[  ŒX˜ßÄÜ’=?ÿSR-	ÐëÃ¶õöRÏÊ´	ô…v: vEÓ‡¾ÏûbS}PÅ©¡g›âÅB¢)ìAŸ‡›w\Fo.}|1]9Ã3‰šriÍ²®¾byÍ²Þ^th¥Ñ«^„	"u Lr8.Ç3Ø?Ö”H4õeZ—ýŸš¦`0ç;A¾ÞFQÐ+w\ß×ÛÕ·iyÿ`w÷' ðøû,ê—Ð±¨Ï¤FO®ÉO5”»±à€Íòxë´]èµ²ŸÏ{?vîršÕlÅ) ^)CïF‹x¾†¯}õŒP'E7ú ¤=Ü
+2gW¶Jè|áTîÂ‡8‡ÑÐ“¶"‘gª²·èî^: 2 xØ‹/XU"ÔÁCQ-\$êŸED¡Àõ‚®jxW‰®=+Ç`axAºŒ£þiþ¥h2è`Q@áhå6˜o£c¸ž¿±Ë6ó2§hïæ¨]O<t¯òãj>ÕAÀ\Gøzþ¹:Y„>®Ïc!Ò²þ0L+»J|Z•‡y…<pÈóz
+^Sy¬ò$²‚¾õýÞ*o^1™p«:\¦ó)™Ãé§d€t0uüºëyƒ?Ö~îyøµ3U5âõÖ)Ë-v…Ñ¦§0~Šþ®2Eð-ñ6«ÕcBš¹Þ×ë„óvÅ#G·ÞÕ³-“Y’"±áXãæ>tÖDqlù†þøâÉñ(ºþf¼ _~;ÒJ²_ùòw1þVn"ÈÕ)VÅ…éÎÂƒÃzÝ’‹|
+QòIYè¦HÄ1¯^ü,çÃƒÖ!ÑÌ=,[ÙÈ[Sj¹JÏyí"P$j„Û`MÔn	¨úÓëÉ9ã‹h³Þ`Ž`Ò0¨¤œf´IÅçOÂ˜.×E>åO9ÿm}qñ½Óc-è}Áu§…©Û*ßZüðQPqü¡áÊß*oýy~]ù}áö{n/úÀg¢Ž¶¾ãßüj’Œß9äVL¬åsgØœ,ýrXŽé
+é&ô
+rCs“D¬A%îK•ùr—¸²-ñ%_6ÜûðX‹¡ÇÎØ]Ûb¸ÿµp¾n~^‘}„ ­ W“¸%‘÷;È¢`2b°(¬ûç¬þ¾ÅØxì¸ß7ò«ždñýJßÀy¸E ª‹×~âé—ðÉöÛ¤elïg£U ¾ºr†²èƒnO‘<ƒx°ÀÖ ‹x0P9ˆjN‡È¢þ	8ÁEÑ+ÈÇÏêdÀvcTHë­çùÒùTµ
+SZZò„²nåRé9—¿3‘áóG“B&•³:òÈ‚¿œä©nO™žJëMê¬Íò«?ýÙÙ?¤»½Þô¯ó‰|;µ™¡ÎÎh-Ô™Ä•µx‚W•ÇÛÕWf±ÇO’ç¤éò¢ÉÜÒ¥¹É©ü4ºñ62ÅØ£TM¡Û*/ô¯Þí¸vÐ°ŽïµOõ?¤Yåa·µ±¾.¤Ü«ìÇx?<ãél­ÓY›mõPµs®Ón\ê¯ÜØXò¥²¯U±Z&$×‰ä3ãQ;:±"æó5:Ð·1jï]âõFmH³*ù¸n­~ÆX‡Ûu~Ã>Œ)V9÷$™ ÐMæ¥úg-ÒtHˆ,h†J>(–HÜd˜«ÑÓ:?!º@8ŒŽÀa ‹:E´R3XNÍ°è@í&šSà3zg¬ÊŠªH-ë¹oà±ó;cBû§”3$ŒD8ni\Â
+Œi~EKÇ½ûcÌpùt'Oð ÄÓ,´-Ê2b¼ú†1Þ›¥XžIÐ›EzùpBù,Ú1(W’dBÿ…¶‚…ù•ªy™ÅÝcµ…PŠ´5Vj:–Ø©
+¬Üál…Zí¸UAƒt±}ë[Ì1¬¡€þÅ/áaÙç—oY²‰xÁŽ?7†Wäšmõ6G›lóÖÅw´tX¼æ£"ð«•$Ò<¶§|êÄöd]]D«u5XÛeº
+zÎ=Cž"fÉ)Å¤~éVéuKè¤ßå¬bl…^ÿÛàZÏÂ(HwÕóä¸‹ÝÚ’Î	ôŒê%8ÄÇ $®¯ôŠ
+(Æ½&)gµƒ	dã¤(ø6NYDs†å–3,·cT¾fVÇ.0—H÷õ3Š€‡Šõ´ö"˜ð=,JUè3$ËÉjS½sÅçŒúúƒŠT·buÂs.¤?Ý—6Ìªõ£·K«£+ÿÖ¾!7=ZìÃK_xÏò]—dö.<9}zweQr"?0éMy×Ñä"ùÕñøTS¦×3¨ù°ê@Žzë±‰¶ V‰¬’ø’Üš ÀqE“‰ÕjR¨‹¶{dK@»5½*1ô‰=}§RcÑ{ËcQÙ$×µ&ÖâÅ÷›Lµ¹M5¾b§ßdÚ4ÔØL,›N;œÞø=¼›fáéÿ×Õ-[@Q.'bI®=\kÒXß½"[Ì*†‘@ŽTqQø¨ÆXAƒÛÔ¦­&™õà|ŽÍ1ìƒÊäÓa&PÌíwV=5Ñæ)Ç³¢± ÚÆ¤‹Øêú`g€ 04ˆ€.@Ñ°×«‡%½þ ¬(Ÿ…lvŒ>f†ÚJØ[è~†ùýuÔfîžkÎ¡Œéˆd6ÍVk„CØ‹ È"6-\ý³ó»;¡ÿNûAž‹‹Æç`¨‚–T	Äçêƒ hÀ@ï¶–fhåy=Ú%
+ÚA_1 ç¡XÖK/-*f9×ó›,6³3UŸì2×9P‹wÿôjŠ]ÓM—…vO“@³kcc›l5YK[mQïÛò½wnxºÉîPÒô€9äóF¬È­‚éYŒŸ¿L–#­h:GTl,8‚aw¨hÊhi°“ö™K Ãõ flÉ€¯˜^°5nõX+g€öìúˆj"ó}P†ÐÄ7
+k—ŒÆ>óð&_èwªsXsî	r%]O“Òféjéfé(Ækç@è Û/cF½\K|õ°nDX"S•Á R<Y8B C ì¯h‚kèÚºQº†—½és×ŽP?^¼hXEƒ6ƒ’Eã´5hÜèíATcÍoî2„ÊEâµh˜sß	ÜµÈ˜û Æ³áPzD‰§Õ‰‡Ù¶ÆNTœ9 >Ig{i„Éá¥Î2ÓY?)qÁ…Z*ãBZÚbW=Q‡­ÖL¨¦Q°=îkn1y¬5vì×ˆÉ²yRÞDfíŒ­ÐÔœ·|ÛÙ§"¢šš‡Ì^B½Mª‚k,%ªà°¿áøÄ!;jBÿ|¿'ëA8èUþtÖTïr…j†=öè!J£V£¸âW£WuX‹ìo÷·E›fµbLæ“M‹£)Ð¶7DØx€5äEÜk{Íút¼‰~îÊU•åàJ·¢—ÐãÈÔàëÿÐÎÊZ7]}6k61^÷)2D—î± í:Æ\ŠY|b@ŠGñ¿Sl‘¥:k™´õ&'Ð69ÞŸ	~¼ˆ ’Ò#ß|²³^1¢Wpláœ6º>t	½Ú¼—Ä‚òf9:{á°{Ô …¢[å¶ö"[7âœÏ‰n`EûNƒ„S)€i`ÕY,êE !^wp ¢5o øy]¡¬Ñ8Ã™“Ð‰?£å¹ª'½éœÕ7c›Cå³ø™MÛ57t×e¶®ÿûÿÔ2šö>Ý3tã±7Gd}}Ê±÷¶Ø¾'z“ë‹ÅéÀÁ'§ %Ã}¶ôp:™É KRÍÎxk­ÅÔVyãŸúI©üæH²)’^>>œG@±“I™.\16?Y8÷4y”hå¥‹Ðµ QuÚú•†¥ÞÙª?‹*Â!*D¿Áe‡Ÿ³:¦ Ôk¸x ¬¬×Úéû­b$€t6¤>®)ÐJZx´h‚gYtBÇÌxÙf³ú›8?Šñ‹³Š£Šº<°u"DrýÙ¦®7å‹õÿ_äU‹dÑ§ndA€.w5SÕ	iÅG×_ÓùhÙ´G­¬gh t	XJè¢dL|¬#‡ù…qˆnQÝª/Ö˜Žä”B	ßS1î‹1Rrüóç*ùÝª™½‹ñ›1%÷žÎ¢[b;GG/oÝ‘ˆ.È;Q,[¼aßðò'“7‡†S©~åcà–¹r±X—õü|ë{»ÐŽ;ÛÒØ¿ õ[ä*ï*¸‚ø#„àID¸žÜú~ª)÷¾¤/E\âÝ_ÊbºÛîÕ:Nk‚z]„×î¢+s+ç'Òês_ W³˜ü¨t¥ô{ˆÈëuºxÚm7‡éÝ| Q-[±z€H¨¢ZgÕ#¨5\TX…Æ‰Š‚ç¢åêH1V#`2Ö²Àsø
+^"\HQp	VWÐÒÃë_«\Gs:ƒùÆ¯’BÒ°ž—žÏpÁY¿y1&k£ÑüPæ¤ªµ(>PÁŒcHöUmm¼1«ã­=‘3Guæe%QôTÜ£Ÿù"K¤¢‹úz’qôA+ÏQƒ.ÙGqñ2jôj¨ëÇ†SïƒHf°¡òMGÂë]ÚwlÜ•5âJõÕÕå˜©TGyÝ¶Bf™=¤W~G}Ìlqšp{o¢\l-÷N´6¡	ÛB‹sO{¤=;Ñ`®[<ð'ôZsŸË4øÕ«ïüajF–»l-ÔVÞÂjîu{ÂVBÞþ…òØb²kÈl¦XkÊÂÅNWÃ’Îec£Ýëf:Mnó¢PÀf¦o™þÓ×R?õc¼Hyé¸ô%àÃÑ´WŠ³}_K‹èÏ^£Aw	~P ÝdÙ_ W ª²N¾ ?…Âã™ž¹pž1À –ÏÃuˆÇ ?²Îª÷hœhy;g«-„;Kh'{SóR8‹A:îÓó("¨Äi«æfÉ§UQŠ`(‚›G;¯ãöR/ªNŸK‹ØSÒ—Ž‹$p¿1˜¸¨wßèÂS‡rK¢—|å¥ŸZ¶üÉûïXµáÚÈè±ÎÃ8•˜xfÏå³ûG©™±‘D ÉµuÔ³Q?NÖä–eËì~EÅÊ_Rï‰Ø£Ñ¡¨Ù4ñ[O¸fÍÕ)tÙûßÓ_°ÅÑŽ´×Ûí`[¦]ÓühX½2žŸˆ§Æ·%,Ö+ukŠ·nåbqc³Ja^ ïŒ¸”P·‡\àeš‰[ÃÔóDÍïjìñ„‘î¢2(ûË¡ŽZY•%fúÒä~®—²4.=ºgˆgƒ¼¹*ÅC™z×ØùayÍ€a1¬"HÖe¡SOïàã½èc'ë4(-EÒdôíœ[1â´˜›Î­W­è„Õ :ÄpTœ?ÿiY|uñØ-õn(¯O¬úBezàÎ•áéÜ;åÚ`Ìü
+¤]¡¤êíßØxlfí5ƒ;›Oî_}òÖÕ;±yu«×³rzKšÂß¦ÊaV˜2ŠÑUíŠY­WŽšBêqÕ„ýÖ+06£÷îîÎ9]Åë—[³Ý€UWS_hÕõzûÍHÇ¤Ò¿ëcJ€lwÿ,0ÍTúµ=n™ÕýoaÌ/wV“âR¿—-ÓG‹[ŽÁ_u¾U	þN½ªã8ŸG½Mº˜í£¼=èrÖÁ«w×
+| ²ŽnáåJ—³—¿ØY­—m†Ê3Y^øÊ¹»9m€Ÿz‹mjœ»4D”3_Ùç5ºVs´§â¶†çÌ9VúÔéB²Ì‰G+Ó;ÅÌ™Ø.	N´eW—mŽ®ì,®/›X³ø¾º÷h÷Ò»Þ½dÏìžKM2’5ÕÅµÚê/Å½‘Ù¤Ø¬‘‚·µÞÑP£újzÿ™ìÈäPãB-­uƒÍ+ëÞD¾ŸCuÓzüqÙNT>úÐž=ø4;ý=E¿I5™j‹+á‰Å¡†z£L¤£5Sl&d’‘BÒ¦DÔÝ\oòÙ…Vw£Ãâ´Ê“
+ÅSôWˆ'jÛš ÷þ v+©7û»¢û*?S^üî:uõÑõžŸ=ç>NV’Vz‡Å¤ér¨JÒ1C#×û.Þ2g¤›Ö•èëEˆp\îehÞó°ú2ÝŽ›¹bñìz=Ër	«>gÓ5ðgã _°]¨ò‡ÍÉ…ï]15ÑBÇ±†Ô¥}–þ‘SÙÊ·ÛËWìÎ»/=Tî@÷\=XþË¡ë–£_+ª‹TÖUÖ÷J<ð"î?[²U®8¹lË–å§N-[»f°~™bý§p…âª(cv|ŸúRwðo£Ÿ9yzOŒ@5 ‹($b}<¾I šµÌ.z9.×=ÆþÍy?*[‰øT»áÞi7À­w*Î‚øƒðAC×8«1¨¤è^ã·EGÕ¯•ÞAå¿o„ƒ×Aszh@‰‘î ÆÿOO†ÿÏò±ƒÇo¼(º¢pãuSm«ŽM½gã¡½ëo?œÛ³×š§n\ga²®vñþø¢ËBg¾ƒÕhÖüúÀ¶ìNªa´™‚ey¡W1õ¼{aåáþ÷N¬ïÖæ†,æŽÞæ–ÚÆ–­kÚ“µ¾ŽÇ„ûFÐ"=¬X•€¶‡.q´%äñ÷7¹R~“Ç&oŽ×Q=;Ìg/Î=É8dj©ÅºÜ&½{Ò¢ædc×šÈ•€,æ¥Ùw€,,Üzù ;)1EaÈºÎûÍ<Œø›ÕJóD»b'z>Â*–Êùjüþ	ê¾Y¦ÊP\†Y™*Šø•_â`÷æ…±ñt/½é±jÓ°
+ÊÜ„4ÔÇû–nYì2U
+gÇV‡(&&rÐR9Q¦v½qlGqÒÿæªÌPRv/<uühW ÝVè9¬ÀÓè9­6gÜÛ}rq 0{-ô±!„tÔçÉ#ÄM=ã²t%ZZíú¹ÊðÍ‚W5‚.w¨÷ ý¹qV×úBs™a€¾~¨Ä€½ˆC.]$'AÖ™ð~4(± ÃUã®·	‰Fñv@öÍVqhÀYõq] h@|0Ü{Ã½÷˜hC. Ì…c‚ðÑ$iûhÀ5±ÏÞRbQ0²ªÌu(©4s[çê©}¬Ûfdø½zt¯¬ñûT/«æáCt1%p¬aYFÄÈÙ«ëß<Z¨%+Fv—6g èºÑVñOV¾pÑÊ¡“'‘Ïl—Cè{Í}¾Ú¤Ë
+á™bq²î†ïm¤®’òFk¦ŽÅ5ÍâÐÖ¾ËßèòQc„¨sR“E“|ë#ŸÜ9óñ¡»ïVÜƒýËì±Z™®²E¾i'”d{”¡!ç	yæiÙ~È2:Ù=ÅÂ×Ñõ¨æè™Ó%«Íî5mk7i.¿
++©D%æˆ7Ûc®³CÜ®S‚jÜÝm-u0‰‚*ÕS§™â×¤4%í”®’®CW Šíç€S×ó[YI¡ÎX"–
+”
+
+ïy«A=ƒ,òšpŒh9ÙÈ„"<_!û{‘„ù”èáYG×Ëu[]Áyc|Äß·%>Cq†Q`Î°äqÎ§à(ÙH®sþsÙpF‹¸È"nc¤Ê„ôNfýÏdÂ»ÂYeNùª³\58õj¨8qv~­Kß!ÈQªƒâ´´îª³7k±N¦EŒÜà¬·!šÇd‹¡A3_N²d‹±›÷þk)ší
+ve‚¹¶Ö`µ+Þ®d"g­<E—òúCM÷ãk‰žý¥G­A—P)øj@ÝuK›V¬HOMû2µ™gr`VªßÖènAÙWù+h>ðN_šÏìJ-»«÷CG÷íº
+ý2i7i5éˆÍd²¼ýgü'hã\À(Ó÷}
+æ6›©lj­SÆ±ÍÈÖÖÔÔŽöÃÈÏ…õ+zF9·õŠºú”]³Ê~åàaGÀŠÈ-ìé}@¤ÜqÃšç%ËÙüú¨”“F¤	éÓ°Êu'_åiNˆ’vÎ§!i…[¤'Â)7 À1“°rÙYÁf[E;ƒ¼IçñÑà£È"ÈLDtd½ôŸ5tŠv, Sú\ž¸«˜êLÇx’»x,4m¸Ü8’ÊŒ/jŠÅ›&'š££z6VõÆÆ¬Þ2¸à?"OÂ<ç•ï5o)yÚB0“£ÛœšúèèG÷¾ñ J¢ÉX¡K´Ä›–e[ês[W¶7å;ÐãfR/W^~û?ÐóÇ?Ò<ÝA*o±ñ‚¬¡D.Æ>
+¶‰Ôwî²“õ‹¤£Ò+z9Í1~“ˆRB Bø2 v23[½aß)þ–1ÜÀÕ^à¨×˜]•ô_ç`9@öÏÎŸq!`>È¢¶dÝ¥‡SKRŽ³d@rJ+ÏUüU¼ŠâŸ¢SŒ˜}ªAþ@©\,ç«™0Æ ¢³Î‘tíìy-òòpÆj¸`ÁÄÛ—nð÷mŽÅzƒ.³>€üÍ¡ì×L69€¬SveT±jªMwµu[üÎ¸b"Å*j¬M{-®¦¶ '©¨ŠÝ—§Ž”¹ÞÇ(à:qPµÈµrïB~Nzáýjå¥Ê§•ìÖba:°üH<Ñ[oªtÒª3Ù”øúAKƒË^oèÎ5k.K¨˜5K"Åïˆ¸êruÝ×÷ËŠÙŒÍf3Šç'ëÚ|}ã€[ËR„ú#_b¬ŸÿT˜GXô6åfž`2–ÄZ‹ó«èCèÄ
+Ç»fy==,+ˆ½1&r––×±Ø	2[ÅOðb"ÑaÌ@â…jY»ä¬Ž‰õÓ1ç|\%Þ`ÀðazlžÙ‰T&P9 ßÞ“ÔøÒÄjª¡3‰Wï@¥}º‘ç ¿…ñ_;úº“„üôw¿«|ûžÛ–wmzá_í_o*ÕiGG&'¢ãaŒ^,Ë£¯LAÝÃéÃW>®_+zo»Ëø[m[šAa¶w#TeÙNoo}È)êc@ÍsNºXºAºýHgú¹–ÕÓ4;¹Iðp¨øú`°3bøzÎ§ô©0Ë¢¸×8âášeÀäŠ ä¯sú¬>|d1r`ÃíT¾ËwPù~Ì=bJ°Ž­õv¶;X#Ð$w#Ü§Õæ«YŽüi£Ô5ç0‹µ²qn“1ß$LÈ/R@½ÍV×
+ä–7æ™ „(R]†/ïòL“ü‹ÜhøA€ª¤†/Î8K¯„qx•ÓœŠµSo€GÃ9f'>7®^]	V-…à>XüzˆÏB,ÙÏ:˜úQ|Î¨Á³Kôœµ`YŠCó0…zšÜ½x&Ô:9ØÓ@ˆ}0_XPƒÜ÷/úsæÊeh† Ê™DÉëMy¼Ý©TÁ±÷+OÖÖ6N·.Ø.d¶´46¶Ùb=Ÿz7€js<lwÇÆë£ï×ˆŒ'»l„Më01ÙeWüq&è,VW8µ\ai¬;@9Ž *‘eyã:8Ój†àÑå0ðA¥ÞÂ%ýùC,8½€¾Ó‚µtÀæc=€Æhèb¥A^å]u<KL5Êxp“JNôWØŠMŠÙé&Ñ5¥Ê›mþ˜™å1òç^$Géý–z¤u0	=ÎãXNF‹N$<A…{ao”– ÓngL¿SOe‰ï”sm˜å=–ÀH¶†£õ,cûôž“ë·XÍ%g5ÓQÁ]³„~€ óá†M-ÕÌ½[P½Z‚œÓFŸæC8©^#D—|³õé‡%;WuR%«ben:a79jáÁ–QV´Øà·ß0w!Z²zõ’\­5ËeB29ëÖµu&Ul±4“ëgvÍ<µôøÀ©Ç§«=šÌe·ufvôÊ§2Ç–/¿¢	©HÖZqÈüöCõ¯EE~‚ú0:‰‡éù~WÇlš¡5É&ƒXSê±R¸ÿÛ‘TÜ,®Ó{îò8i¢êt¥tJDIŒQfbîªCDS‘&Ø	ê;I’Á¯í†t>TÛ#çü”¾1$¤#$8%‘†X•Y‰KôjÄ"(îbSåèýªè9h•NÍo£ÿríøüY:~`ˆÔ¼Zu&y¼²«“Ö–ÆXJùzaúÁ©òTÂ®ù¬nÓ–Íým&‡Ùì4å&ëº"îlHÓLþ¡ £ow[.d²«£ô:Um\2²Å™®#¨ã‘ß!àzS¡n_~Bq¨qÜ•°6x\Ö¡vg½Uµ)f…Tn ÿÃæl:]t¤ªxe·mQ¡¦Óo­O²’3øÓtN@.àVKÜC€]…Â_@ïœÕÙ÷áž‰B½)DË‚Ùª…ÙóÝ<÷SÇ¸ÀÖu´°ZTÝ2ˆë£ðëóN­g!g5‘sÎwp.Ä“Üâ¬ÖÚøœóI‘¿Žðaª-kP‹šž›²Ài~ÊŠh²`u“>½DÝÇ"/ú”]]ç“3Öm›s¹©ðÔ‰Bas¦içÐ‹•ÿ”1ê»¨òC7–~‡´âÆÌ÷[ÿuÝ‡†ïèòÜàÉ¶/ô[	æ„&:3ÏçÐÙYúÐ ÕçW Òz÷JCoßgAÇÃ5ë–)¶|/“k¥ó'ãñG…¼ÊÑÄÎ"
+³ó‘œpáÞÐ½ë„—þ°<©!žÙ™Vu¹a(‘V&O…ÚÝ§o»é‡—oº:ŠÊ•[ÍÐÔ¯Üì+•LèQÈWZMšÃDÌÚ—™ó;F¿€`‹«oE]}w¬<dÁ
+ÐèáH‡·tQKfu›«=‚9N{‚\Ájæ}ÔR\„öBç™]0o¶hç|£kx_ã oº€p®ÀÙƒÎjKÎBçüð¢™[¡0U—
+dCˆ#**"†/1bXˆp¼hà Yä@ý‹B/è{]k ‹òÓjè_ m`/âPp>>«¦Z/qþ‰)n>E-Q¯}\ÇgÕ&`—áÎƒð€¨dƒ7¤c{V—ïó+Z90›‘F!4wùu“£#j¥4¿â›c‰@¢A²œŽS3¬kU7S’æJëOÐè8þÇOÑ(]ÿ‰öPÅUyÁâ2f
+ù-i0bwßRùÕç%¸òo5½£¹¥Q[À‰&Íl’/µ<c”CŽ`DÁèÕ–pZþØÇÈ8ñaìEéÍ™ß¿ÎÑ€n§ç7YêÌÙbµþˆå‚®&Ç\¿¿KUÌ
+¦Hç½rƒ©òÖsqŸ²oÃó­kp'ýª•øÌ{¯û|¬ÛÏj]ðÚiý†KÒôŽ™xÛiŒûye­ic”ùÔ…‚¼¥Àáð8\OødÓ¡¯u„Çm¼´„|	œÂatÎ-Æð™þO¥È0KPóL>ÅÖbvl¼£ÔÑ±x¢#¶Èwvß¶ö±z${B	ÓÍ¼ÎØo!x
++–Xså­ñ…Û¶LŽlÛ=:ŠÞZ˜Ž'ÒûÓÉÆdeôŸêˆÔz¥òÆžç‡0:ŽºÕÊOÖws¥Õ[{Ëå’>ûë%ò>GíIŒÚ¨	„ƒûÐ-¼½Í¡DáÆÊ†ïuÆ ‹ô 	ýšÓ–­r·HÜìæ3^ÎïÚ2^dh‰1£ßjP­Ea$Èm5X©ngµFÝX’Õoøã†²‡XG¨âó#†åÉ SçVªìaƒÞ[ åSX¹Z‘y öaÕð÷Ÿ«üå·h…·?“WîÆJ0ÐHQ^ïó/hÚFaFn2ôi4…¿ÏØãµ™ãƒ·LÜòêú;*?¯ü€òéñØÐ}Ó>ñ'ðÛgà²ï¸	ib±šQ×˜>©µÝ{ÿžVÀXnEÞKú‡Á,ÜÊ|ƒò¹3Œ‡ÃJ½Ó)éAðÀÇØ…qóx¨ÞtôÏ|–BÃ›ÞÜ€r^1±=KÏ©Ï©…gN‹šMÈCMòÀŸ÷uféJ4±Cá*C†ö‚•Ò÷ÚkéO´³â,Ms^•R5!;Ç2Ë‡cª¬,‘‘9Øò8ÌìX¢=ÿ¬DÛ^:ƒ[›Ö·Ûƒö¨×Vo£ªJµÈ¶ËÚè·ÖZ(©ºVo§×jY¿â;ß!µr½V¹º2€žAß6¥•zeðþ±J	=I†1Êk7ŒÞ¸f]¾&`OF¼¹°mæ`‡ß‘òY<–¶¨·£añÒÜŠPäbX½AŸ”¥Xñ«RJË¥g8S7k¸Îêf«:ß^ÿÂ­Fy!°:
+Ü²ßXô4ÈFR	Q5˜WQ[ÝÊeÑ7	Ñ¡ÙjF}Èp‡èsïÓ©¹ÕŸ§V=Ô>'ÁteÁM¢U¼ÅL/@s ò\pZ4.²ØèÜ‰l¹)·ø½K‚3Î–PÃ’õÛŠ¯l¿4¼«òhåéõë=á‡,7®¸DÆ&›Bá}cÜ„Û?#WžŽ.ËåÖg¼û¦›ÛV_ö„³Hçcc…F¼Öù«2¢ÎòeŠLLþ'1¶[Óãy›[SÍ²Sû8FkØ€!Ò¬NZi-£Xé*zßÔHË¤K¤kÑèÉ"/Ê\Ëö5†¤îsÁÝUä~%å ‹Žèç‡y ;¹Ñ*ØCvÎ$I ‹IÏ _Iå+¹¬SðëÏ;	wü CãnãOgÞÂ œþDc$Swþá-#éæÇå¸¤Oùˆ!ÃÚ Y@²êºÐ‘Žø° B ¨¥×!E@Z™“É(i‡>©´¡^i^!¢îÛx’sQ$_\ðÎÔÂ¸Š€â<Ã‘!Õ«…P­×¯•€™šgÅ VêàFµÝÉd›©ò/ègèdåCt9Ùí8èr†6Ÿ…hÄnsõ¤»‰¢l‡fâú-5å”3•ýK.Š=ŠÕìw'¾HèJ'hÙÚµË°­!ý$äšB˜5©‚¡%ÊþwƒŸ9„Ðn“E¶ÚÛe{nÕa
+yC#q(g¢PJÑ,2iÛÃœ±<Â™!-dŽõ7÷v»ëÑ3æZÓ/þöR„`ªv~C½Ía¤Ž=ïñS_ &=3pSi¡ÓQo¡JF–fÎ}‘<Íx¬Ô¿é•¾ö¾ÈUpoÎx¸²q®4^ôÄÖ4<L)Sã¬FƒYT56p3\äf~î‡ÕÙlð®€ñ¡Ì1‚Ì;Áóœ‚N& ´¶ëqLjÒŠæOÒÃò˜:úb,{å¤'®‰‰òÂW¡•Y‡…†¾Má.5–!t¬ëöe££÷`¹.Ú@”-w£ž·#ÆVD„=Øj¹½²µ²’¯w]UÄè_‘ï¸U¶ƒ*¹üvYµøLw lF§w= Õ/é,mjú‡¿Í®˜äså×O‘géIÎêuÅç^${Øœ‘&i¿ôœ†jÂK†„ÓY]Í0²Íê5á^/	×ÏVjÀÞ
+·³Þ @5$ÝôÅkÙŒpx4WA¤!Å5D_ ¢­›îCLLÓ+“b‘øõi2!—e\u­ì#…Š)69fŽúìBfyîVžs~9«£>«f²Èž·ß‡H8OdòÖÆ{ºfDFåŸÞ°.M]]ô§>Õ¦9ê,Ý9{}lQ‰Š]ma_GƒÉo'26×¨ìOÙWo¡·¿+¶` ¶z¼›]	÷ úA»I³Ølò½ô®&QRgy£²_¾
+©¨Óõ”ˆD
+¾¤UÒÄ­ÚTSšî†R*_jUú¢þ6¿æ‚S*VÅŠ‰½Þ:tzY 3¨ªfâ‘U«ì÷¹•–dbUÈê³ê×ÿÅ\G˜_³PZ)=	¥%¼ÂB_øaÎ"ä¥n¸…×æà	ÔÝc0Û`ÂOçB	8F4á…ê»Ç ²áu£< ßzÆ.sS¦wÑô°x á"›¼B^>jÕG¨R-@ìžhžZÕ,z³ÅsþhÙ5W…€½PP¸øø@_¨-âèêD/›è¥]DÀg¡6wŒ)M‚ìÑÅj×@íK ]9‘ìØ¿®#¿yëæBÝQ»óH´gE‡oëÞ]èÏ@Êóü¯žÙ®Ä—'Q+®ü·+b_ Óïú‰­ÛoŽ/š’MÄo=ù4F©ÚÍT£(•ŽLm˜ºüÎ‡§3ûÞ{îeò8ñ°nñýÒIô-}b°VœrÎŸu½SOã©³zŒCp€\Ç]IÝ "A;gg†Ð‘Þ²-‰^rÝFŸÌŠXŸn{á{¬þnN²—÷Ñõ0mþ w«á-œŸm4f“D5È»€[‹ªÅùÿ&YTwÁ¢ñzãðg½ybá8«ª×éàë‘ö²¯k¯5€,*£A57 ‹ÖT><[íŠ?ì4ä¦ÀSôì¥BJ*æãþY‰ÍwÖãsú0™Î0áxTgÒ HV¨4X¿ôY0ö bPa½X~þ`Y8?U•¹ÊK•×¨Æˆ¿þûØÆ^o1ËÜ‹r¿ý÷Ôöþ†ÑK¢ºû“®CÏ.Œ-ÏullméPÝ;<8}]!¿)³Ïî·ÞmåcO‰£Š5Åbw}²jV.ž±Z¡°†ÞŽè€•${jGöf>ÖX”Ë]ÔñòØÂ.B–ïGxZ¯Áè¡ÛÆ«Y€Tö?™Äjn@XL¡rÜ !¯¹Ö^gÑˆÍ•nN;1N­Îª—8È	zg~ÑÉÐB¯w’biÿ¹O±ºR¿´xÑ†¥$ï|há^¥ãô*EJÍ¾s&Jpï»¸,7,D¨úH¤HÂk,7Ö¦vòæé	>¾¡‰ÇŒq:E=£±®¸ÚM¡·r‰—hïà²1 "‚”ÕéÆsõ¯ŒPc® –W€ÌMŽ¥x¥ ÝXY^«U(k~º8Y_ß\˜œóæ/SŸ)OU¨=Ðô>oÂ‘Ý’/ìñÂýw£ãM]+èùÆž|ô²xÞñ¤QSsSŸ§<ÓæŒ{IaÅ°£¨v¸­mc.×eúêªÌúœööF–“Yîÿ&\ð‹ab”~ò}ð¢¿dTøšFÒû¨c¾’Gj–Ž Tå‚…â	| ®úùî«PcVÃ•žW‘– í
+s"0²‘„N¤5sSÒ_òS¥ÝìŠ'øØãƒsÆ¢1)ÁôDðE}œFäw;«E *3E!îAƒ>yŽYŒÑ½ë¨T°*_&ñ¤õgP\îb|²†æw^”EÅ’-–-ª„æ2zÏL‚¤+#Ãµ„!ÉUfÄ+~â¹Ïë|²ï]„•Xö+0Ñïj_I”MŠ	»<&Ù¡y#¶éBG\µ›~fò«frÕ[B~)ìÈVdSÛd¦Ïã	YkóÁumÃ¾âSê[_$©ýããû7}2‘êõÛüÖzKåk•i”<¶zõ:-Äàø¨…Ú]kã—¬Ž”êŠ‚íU¡^–Å¥eóí}æzGYB5 ª3@kÜÖ4?çduÖç¾À°´z	—K_,¥›Ì=Ô±…½‡1ÊÎoêÝbÐ.ƒ‰„0‡ÀÓç³Á¦Šrs{= E[¤=l©À™ŽÌò:2ÀÑVŽ£EÒ$ÅªÆ¹¥	OG¬FR*ˆW‹qlÍÈZ{´T‘b®r'Rjd4NÆ	xÄÐ¥w~ƒ^1Ö)ÖF§_xnVÇÂ¶ ¾Ž˜ Š~ëÉ¾pBùÄ'MÍî¸ËóCUÓÕ*SW2Tô;VÙ¤XlÑGÀTk)µ@v{¢ÅÉŠYq»wªÇâw¡µ›U°Þ;‰loß¤¨.‡Ùíˆ6dâ'½¢ÝèöU7gI%B€ä€Z“SõåBž&¯æ¶úÜ¹R};Ôye3Q gvÝ8¤™Ì²f²ÉZØU›¤.ïÖÅÎsO²>`½¿Ç¤@wŠ>ð¨–eæíêÞ-¬…ƒ•|l$‡u6è“~ƒ²Y”#ŒÑ×ÙZ€³²|Ä¯Y=’RâSx†x¾(ÄýZc'T:@|úÂ‘x	3%Å­ÝÖÑëgQQâáÄÓ.ÚC8ÄÑÿy\þ²/F/»êó‹:rµ•^èI«ºà×¬O(o<Fa¿ãyGBÞ¶@`ªäj‘<Sù;˜„§š{Ü‰0	ÈAµrô›®”ñ]K.ÏÒHæÊë•ò—g†éI¥Q¤ho?GdÅUh˜@VTƒñpmÜ¶£î›Àf/×0ûp†,g×jZÚ	SñÖK›Ù³Þ€6;ußx½Á.€,²x ‹b%8Ú6”4ü~7\‘íüîàÚÎyå¶ò9 ÆŽÈÙ
+\­l‚XkHÚÊîØ,½c·³Ë=â¬fœó'á‰Ø#hÀ ç®ü îåIVéÚ’`Þ±"Â@Šc ÄÑ›øð	^ð¢zõ W'kchbjªü÷äGR7:G×!ôŸZovi-¹˜_6+ªE	ç|Ù€ÙïDÑð®åk¬]±ËB{–2œSÐÛQv×ÿQ' Ý²ýËJ(Xª 'Å eÿ¢~ 5*Ð@FŠñ¬É[c¯3—
+¾&f7ËÜzñn
+@É Ñ£ª˜ä“‘N_ÒjCSÀao	‡ûÃ2Nù‡„ô=6¢2ìè¹gÉ*æ3‡¤¥Ò>Ä¼å&žÐo§õtñÀÜiX50èº=áê‹^¥QÃÝÝd€sF~ÝwâÈY¸;Õ¨-ÈÀn¸5ûÏõ†¢ož{é,ŸèZÃ{JüÍyEGÛ\³…Î".¼ eoÖX*H`Ì~®+ªÓq ·­Çu&0Öéëý»%>[Z…ßBÚR·':¼T½0äÂŸæ…zðÏréˆ°±0ª`+Ôé•ÞŠ¬/õmŽÜpôà©åŸx°kSê¶3>øñÇ‚íî}kûv4Í­L<öè·3;ÊÿI×Àé‚Õê5Y¢ÑùK
+®&ÿsš#$‘1"öPób_£¿Æn¤R-‹§,æÔæñ©ÅÏRjSÉ±{èÁ7"<@­‹%è¥`ä$ø1÷@a†UÝ«Ô)®`MÛêæ‰½Èæ3)_îm5ÁÚ=÷y†!JÒ.éZéNôÚg¤»èWy7ÝîrŒŸå%žÎ*J½›Êèú:j¨âß‹ÈDíDAÈÂ‰†c`j4ìEMÈ‚|Ž0¯pcAå– ‹¨?ÈzÔŸGûEá]Ò¼ÔOwÀ¢|Ý­á]ãÿ“s%>Ð;õÏxœó3Gbî'|'Èëf«¥‚³ZEÔg°ukøº…½ÎÊQ(‰çÖn-àÔÔyît
+¿[¨|—E©.Èú`yðúc<œIÙÎó‡Žiþ$¤ÐÅî¾”ÀtöFÞªO:ã<Àþ²OËÚlàöðˆÄ$¥2
+OvWh¼”¿.œwOåÓ•ça{WOZ—ìkÎ_³(:Õ’™Nd>¼gýG‡1®|/7Ù›õu‡–\—¼_lè]žÛÕ½Q¶Ù­¤ÆbÙ´Á",.z¬Øùn“%²ÀÖS7J9?©RlÀ2–£­_Î_5Xù±¯7•Zœè_lhsÈ`;Ýx'»ÙÆuþ:Ô…	ÆëÖÃý³’{ó]&«
+&fj°ƒ7F;üY¿ÅÍæ†'I~g®ÞfVUÅ¦|Â×Ê>-º¦³òkŠoíßì¯KØµc“î¹¹P,š;÷4YD2’›âöqé õJ¢’A{CEŽˆ‡ƒøÝHš³›ZØ‹°È¢úŽe¨cYÁŠßÆØ ·ýb~v÷¼Ð€ÆùuH›ü°†PÈbAd”ZÝ<´Ó÷">ð”’¸5KeÖœœ›vÕ§ð³Ù@dáB‚ÿWfÃºUÉ•­ïÙ¾}·6Pù½©¦13Ieû2¨H,‰®ò’£ñ–+7¶•q‹Š†Ð¦í/~i§?ëA¸ìœ”ÃÌDŠ­ò$‘ìí[<Èzëýö¶8ë{úÛ2§Ü‹H	l•Ùƒp'º0 ^`vwb³gY®b±´zÌÿ
+E·+Ù—µÒpu NxQð¸p™Wlçƒíy/\™5Y}Dêni;7æ]ó²“[Yýüì$$,*»ð@0°§“¥é¡À`¢ªÚ ¥P˜nº Þ;xî;£7Î[ŠùÍª
+dsô„"-™J`æuŠ¸c¾¸qü—¿6™Öôr,z(”­ÂP\LêÍSøíü`xsvwß¾ÛóèsÙ:ÚßwÖ‡·›<V“lZ°bq8”Ð@ÜñY•Yz{º}– ‹:Å—£q¶ÃCnêC;2¢µ9°ÿ²½«þA½š‡ÿ!>¹ÅßU^˜%†ŠEU‰¹Æ„D ¹%êÎ´¶z»ºj¶îr,¨X¸a¯ è%‚Ö´.ðzíÈŠÝ.ò:}Ÿ_Å¸ndèÛz…œ!NŠ^:¥5èjPÖ]Ü¿Ò‹ä„\C1c6.‹±^¼õlµ9-ÐtîgðÑÄä¨Ãåy˜<n¬K9zõ¼­Ä.éKøêJ°ýrÎVd>€¾‚oüùÑ¢’O„AÁ‚ó™¿DÜ<aøpnä0ÿÀ°7²Êµ¸ÀÔÝ‘Ùù<vú­YÐ¸æ/°ùœ>0d¢(ÉÑnÝäQÏV¶T”DL²º$=}N›Asýš/Æ¨£ñf|ã³hy|CfÏU„TÔ?w­
+‡KþÊ/+?"Ø¹¨Ü5b}ý»nl¿ãrç¡ŽòûáÄ-•×*¾‡—ŠÖ×ÿcË­…û¡µi?ý9ræ§txQ¡££e-&›Ð’-x³>¸‡ õÛAšÆ¸€[:.EëExýnxt	î¤–dÅF„·ÒÅIl*:ýÙ¿<¿ö"GßßP„¼)¶/¹ñ*ì_»-ÙqîÆÊz¥EÙC¬—Xñ†þ<ruå³’¤Ìœ»ñ­Û”v&ãŸSôL,]÷†´‡nÃt;J·Aº- [™n=t[C·¥tëâ?÷ðßÃvÝŽÐ­—nñÇâtë§ÛÝvÒmŒnWÓ­ÄŸÇ6Ò-O·%h¾ÕcÒè©Bª¡Û{/Yiš>výUú8Ý¶£³R	Ÿ‘’((­ ?7¡õÒjº·ÓãÇéöÝvÐm%ÝÊtÛJ·åtÛL·etÛD}™n_¦Û
+"IpN¼O¢¯Õ(ðR?.¥èÖ…G¤V<&uâ7¤þ¢T–~$-Ä~zÌõôç&©HÞ#µÑçä‰IjÂ¥fªšñuô<ÇèþzÜ/¥<þºä"ç$+þ†¤âOKn|§ä¢¯y–n^öyþ*9é&Iÿ|¸SŠâ<=§&…pƒdÁI)ŒVÑ}^Š`µçKAä• W´I—ÚÈqzl–n‹èï3t—jÐÅRúßR­¡¯ÙBßG˜¾þ=_TŠá6©Û¥ÿ.ÿH·KðO¥AúýÂµï•¶HÃÒ tLÚ$]E?íêdB(iš>º–®éúhb˜ÅÔwØCåªSè±ÍÔL^,¦X£$–6Ð3•¨Ö)Kct»XÚAe?}v/µxcôÐ3î£G­“ÐW[@_§—¾Ä(ºéçš¢Çî‘:è+öÐ¿RŒž·¿f¥Cô½uSçw„þf„âúúw5=¾—þ¿‡½·Aºm Ç—¥S¬æÐÎ)é }•2ãøœ¡g„×ÛOŸÕÉ>ßQêæèóúØ½§?‰žÅ·‘¼l’¿©–´c¦cæ°eÊzÌvªfÜ^ëhu6¹îÛëö~·Võ÷Õ-¨ûcý‹-Á‹ì³³!)]N…ÿ¹*r[äå¨%º!zGôÅè«Ñ¿ÆL±]±Ûb¯6.l¼­ñññÅÄC‰W“µÉ\r:¹+9›z(õu/¥_J¿ÙÔÐt¢ésMßoV›»šW5´ùß2¥Ì™ÿÝ²¥åÕ–¿·–Z×´ÞÞú…Ö?´ÙÚ2mƒm[ÚŽµÝÚöP{±ýöŸf‡³·eœÛûdîW‰Ž5û:~•ÏäoË¿UØRø`±¶¸¥ø±â×:S+:Ou¾\ò–2¥Ã¥J/twßÕsSïÁÞôÝÔ?¼`pà‰Á—‡žþ—…îÑÖ±ºEOŒ_7aŸøõâ7'˜zjÉ›K§–¾¹ü®—¬üäª—VoYýæZÛºâúK6œØ8½IÞôÉÍk.’.zõâ'¶Nm³lûòÌºØùÐ®žÝ‡öübßáý».Ýsà—m9¸|Ãáâ‘ö£Î+í»2z•óê®ùÌ	õÄ×þâº¯üÚ©¯]ÿëÝ”¿¹tË–Ó—Þúýw½í·o¿ýïw|àÎÝõë÷Zîé¹wÙû¸ïÅûüÀ¾øÐØûóïÿÅÃ]<ó¡£¾ý#ÛI|,ü±_üsŸèzôºOæË?ö_g¾ûDæ‰?>ùÇ§¾ð©-Ïlö®ç>ð/‡?}Ógž}áÒÏnÅçïíˆö5é¿„ö¤,Ðf¤|‹ëËºkN‡Ìƒ¨ùà2–4zè2¡wÇr.Ë•_ÅeE2Iïæ²JŸ{—5º?ÈeÈ_—éuÒÏ¹Œ¨Uÿÿ%?¼ú³.Ó÷@õ¨.Ó×E“\–%7:Ìeúºè&.kR'ºJH–é{VÑW˜¬RÙŽ¾ÁdÆÔ¢1ÙÌÿ“­Tv¢?3ÙÇ`Äd'<Žk˜ì¢²‡˜ì†óã4“=ì˜6&{Ùsû™\Ëä	&ƒý²ãÕL±Ç·lbï Ùfa9pðÊC»wî:}4ÚÑÝ]lËçr¥èÐÁƒûf¢#ö<rxæPktâÒmíÑ¡}û¢ìÐË£‡f.Ÿ9ttf{;;pÑÃ»vo[1³óÈ¾­‡DùC½ÑŽB{n{ÇL¡7šÏu”Ûrå¶Žü‡~e<j÷åÑ­ÑÃ‡¶nŸÙ¿õÐÞè|ŸÆ'Ów¼êÊƒvÚzN06³õðúÞáq!W¿€ëÿ~ÿŸ>ù‹¯<ÿó¯|îüÅ.ø&^üzô¹?}ú•ègÿòõG^|õÙWžýIûžúKï}àUi)UðÛ©{t©ô[*MSµ}ˆ*ê­ÔX¬ Š{'UÜûèOÆßÀïv_àÈüÈ™ÜsOä^Ïý>÷Ö×¯ù\Ý·Ÿ5œi7•æ¿ŠA–Ãr‡<)/’ûéÿÝÆßlé:ýÒÒ•óž']œ{ˆÞ»øCÝ¾–ÿûÎnendstream
+endobj
+128 0 obj
+<<
+/Ascent 1386 /CapHeight 1386 /Descent -423 /Flags 4 /FontBBox [ -123 -423 1323 1386 ] /FontFile2 127 0 R 
+  /FontName /AAAAAA+AppleGothic /ItalicAngle 0 /MissingWidth 1000 /StemV 109 /Type /FontDescriptor
+>>
+endobj
+129 0 obj
+<<
+/BaseFont /AAAAAA+AppleGothic /FirstChar 0 /FontDescriptor 128 0 R /LastChar 255 /Name /F2+0 /Subtype /TrueType 
+  /ToUnicode 126 0 R /Type /Font /Widths [ 0 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 320 376 400 680 680 1000 815 400 
+  500 500 464 684 283 500 345 500 680 680 
+  680 680 680 680 680 680 680 680 500 500 
+  500 768 500 620 1000 726 644 685 685 579 
+  582 744 703 215 535 643 552 911 726 776 
+  603 784 640 632 661 735 711 1023 713 695 
+  657 500 500 500 500 500 250 565 562 519 
+  540 549 340 562 522 159 276 514 167 893 
+  559 583 554 547 352 496 342 555 542 835 
+  544 557 526 500 500 500 730 400 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 ]
+>>
+endobj
+130 0 obj
+<<
+/Filter [ /FlateDecode ] /Length 1224
+>>
+stream
+xœu–Ënä6E÷ý½L…EŠâ0P”Ì"dòž¶<Ó@Ün´Ûÿ}tO5&@‚˜A™.–¯n•x×>MŸNÇëþî÷ËëáózÝ?OO—õíõýrX÷_Ö¯ÇÓÎùýÓñp½ýÆÿ‡—ÇóînÛüùãíº¾|:=¿îîï÷wl|»^>ö?TýŒ?Õóù¯õç×ë·ãáÇÝÝo—§õr<}ýŸ?~×¯/ëéºïvû§õy{È/ç__ÖýÝ÷ü“ñçÇyÝ{~wzx}ZßÎ‡õòxúºîî»îa?u»õôô¯¿ù®Øž/Ï‡o—[n·ý<l±Ûâ±¹¬ØoqÖ{â©)Êé
+9Ã·èƒâ¨œ–ˆ“ÖsvŠ³bïØ[´7ÙÞ*Æ¡ŸZwV§±žÅ{göÎZ={­Ï½r\sÓ^çÈ±XüÛQTß‰ì§¢XümªÄâý¬šNüSï‰á/V'£%çrðûÆ^ñ9H'þ:w¬7«)f7rÄ?–‘õ…½žåM¯þÙë\ÞÛ¹X‡?Gâ`Ú’cü±ñ;rnüÔ7ý'éàáÏMþVt./þ–:bøÓHMôŸ,gFóšèå°û^ümªÙ;â{;/9âo÷ÞôÄK=üõÑž¥çö‰½Ó¬þÉêê'öV˜35Å?%tîë–ƒþ­gýë ³ôè_ª4	øÇ%Õ	Î´7àŸ2ÉÃþLôOUœaÀóNï=Dj¢OÿäÐ$džÛÖÑ6À?¬£á,ý'‹Ñ?'àŸñ@0~˜ã/½bÓ?é\ƒ76¯ÿ¤M¦-¦{G>ý›Šêðz]¼ØôOøs0ÿÐ/Cµ~$ÇüS©Óxn­Š'ú¢—æÃl>ÑÙ‡…½QºEø=½Mú"zó6ëð—Yub0_Ã?97ÚüÉâ‰èŸx×1[>9ð[_ÄjœÄðûÈÞfsƒØüCEôOôu\ØÛé¼	þàÅ™œõˆrü¡Š!õÌ4Þ]‚¤¯ü³1áÿÌ|KèßfêÃßbH7ÿ³ŽþÕ¿ÍO½Ó„æŽš“Í[âÙæ†<ðÏì´7Ó¿‘þÊðwè“ñÿ°H·ló‡ùœƒùD53ý[GÕÌÌŸèÄ™éßÁêÃ?âŒþŽ÷›áïgêÃï™?Ùú—9œñtÞ<Ûìå¹ÌŸ…÷[Ð¿kzn¹ÍbôÌÃBÿvKRlþGÃëÄPÐ?ÒS…ù93OJ¶äYôo„³Øüa¦Ó¿¨×ŠñÓûý»ª9VÌÿ1þï˜{ý—EùÕY‰§zÓœõÞz™|øÚVæÏÂ÷¨Âoó¡šþ0Tø¾;õæ1Ôj<â¯ðx©ÂßèëjþažTó¿qâÏÙG›ÿ‹öŽÎzA£Ý˜™coç"Ì<0¢ÿ&„b›?øaDÿ¨	ÿŒþ#þ_fê˜b¾¿m”£ñóm'ë;jšþMéßeCëà	òCƒ¿&ímøßãÃFÿFîÍüÏ÷´ÁïøÖ4ûþÒwùÓ[}ë_îÿxz¿Uë#bæOä]7ûþâ½fü|kÚlž'g±šª?áÿ"ží¶w»ÕéÞ§kë÷åáýrÙîšÜm¹Dêúx<­ß¯¿ç×³véßß·}endstream
+endobj
+131 0 obj
+<<
+/Filter [ /FlateDecode ] /Length 69372 /Length1 123352
+>>
+stream
+xœ”½`cW•?|Ë+êÅª–,Y²,É–‹lÉ²ÜûØÛÓ«§÷>™É¤Nê¤Né	$@(¡…tê0 ¡.,–²`vaÙ…eû±íÏÈß9÷½g½–ÿ~Ÿ3Ê=zzzzïÝsÏùú%„8È9ÂÉÈþ“{O·œký:lù!ôÂþë¯M?¼#ìnüß¡Ó‡O*Gß5ä}ðù5‡Oœ=ôÛo”@ÿ=¡ß{òÈÁ½þÏù™)BÿòQØ¿ûl°´“xÿ§ð¾ñÈÉko|®>½ïßÿõ‰Sû÷’É>Gèï?trï§ù÷œú“s°âª½'ÖúSðþ½„HþÓ§®¹vé=¤@è_??}æàé„´Àû¿€÷¼(ÁëÁ+RèK‚ú6lapu‘‰BTb!Vb#vØÃI\ÄM<ÄKjˆ®3@‚$DÂ¤–DH”Ô‘‰“z’ IÒ@R¤‘¤I†dIi&9øÍVÒFÚIžtN8£"é"%ÒMÊ¤‡ô’>ÒOÈ "Ãd„Œ’12N&È
+2I¦È4YIfÈ,™#«Èj²†¬%ëÈz²l$›Èf²…l%ódÙNvdÙMö½dÙOƒä9LŽ£ä9NN“ä*rŠœ&W“3är-¹Ž\On 7’³ä&r3¹…ÜJn#·ÃÌÞAî$w‘»É=ä^ržÜGî'ÉCämäaòy”<F'O'ÉSäiòvòòy–¼“¼‹¼›<GÞCÞKÞGÞOž' $"&!/’ÉKäeò
+y•¼F^'#'Ÿ Ÿ$Ÿ"Ÿ&ÈgÈEò'äòYò9òyò&y‹||‘|‰|™|…|•ü)ùù:ù3à°?'ß$ßîø6òÌcëìR»vëë”><.ÝsLÄ>³Áwïj»@hk"±âèÄkt¼a­°!—Š·&&_ãéÉõ[Só‰¬<ð@b2qdï×¤´áƒƒÌç¯‘[Âÿ7nM¾62]&ÎÏ÷Áq$<Ž$ŽóÀ<á˜~„câp€K°“Ü:›xgÖn]·õµsÑ×F&æ£ÉdbÅko®ÝúÚ›Ñäü<ì¥,Ÿ)Œ·ëç¬Â9+9 ,ÚQ6l}m$ú™àí]*ùÚ¹ˆ> ×¡¿¿@Þ¼b%WnÑ7ÀÀ#òôŠôÜZñÑ¹T2ŠRÉTÎs~~ÛÚ:»aë
+8Óä|,c2¼ôÿ(ÏÂúPI?œZv—Åó± /|4_„;/´ºó«ÂÊâ-á2Œ!oÒ›…×0?>|©f‚ÿýSCìŸ.ÕàªÜ±ôþ1^‚ÕWëd3^„/Š¯`1âØ‹Ç,6Þ¢ý¦~ß	¿_ :
+tÆŒ±¼F§N=
+t?Ðý:=ôNO =¡ÓS@O-=ô¬N¯šÂ¸ÆuyÞ ôý··.s6ÁUÜœ‹ %,âd§õ“V`Åk''à ìºèZ {õÅÏ×,Vpzù;:i)•I©š–K]™l±ø•-ºË¾¬O-ÑA
+Û¨ö‘‹¼å´‹Æh(«ÐrwW>j§Ë_Ól¹¤_Ž_­>ÀÞUùDå{Œ)±¼åç›^\}õc|–qÎ˜;ÒÃc•Ý\æßü,©—_ r<¥[^àü£•«(?ˆÈ6qÜO%NŸ§•ÑÜì;×5­9W°ì+µ»œRå_è÷!Ûßa,XJ$cùq¿?å’m<,o£ln”Ê¨M@Z6ð×ÙðÄ
+òÖEŸCâ6v‚°Å1	7og
+nOnOn}3l+ykza†aë(l…XÂÙÅYBvåðrÃË¯®¼6ýÈ¶
+ì¬è´uAcs¤@;tº ³Rïkô© €Ÿ€Žè?‹[“x"Æ–	<‘ÅŽÎtNÜùvšjPTUµ§Å²¦+„“ð9L¼ôið«Ù!Z†]Ýå¬\
+ñ×]Éä–îîñÖccë½Élh¨¸‹1Öœ²ü	NŒÝoOÙèüµã’Â»$ñ•íÿ‘…ÃYƒ? &§4æ¯·pIeµ–ÊimMP–-¥’Êë,•Ÿpv¸öï~có×;›VÄŽæ™º‚¡öYúÿ0§ Õ¼@:ñ6À‹é«ß¸…¦Ûfíxï^ÀÛNpš´Õ"Á}ËŠå|´¤*¦R5‰¤}Ú„1Ûò@×]wÙ‡U‘
+„Ô2W½)àðî®RViP•†”ZJÃÂè†ÛWJÃM/É°ðÖSþáKò4•³BÜ±z¿?n?K×o´Çv:+ÿºæå•tÝ"9íöcóVzà—_ãÛèf^9äJG"YO¿ÖK%¹qpÆwu˜ñÌ|W×ÖF*	8Dö/½Î/ðV@]ä0p œp·~§PVªš¸`p®C0&`[Œps¼ +˜`¡|šCþUuñËác.a½(›a7¼^ÙÉ`Ÿ²œéÌ¤Tí¢áŸwù#ÁSÅB¨âžž¦ˆFcÖ§+?Sljb¥{¢;¾gÜß•d¾xÒÚrdõÚs	‹Ét°r=ã™z…s›–+w°w€´`ª"Y&1úµ‚bq(a^¹‡J‹‹q¼0OÖñ%ÀRM€|nFåP§Þ("."¦?bšÞf ðš=ðÆ‡’®¹´~ÁÈ
+¿àƒBð…P^£ÓpkÃð>ïÓð>² MÈsp‡º²pC”€?ì§…r·/Ó‚)—êiiY&g¸_URjC6S~‚]CAÎ¶¬¼îŽ‡ï	\5±áÕÚfïµÏwV’ïþ/îM4Z>_º®óÈ¾5ç>±eæØæƒn?Â¢ÛZÖLìÍFê+›Gä…>8+2d}Vág¯íj¡Ã¥×v·zÄ}Yú<?Â[ c–È:j½@Öç5-³.A†Kq=-hZ5“.×ïíðÞå18¾ƒŠ>ë^Ð¸®Þ÷ Ý£ÓÃðÙJx?lÒtÃº¦[ktM^[ƒ¸Fºë9Œã$ V¼÷åE­Ñ†\˜æ¤ËcÌÇE˜{‰¬ì\„­­°µ5¯Ñy ó@˜ò¤G;Å•0kN
+‹#Lê²bbw‘j\­hÿ¥²°Ò»K9ª­üP¦0àóCÀö¸øC0­¿¥l¨ÀT>9ÿÚ4ÈÃd“Zlk?Ðsº¯ò",Ùçl,MûsR;;wÛ½ö¶††œõgÙi*ƒèÛŒ\•èð£åå@ãìÏC>»¢X]ÖwrÜÈ¾ëŠºR#ñM#=íõÑšn¼ñÜÍ”òQ:má!véÉz—DÛàÇ‡˜Ä;båu#qPÿÒüEªPÿSô¼iqqÓ×€
+ÄQ“Ì·‡éÂÑà¤m@ÛtŒbpF“.Hãžêâˆë˜)ªÓI “ú¾nÂc´èp¤Æ6Ø¶Â„“Ö,sÏE0AVˆÉ½ÆÅ
+}šñ|ÞŽ+OÂ¯Ûàu¼î†/H ð‚ÐöØ%.ÌmRnW1!½M'ƒÜÕ¹ ©!¤Ë@—uqŽØÃ“F–×i„k–ù/ÀNn§}l½~é,|rö¾Þß³ ça<)—’uSä®rÄp\HÅšFÓáf€t4¦¡…æÇ–‚¡`¡8\…aé,0¶›âNFÈ*ºÈFº!€¦ÇÊ7 3²jœ†à_Pü¯d?¬Œÿš&#ÙjÈ¤Û-¿5ÆPñkë¥?û-åápâ`öòÁŽTýú®#w4†c©7(óÖ7(ôÑ€míF×¦±`Ú+ÛU¿3ãŒ=^“1OÕ–ðªuÅ.?•ÙÒ8þÒáƒ/Ž?óð±­55:ïjr‹…Ÿ=K ð¾Ì†FV¿ËÔâ”›V¦Z<Þ¸KuHÞÅy[A¤úßžßèÆ ¼“ßË˜$uH)Òán¨Q<ÖxMyÌÏU©…)œQ™ËÞTÇ µÖMAéÂß0§²U
+uDÚÃ’"Q´ä—>ë(z	¬ß/«aÏ f]¬®–«M+Ä°$ì°Í¯3YfÕÆE0ÌHF0F¶î€=wäµ=ö½W§÷½%çŽ|e
+q×~¦Àbë–Uþ„ì\FÊ¤4&)e­ÔzZSïM¥³\ÖMKrYÇ6å¬Æ*‚u2Y]"Â ÞVY§Dåï¦¨þ×A6»ÂÖGVîÏd&Œ×Åb*ã¿ëÝ—Bw¶êø&ÜáÕŒ}õ´ù¡u·wìj¬©³®T­’ÝÁ"î½çÒN€ÆâÚþ){¬ÆT9WâÞƒ«Æëe›¬‚Éà³ÅsÎÇ;Øå@÷ÞÇ¹µÆÝ7$ŒF‡@Þ“oq²«of–)d´8è'-ÙåëÃ;Ýê
+Ã›Á¶7`oÄÂ³Îbë¤£Þ/I«,Kvhñ„-Í>Eyrné?z4G¶ÐòE²
+@Š˜•ºM™vÃE`§9ÜSÅcÜ$C&ç4‰"´7üšHê #¢Óh:M2é,ÐY ûL"
+éA uzÐ+€^%dêE²¤¨MpžÑ<JQ<„3V¥v«„Ä¼FÑŒÓÄ'.Ç,	ÑzD7qŸA‹rèIý'5KÖI²–tÑ ¯.¨TT»Áü(eS>Õ§™BlxQ€&ºŒ/áß KP±å’T¡²N(j6üƒ‰Q˜˜úØ|RÆ7Év;½S²Ç³•×}qWó|GMÎ^_ƒzáîÂ\ì}o1^ù;Æ
+Î¦º–µgÜË#Ž€½òŽ­·d2ÓÉ1ž™H­H}¬rÄì³‡c±ŸÃ*×Ù+o¾õmåÒ-`å¨N!*¥¶\"™‘_¡ IÙ8g·¼ÂŽž“ì*Sdá%Yzž¯çÍÄA&È<ÙO>7}­¸¹xãe-ÐtAÛf¾±3@ÏèŸè
+éU@¯ÒiÃ€ôf 7ëß=ˆ3½YÈ‹dÙ¦£]®[Iže†5L­¼I‘#]t=ÐÛ–…H•”/©Ùœ`iÂ"%7()„·ˆŠ²åB Nh’¸˜p®Jš¸PÜšô)ú`ÂUŸÆ	Àš‡A“Tî£8¯kçXå·ÉÝÃž¡SO$ú";ò•Sj—ªnuÖ4úÀ¼”@ŒSzƒìŽ¨+î qw¾>‘w¿C¥|•°Qí±¦¯¿\yMt¬êôï¤6T`l‚ñetƒKÖA,ý5÷xü²ÜÔàl¬•,²ìMM6~³È>é5	þè-4byoå©{C®¯fõþÚp“W¹©#Ýoß±ô¿ä„—´’­äœeMR„a1iÂ*nxØ´úÍfEQUÞlbh³8ôXþ9cè9]ÊlÃ™v	®ŒzñChÓ6ÂNh«À÷Åi@õvµ³ÞláÎñ©e€)œ¸a*01Ø&¦˜*{5TP  ûcæ´»P®.Àë, vÇ $P¤~F	Vûêþp)€ý[û.WÐV7–‰”õ­.æˆd­š¢¶{-ÁR2YÙÂ^ÇÒ5•=_ûãôÞûß<[–¨´AeGåËòËswP®?Ò»:Swé-IfŠ]U!ñÑYÙÂëíÞÎd²7|k¨5 {Xd L¶³B®Zú(¿æÅ¼‰L‘dµ£MóûÄtÃ·C·"ÛˆKÜ¼6tl3-¤›nÖ­$ÃÜ@WZH8öÂØÛ:Lr¹Cž.ÓŒº<U»gß¸`·“Mâ„Vë9£[«c°rq´„8Q4çÜ:ô4
+ W½vA7Â¸¶mzÐÛaÜ
+ãÖe+6à;¨Pc9)— Nj P¶I5€ÙÚ’M}µœ
+	¹ÌR6L\!¸å,BÉP?¶ÈSVÒobù»ïê¨+Ò÷Ñi^ùçÊB(í>p6¸ë9Xâï=°uë±ã[6¦‡•)~”h(¢Ü$Ùâ™Ê'~ô7þÎøáÚûBM5GNõ‡£ýaúX_À±}‹=P¹·‹ýÎ:^(~†¦WLM®˜›¥ƒr¿ôìß£tWÇ°ÛuPÅÎƒ–oß÷¨ò—2Ð<Wmœ‚qÅˆÑCÀ#›…¥‰œ"wÑ~4+ ¨Ãë€Y¾Åªœ¾Û¤£Ã‹šÖõ¼ÙãpÐ) S:møû€51MLØ$¹qïë€¾N§Ó]7}“Nß
+ô­:}èsˆÑY+,£‹ q|‚S&ªª›w†×Øá©Â”ªsM;°æ“Ôh4÷¦KL,_"^V-¹Cèú´î.sk¦D1R³é”Òàa’Mjâ0£ß3&3¥
+6A™äiwç²œé*¸MõÃÇ€­q.ô‹¯Ä Œõuá!€'¹Ö­lÏwðÆr}ñÐû«f¥Ê¯nq…ì
+~H¯mk]›æô»»dw1Õ&w—¢-.Ð%ªCIµg»¬A—äª`XËR(ãŽv†Š>W¦`SÀhp¸ì©–b-äæßCãˆ²Y	 $‹†RSµ¶®¸sÀ<÷)ÜöÞé²ì /Zl’ÝÉ$…¥{b}qÙiñÔÚò¹¬â¶9k˜lÉv
+±áù¡Q›EqY,a§›¹²µÎB‡_õX9½hµ;¤Ê¾«!
+¿zgO][U	‘É ©ã¯°ßæJ“"™$ëÉQhju‹_su¡õ±¥*ôÏ¬ÏkúÃ+¬k´"zu´ÓÝä\|Ñkâ	¤Ñ2ü©:àh@VŒBt-h¾ñ^OÕ‰„ô Ð@›Ää¸§Š1‘6p%Z×S‹B©…¾Há{1C«ž·?t¼	¿
+°rMk’Ë.O«0ûèÎ}×4×õvnÜ»•JºK.÷äq9Ñ!\rŸë¹÷ÚÑõço½ç¶ù»;¶åö~dÂwn¹«ýÔk«ÿú®ÔP82M¤èÃ©l­;™óys•×ÑU7«ÐÇd»¶î vilH×¥æ&Æ¯þØ$ì!±@™I´@‰˜Ë¥ñòPEõ`u%×Ò&®GGJ#x]ç©z`ÔEÍÁaD¦ÂË²å"•×/$NxA\ªm8	_8•×Ûkó8çšÜ8CŽ‹q»€«Apq=òÔ´ì62ÜÌfWÒèêiÑÕ¢á+˜ÔåZ“ðCm´	èMy³fÒöÙônFùŒWéãé6f> 1!&<£yZ‹`ò–Û¹!)õ	DŠUÈ™Ì²cF”2\s‡„ÔÒ="[š-ÔÏeö÷œ==:73vÝé+Æv¯»õõ¹=»Ö>ûþ•oî¿êø±òà}}[¬Mk_ÚuÇâÆ/Û®uùéHç¡Žm­ö¨7Z
+÷nhïJ­ÉËCýý‡ZÆ?¶ý‘gX(]ˆ•Ê-?9}ÍÕ^—Óžó®.4ùC…öP l]—Mz½éuÓ‰Æó µ„Êcã¨,~Øî’Ý5Žl '9šE%oÜÅ¬²#ÝÜìåTßgŒr[]<á¬µYi®é½{–^Û¤8®,À£ôt¥­×@×é$IBbÒ=Íÿ‡Nt§ê‚Ï“Z¬>é~,,hñœØ«´ E-zL<:dC:*Ò—ü:á?ÖüÕ{¬7±ÒÛQ…™Øé}Zxíà‚ö{ÇQÎ¡	…Æ;pº~Ò¨ûŸÇÅx@÷îÐýÓ	q¹Á:£,nÈFOUÞ¡þ3<0†^lôTç¨K[«ë¢ÅSöH·Ýô }HDd³j DµÐ^RDêJY¹\’u¾L«¡´X–_^Àd 5Ó:Õ=l*áKsÊ „“]Ý¦ÍtU½ˆeahÿåý÷ÞÃxó¦öüL¬òaEÓ¦_]úÇätSÓÊ-qVù‹_::'S^o—iþ¡½ðcÁHCå[ ü*‡…ùíÄÕó÷1k<E_z‚±'xEÒŒ¯¨×í—2i7ë°kïqÎ6	¯oR¢JêÌúâd/áªMŒó>v=ì5žJY-Í‘/¾”ÛWh…s~”œò.ÎŸT…lì_z‘¿Â“ s€:fÁªýÔk%=|5-Æ=4mâV¼å;ðÊ-hÙš| =º|Kc¬ñSÇ²Î30Ò†»Æë¹<>dà"¤ÑrN›xÁlÔ!:—ÿÿ–N`6ü¶ ½v?“Œ3àÀß>øOaõ-û 9¡TÌ"jÒå¢¦	…¾¬ê¾<ú’Íªpû«Z#uÍ»¶SÀ‰ÒZé¯:Ž¶ÒD"9ÛÒzbld*5Õ8“ú\_rßxßÖÄê[o½ï¶ùpÖ}ü¡ä‰çÆ‡Ÿ?pâã«vwªÕfõ¨B+6Òo¥k=1_]¥é›­|Ó>Pc†ã–Ñ—º^¯Ó‘˜ì*ïC­È‡@yò"~:¢ëFóÿþ2o nY×PŽ*KÓ¨)¼®õTèäG+®ÞSJäô©Ð"¸ÄëINH®z“$Á½ }@§ëR•ÏUˆ´q'*P¶Æ5õz>®zÃ-üÇ5BÏ‚Œ˜X4b’.fcOÌHF©Üƒ§MÉnÍÏ«¢Ñç"’U4"¥KzÄ@B8µYÕ´ÓËa·¢oéÈv/£náè5Ü¼AÝÑ[ñÈZVùmåß=í]=‘ñùcwFžp§3_ÜòÜtqêõŸPæ‹5
+Xü©á«‹í²­r&Iá&×üuÍªÛ"[ä®Õýëj[˜ÌjÜ2¬¶õh‹Ë69Õ¦}g*^7WŒ÷clSÿ:†…K|rºîÉoP¬V'/•dé‚ìeÜaáVYV¥Ðd‡Åï°¸ä±ÖÆ ja
+9¬ ²@iÚsñ¶a{´Æf“eÉ"ò)Ÿ/¸ž
+NÏÒgøkÜ-p×$ùéE Õ]ºÑ­yÜº\A·(BYÄ\F,tP_Ê¸måâÜ§üº«A³àƒ„%¯yÚ…´a6"­™m¸60U7Ð½‹Úã	Q)<AG<U—CÁc`jÄNËñk;-‰²Ë9&ºp¨Ç8AVNÒ²ZOa œb¿_qøì[§vœè]¹.sÕôøU-Çö¯yàÉçoµ²Ù]]«j×ëìØÛñÅ¿ªü+@`]Wù—ÊïûWÚWùùgJWw¬ÍB¹BØç×¤k¼novÝºtlî	C:ÐQ™ÞO|”É ¶ÌQ6Âïî‚;:úàC¼	àJ‘ÜNÎ“¾H¬ÂVUòa}ÖÂËë÷"9û\%bŒ×À^þe||?æ›¹ëÂÏc¦*ŒÇ`wí€’î,J‹¢$÷.hVSZ_ÇˆuéoÌ:Œ8#ÒE ‹@úÐG€>¶|rÚöS*GúÌ‚r:ô@Ÿ‡ñ.ïÒg±…jXHo_6™ªæ»E<L/‡¶YDº¥}eŒpY2td»†˜n|—SjI ¸a9P¬§Ž‘~9Ó¾aóºŽ¹±é¶s7¾ùÖwvÝqëôM|ï]êÜ4ýÄÀ¡–IM½zôš_Q9¯
++2»·;Yòƒ<°["C™HO½½Ö-[xCfžpÔQW®[“±ÙxlßûPWf>q^uY¡ÞÑ§ý¿ï?u"1—ìð9¾|W@‘›i­zÂ•Ü¾3é_9½-ÉTõ„Ä‡ElˆŸL"K+ü/XëÂh Íe‰´z5Ð2Š•ûí&þd¯³!ïŒÈC 2†˜Dí!»+âªw¡Ç>àœi¹(§–Þ ]Ô|ÑL¦ÈÇ/’~4”[0FcVØÝš»ÓÀ1ñA¤?pÖ$økM‚¿Ö¤Ë²&ÑÐï¹<Ãð8â>+Qöà´œE]ùÂZrL`Y€ CÈis|Ð/„i_Ê—òšSûj¨(#Ç¤`ý‡Ê$`N%2T:‚·WÞÜJÇ Æâ
+eéŸ¯¿ŸÏâÚ­5À†û*ßŽ¤VôU~ÅÙ?|·ò¢ÀPƒk¶·kkcMÊ7"@Àù›¹l¥!ûøjj¥o¯|~~ÅöP(åRírÔöö;Þ![e«÷‹Œx#¶U¾ûá;’*ƒ+ …ÉìÒGù­0=€ã“'.ŠTh¼Ü1¸ÜÁÅË]+5X…´AAÚ°5ð;†OiÃî@ú$Þc|3÷ö0Ù%~d—ÇÝ\0Á¤}W«¬6`ÚHHÄ9L¾¯rï¨XVZŽ™>FÄ½¯Ü¥ørà,¥)vœž-Ä™œÍaô0\?œ­«tÅœIšó…\ }Å²ÃD°Q·Â&í³‚¾ô&ö·=‰$,´– Ÿ£Gµ‰£¶x‡Ep”Jžú°»òò·Û'Ë9¯÷ä[C-ÁO4)WÀ†ûykmýMSqÙ©2›×sµÚ™%”Õs³)E±Ê>éö{8ªßV9éªœºýÏvÒ§*SèÉ©kÛ¶S]Î ýÜWè‰q*[¾‚ñ”!46ô5¶vé‹üo%AÐ–ÇÈÛQ;t“MhE©à…Ùo˜ëeÀn¤ó«yYm^$ðÝBæGaë	œÍ¶|5Ön¶w’½âg&àlÚÄWöÂW¶Ávz¸ëH¤dTƒíÁ º Òí-Ÿ_È»¬'Ô¢“Ré¼…@Lü†_@¿'JÞr ‹nOÁø‰Üöbç¶æÔ\KnMš±Æ¢åÝôB­Eñyl)5„"yÙk,áî˜'î•É"‡
+®XMÜî–ë=–}“3O‹÷íù9e+ŠeÏrÅé‡íÖ€õQ‚éõíÊ¼CUk·ÍØ¶ï½­•Ê•I²ÀÁÅ!{[£®\ÔRë±û,¹R(çwyT›b’ÊÓf£œ2ÙgÙ³n`„c<½géOøë< öz¬tTqð:èÑrX^sL£Úbè¢–®cÀe¤#ú6c5+žª· ãæ;qr`êöÓ(šôV}†™È
+éaü~]³;u?gN0:Œ¨(†Ý>Òæ¾qZ~yª~4¢‹ÕàšfCD‹Ïi´ÚÏ™Ð&¿~ô†Ÿt¥§êEÚnzýbÕ·Ö¹,“€G³(½Ó¥ËŒ?Í¡Ù¾œö41RL‹Ø­`É”æ•/	a$öXÊÊb·ß@eÞýíÊ>Æ¾K{Ü!ÛøöÐºw¿omb¬òÝŸýpîöbcëÍR[nóWÎK­8xÏÚ(ÙU÷²ëZ6:UHggCqo{ß–úÁN‡òƒÊÚÎ¬ ÏS»WrÛ%«úÅQ¦ÌŸeÒÕ2vÛw²Â( ‡(ŠN§Àz´¤"]¤H óh´Ö‹ gŠCê®u‰|îôO¹zÚ\é°f[^·ô>¾dM°ù<ù7t\ ÛqJuN4Â'ÈqFø§Ûp mD
+C&Ý2M»b’OŠI>!v©â©Â{¤—)áx?¾ åX, ò-QŠuèVi)æc$&©º€D?§j"­ùôÑ–ìî*uÒ´î4®˜`°G7“HLëîB9VÒã-æŒ²9aMÏÖ0$_³†òÊÏzŽwùÚë<3ýýëÃt/U-¨õç4±Shx<ÑéÝÉìðw7à¶H¬ÎH¹›vw—wekÓ;¸Å!Ÿ™çl¥Ý÷Á*ŒÚéOŽõJ¡Á¦¦‚=½êxÜ°Sµò¬0‹0æk¼™ðû3>Å.×[*—0»Òª°dœûó`ûÝØ!N¦Ézê"ÙCVëîïõºO©¤»…‚ËúÆˆ
+"Í4åá0‰¤ô³ hæ¢o´è¼ñÇÜ†%o ÇQ}4\Fæ@°ÙÍ¾è]úyCÞA¦õ ïl%tß§&{õ_Gv‹ÇØ‘„2Éì³2´_ÿÑµy-Øøa”O¨Bõè6-?!F•åÄ‘€ZãSC/©F‚¾ƒŠ¢áQ.©ZbîðäŠHZÈ†ŠâãbwYÌ$Œ”~£…kµ3Â(ädÛkª®õ&qûÛö´åý…ÐžVÆl‰ÔO“·ïN0vÃ£_záêÚ º<ŸÍE,'IQ[Ë;†f³;Ë=›l}tõÞÓ'Ÿl^ß®Ö³°%´²«´¿³uoïáNfmêOÏKýŒ¾~y€Ñ§c`ú\z[U¿ú{žòQNÙ“‰é8ÿ)èmì"ò?Å_ä”xÉ0ÙO÷kµf­:`Rò¢f3!:b’G˜ãm¸²&>CÚpGfM²G6ñÒèÏÇãõé£¦Š€oæu!‰!ñá‹é¹dšO}NÏñ6/Tßf/Ùÿ¶`b¦“Çïv-^ž¡‹'Õ—×²¾Q8Žë´±æLÂi-ÎysQÛ†ƒ}ˆÑK˜âXv¡!‚Cþ¨)Œ¹Y×í©¹YÀSÂ¥.v.„åTc5’(Ò:ãÉ¦Š7`óïüå–Ó™àPsSÙÓ=ã¤6(èä”0}ª[B{•÷9ål‡[R¹æÉ••ßæŸ­|Ì[g_w}†n«—­È«•ßmzi’Úè“ Ûd»Eº8ëkXÈQ;:;dÜÇé¦œ/7ìoN0™í}ÂÚ©sóm\ÀÔÉ‡ëJa‹ÏN%ÖÏdÒ™=ˆ6ÕÕKoòØEæhýEÒªgÎxõé•TÚ´ NÒ§ßõ³žªÝ;kšÖ”.ãZM<ˆŸ¶-Ë/2ÜX³¦éœ5M'Ò«Ú,„’ãy‚7ë1·.ÀU/Kz&\|™?ÞÃ“Ç[Ó™ë„¿nñr?¶hÐžF™‹ÔP2€¬Q(kJ2¥hæ˜ÐY7éÅéT(%êéë@3¹Ë¼¯ò…ÊAÕY~\ùvüæMpÎ¥ÿüíðŽúÁâg|õ®Ü†æñ9~ÎýW_û4£­G7»“~Zz‚a9‹b
+£pzxÝÀX Ð¾Û@ñÑçe•©ªb…Ý>þeÆ»ë:ÆÝÌ*[ÞÅÞš©îŸ„ÚTµóZë©CL«C*“þ*û9iÍð<:2ËÙ¹¢MŸÙ†Ò2
+0²¢ùË\&–@Ú\n6UÃ…M",laH*laHHC~ZÆ¬dÍ»e$A+Ð7X?5‚#<]6‹‹-/eþª”L$öNœok\™j<5¸AJÖ×ïŸ6önK$Ç’‰3—uèˆ5sÎÓ½=Õ8‘zE˜¯ðÉJm z¹Ü÷K%—bav§SúH_ÆìÍK¯ æÄlää6šE…«eÚtK·Sgà• ‚ñ6®3	R›GC+MB?7Ã*vé†‚q[Ñ=i¸Ý6!mÔd mä™š#²Hî#¢jMÃ´çq¥Yu?i³.*¨î+£fOÚk:9sd­Ùs¹¿Ô€<è½ÖÜíBJË¬æ©›•³:NøMpT+­š:¬¹Ge=^Èt4Ó1	~ˆ"‚Ð^œ½ré—´kŽþúçtR¦®‘ÎB¿•îg/GZ½“GÓ›
+±ÎÞÿgê=œûæ¯8ÿ³X[&YóŽC½þŽøEóÊæ°&fXJ¶³{Ï*qÆÂü#¡pWq‚žã2³Ø8&0³ss~–²!Î®»¿öŒÅbaV…¾M
+©ªSÝq]jêTNj»ië®kBá¤EÕðê«¯Ö‚ø=I¢G{VÜä=dHTŒ5ÿKúWçr³Àà¤»&j’ÏQÓ„ m$xªqþO5.2«sŽ˜|¸E?ö)ä›n¯~IÛëô|ôýbÌéžx¬ÕRØëL2 -e#B‚ÚÈ}D3…0}Í‚–ádfÚu¦S1gœ˜añ~Oµ(iL'8hXH»èVŽOÏlÏª¾Tƒªå7ö‹êÍFÆf­ÑìeÖ’àO=º¢±0ðiXÛÁ¤Ã”ß8"ÄJåúœ–éþÊ$]‘ªçÙr¹}ò(2Ym *áø9{¥cU,6’v$üŒ{ö\]“ÓYk·4Æb	ùÆ[·Î·æ¦€
+VabÛÉ\øÍê”¢ŽÊžÕ§RÃñ¾VNoÞÅTÌ—zf|¾¸” ‹Ø*Ü|W[Ûê§@ YìG"ýÔ»©ô~'©Ÿ¾‹ó( ¬Tòçé¥‹Ü’:0ŸNSÐ+ 9há/­ô¯VçËZÏåeºÿ">0‚)H¸iÃ÷Ç1L¤ê<ŽæÒhtÙá¸_êãÉ-
+¿{fQÏ‹BÞì×ãuƒä }ËÒmBÇ1î…¥g´0R‡1oÒ >HFŸ‘[iäUâ"C5j`ŠŒçòè‘‘LÓeº`¬7l/¤wbY3î5ÀÑ^ý¢1NˆáìÃyÆpTp6°5Ö[¤5ßjIÌæUqª•eh©T)SY†æqFéª€zm¡bÁðÁ7©æ5@{®\fš›šŒµÙ!#+K»žJ­ëè˜‰>ëgU~k¯)ïoõ7‡BõÂEpç·žÌô·5¸Þü>çr4k¿P£Á@ÂŠõõ5´h¯M±Ï^?~ÃUsœÕÄR³ÌÕàÄ,7‚2ñ{ìú€la<,µ4D£õü^*Ÿ=Àù©s°ÛÓ"k
+ð‘LŸ“B–ßv¬h÷I;zø c'0þÃ®ö$ÝŠ–CuóÒ‹ ¿s óâ€'×ÓaÌôÑãŽ.Ý€Ör¨uO5ÂÃ‰ˆ´2¯„=Fž±9©iÃÚ3Ôd³.…q4B‹ædK4„Ì’áD4KXE`Ôš]b“øÄß£EÛÙòèzWu€Ò®Ké^=‰¾E\h»§
+ 05ƒëÅeªÃðŠ¶{L™Zò æL*1(á¥ä†¥G	®Êê™NZ¹~µf]Õ³è_=ôÈ}ÌRycú½XX‹ui?ÚþÑTˆÔ5üýïÿÀ(K*?äœU6	¸VZØ®ÏRîŠdhþ3Œ}†UnÅþHªÅfóZ;É«Q6ó´R*ŸüBÃDÃù3|„¿ƒ²“ÛÕ­‘_üe ?“)ºvÝQàÜ.‡¥·1vp³qôØÒ7øÀ¦’Mtq]Aw°tèIišã…Áö•Bé¡)c ;á_ÔÀ¡o«ÀH£ÆÂç-8kÂ?“×ûSä5¸GGe}dJŒëõúÄÔ2P›i#iÃ˜dÒ¨q4VëMriÃ¹°Þ$ÄQva¹qÒ3&®Aÿµ;‘FŸR5!P³·Ìè[4†évÇÐÌñrIÖ{:È¥Ô²®†Ò-ã3%F>YùJåû 5¼µÓ-Wß’÷vÙZR©­ÝÝó©öMÙÌ\ãTÂ´ïK½c‰ˆ ‹üO•_øãÎÍgâ4ÇØ¥ÿþ‡ÍO<~ç;'îìîâü¶ÄtBµP»Ó%Öcü×ÔôÇ†Q:cö¨¯&¢¥Û´Èùž=ì4ZãÇ85
+â/q/ÌZ‚Œ’ûiíò Ü”:ëž LŠÂXû‚«JÃkZó¸+zÐS­¿^|7¸Ü€Sñ[7Âxc^×‹§áuM7`¶DàŠü–6b”ÐNo¤­Í$Â6€å §
+&¯ñhuÓZ^¤V/z
+Ç0žÐ·™ëªµ"sF„‘ï°œ®'‹î¼‘*‹zíÓr÷›ìU	F`±\Pn_Nª 6*1`ÉùE5,Ø™ì?f{ÏÆ—¦å•‰mýwž=¾þ¾Ç·Þ¶ã­;xÌslybhë-
+»UÇ¿SžêT¿1¹3Õ×J»6Dš½²M±zÔP9Ñ±Ñ™
+Õ…¥ˆ·c}zCÊ¡F&Z77ú6oôõì\3Qÿ\ªÍn÷ZìÞÎ±ýõe>2ªñ…û;ƒ6k[ûÆæX¢iÝÚæ¦dö}ÈYÀr£V¶ËUë,lÝÉdéÎ^I•‚í¾l@õZAK¤Å_T¹.(ÉŒ©uþŽ^_.‚cH9ÁÆL!¢Z`æ.½Î?Å›A#4zßK·\$Ã¤L´–EZ°mH¬Ô¸É@|˜Øo¸6<CF$E1	E6ø}#jRöh¼=l’zø¹Ñîi#º4"Düæ#½Gß¶ß°c…[>'^£+ðAÃ©Žô´ÐÀé¤˜.m[Ã³i6§p{ã¢æÉ4¤#fo
+ÛHë×3ººŒ8jFù²w2$°š®XÃàf¾LW¶Tí  \ž5C¶l9›FŸS=íç=i£˜N… —”ãË*¶È¾â@ÇèQ+LòJþ/ÇÚ¤i˜j%“Rè¨?îM¥†b¡¡æ¦nç$®o~ãÓŒnò¸]ö@«75)(í|”ÙMþ´íeü4Æç¢Þë;vex4iˆÑF‹ÇÀ‘û-yy7çeU’D½ø%¬ä¿çfø0¡";î‘ÇÃRR­zí-zmí—ù‹`cÈfrŠœ§.ûàöÝ¯û<UgžáA`^³Xä8= ·êÚ´Æ4÷{°×rÞvØÌ}LÈE]ìY4Â@{ª6ÒFÈOU„áwÐÆ°še©Ù[v(g×éÁ&­—Ñ)²e™Ã°Íà&¬í4,ß–e1Ž§HÈ!qŠXrÍ‚&¥¯[þI¾è›óZÙ-@ß¢Ów,h=5¾{‹à´.X[SÖÍ]™/­û3\Lm„^ýÛNKí4BÙ)è7Ê€CE½„K¯.§S¾”Hˆ¨º]„)]D—]Æ(Ùˆó¢î[Q“pn½µ©r‘3{²sD¾@O¿í
+·mïhè*D\A»yTu.šóß)¬f8"|lTiõŒú%‡3ê©wÓì«4p_ÅŒ´ãÚhLÏWÔ¡ž«âƒ[¢‘f·¯m`®Ð½:é­ïGÕ|þÕ.ÙdEy öo—&qÊ9zùÂÁ0úgr´Ã£“e[Èå
+Ùí‰ËÏ¶ÅÆKŒaC	é³ŽÎÊ;tw¯‰ŽìoL×)v)"WþþO¨ÖÈ€®`šÂÐv^µôß|ÝD®'o£»/‡aR×Ã&®6|6 Ö8or "Ðí¬§
+´Ïš¤)îƒ})Î.3:jCäæåþ†<Å=ç´@²¦ Þ©Ó, 1q²Ñ§âÁ<VSÐÓfzªŽŸ}YŒSõ›Nm³ËÉ8m¬®0 „IøË£µÊS<}B§A1ôêàh,R¬³0<:¸Ýˆ÷È™”`9°7€e`ã’)^©šÄMsÅMÿ§|£]F×ëâZÁ{3&T*ªž¼4ÖƒO”¿ãJh¤°JzVÐŽToàƒM»žÞÃS'sÿ¾ëÑ‘Òc‡ç?0ÆØ?=”yž>ñ‹’	Ô)‘VŸ'î–mªl•#ùÈ`Æà<(Ù-«µ¦¥­ÕJØ]ôìiš¬éïò>„!s‹#–'%®põ³*Qo èBøšó†Ñs¹=ûíLb¨ÄÇPßú~#³ÐÇ5kuI®˜×™
+¨5v»[ÍfƒM5ˆsî°Àºàj°.é¢éŸ4*!ÒlÜæQbÑt¼-åt‰VGôÁ€u{å;uv…1et`K¦0¹¦ŽŠxçš¥O
+¸ƒL“mä1LŸf‚iì&%‹´‘ò‚4š8!gfB HágÜGx«ÑÁ´5UÔZ]£Å¤µ‘Ö 	öâ£d«à(Üºn½$^¹¤Õ±–CX`¨aÅŒÖ,Å`	m[©{9A2¤5Pô/ó€È¨ÀÂÕ²Öbfõô¥Ódzm[Û†ý\(Ì~KGs>au€<sµÄÒ½¶°&Îm	JR&0q0 Ø,ŸQ-j}8È¨û×,pÇ§±éI*?%Q¿:(¤Ë[t0ùJcsgÑQírl°>×¤xlph‡l“Tæuµ=¼ßÛ±XíÜæª±%û[Ó±RD¶Éô²üç¹,_š8‘³xl˜’qàd¿ EÐPÿ¦¹Oçu-gfW-VýˆÓŒj/ºÎ-^Y3@æ´š1=;ƒQ$ôàÎä«EÍëùV0EÌN{ Ùó‡Ñ<¬xÅa½º¸Ã1¯ÞÂªš‰ÅjÆZ¡Fxq£§jun4±Òšßp(Åå~x)”}CK˜É)ô^3¯±êPSy"ïÚI5J—D}†Ò*…Àþ”}z¦L‘Ð—pŸ>µ¿xÕðÐ®Df[.Òh±xÔÄ 3‹åCNUqÔ:ë<Ô÷Pß¬ïÎÊç*?Cañ·4×³;;{uÏªàÑ}`þËÀžLf¾»´!ÁL[áÿš:æ“Ì•®µw5‡Fò.†®	ùÎ~H¥‡‚ÉHÀÎøM‚g†™|æë9-vEDíÕ©¥OñM¼î¯Pþ9HÏc‚¤–.‚ÍŒqœÒ£VzÖ="ytü`º$Nz’Ô…¨Ùûeöx¦£Ùã…´áBhôT]Hôc–/1q"Ò†Œ´á6Ýà©z½6Ü<—§¯~eŒ¦¡µàXVÚo^ÔkïQ‹aN°ª[IÝbØ£ß”!Ýµc…j—÷¨4¢bWÖæãMCXŠ	âˆû0úa´†A€¹kAXj@3E9’[@¥•*—4¥–ÖÊãÔgîå¡vki4”,<fY½éÎ]Ë¢ÇgÿðOööt:ow>ù{ûz©ÿL~VèªÚ%EÕ³iVqú¹Ã[X"¬|WæüçßÒá–7ž²<ô$ÇƒÞ§{
+·Ý÷,cÏVšy`ÿð33Þ°Ç©2æ^×™È{Üu|GÍÛ“É¬¨w¸-D›Fóaø!UÇ• ûÌ[ŒÙ‹MÍÝ®ÜH(”ó+v%È÷36¾Zû`'Ø¤»A—¸À‚[sðiøózô!©;½4ßì
+}Bj=ÕL|¼ÙFè9i‚#ÕÆ*mp'ö³CÌ„£áŒ_á¹¼ƒ‹¡µ6|«¸Ï¾E]ò­9Ç’ž©°™`¿c­GÇr¹{H“9˜…éxèÏÒÒîT5 ü^öÀkQÎÃU±ÚpI].6˜n™m-ZÇ§6¾æ‰ØÊæàß/%¯…Y¸Í¹ã¹áÞküùºë„ï|FD¹“…Ÿï:vóôÈŽ­Ã“l²3™®­êoˆÿ3“(¶Ôšì|Ev$1‹¿­ßå
+ÚÜ2s÷pYö·X½~}×º·gWË0o‡j#]uÒÏV‹;6m(´µ`çKç¯‰:‹>²…Ž_¥“ÑK¨´YÜDVŠÙÛdZN™62Š‹¦%…û^D¹†[3ã©ÿXÙú&]‹mÒgx¥iv‘6Â.æ”\ÜwÞèµ@EïJ-f³.Œ
+Â.Ýÿ:H†—óQÌ9RFæÄ••„Æô›. ß$@«-µêÁ¢@1XS¬Åx°Â@Di¸HômÐãæZŸË²âh7ä@YËVÉÊ,†ÌEºJ;­z_Ë<1'_úÓäÚ|Çt¤yó“XôûþXGÍUk&ï+sö¾/=±joê/~¨E}žýæÆýž¦0-?þè£tš‹&µ4'¸ÌŸeç®“Æ…êaì£ÑL}-½Ì.‡ÄÞvegac?ã»ÜØf%ø“’tž Cì)–yäd¢8‰ä|vwy<Ò	Ìc^zž„gqÎ±¬{£dÏå}Po‚­0ó")Ã¾²–IntÉÀV7Šµª¥‡Ö‹HµŸ6X°ÎÄvužjgIÈ m¤âìUÊ µ®(§¹FÚˆ\#mØ6;uÅ´'¯ùÇ;i-r­ÑXmv#Œ×,Mf@ºM¡±µR…rV+"EŒ’*Éš(EÄnš¹²]‹¢ŠLàvŒjp·»,k!p=h8Fõ>Ø)PÓ:ùïQ?&þz]Êœ©P(i¬Ìï¬£ßÜüôx¨»~°-õkv…›½6VwŽ·t§J”YT¹†Çj­ˆæ\kåÇ¦¦¾šÆ+Wžh|:×å´0·)´®s$=Èÿöä‹/œMÌØ+‰'æpXÕ;¿%™\t¯’ØÍÌj±Ò(çÞFwÌeõ;5–|ÒïT
+É¢ø±€Ô™ö$|¡”4¤ù@Ùª<ÙÆ­Q¯U¡9Š!B­neãÒ‡ø:žzçy—ûvÁ ›áö¯_ÐZ®lö\ÞMV_~~ÌðJbIÃA½eD¢û}ï\îƒkÀôá +~†¸Âý1PÔÅ–ÆJôÔ‚ŠÑF4“ÉSº/¼{P0 ]mÒ»aÎUœ	k§žú}¢}nÊ×¥åóÊFÑàœKYö(ÎˆÃð2nÙ¡8ìžæpªl{SXñ2€Vnñ'œ3­>Ç®ìê„;ÓÔä­ß>|ËÐµÛUo4Ð0hzåÏS™Ï ÐuG²•÷œ<z(Wv¿Â8û¸F¶¸,öˆ×ŸZCîZO¤#”L)n[d
+Å–ŠÝgÉ÷z›R8Í"sT[o1nÎª«LÙ1+¯•~ÿizáß6n(XÅl]†Ï#Ø¾ô%~\`Œ&˜‹ëÉ½4ðïv1=%=|ƒŽ2v‘z
+Áí¢Í¶&ÌM§±¡NéŠé3ëˆ§jCí2-r¤b³¦ôé-Xƒ´áÄýïC®º&=sµn/wéZè¸^ëj'7ëAI­JÙgÒ:ØáÇða›«‘‘6P˜cc4,4'aaÏÑ…+:ø”»M_=|£IŒªðe76Qh/ëÙŠ¶áNwá2Àåzž8€`4Þe=¥^
+bMkfÆ›»:[GGÚÚéxåÇ«ß<€x6«³Ò\yëTOèCv%”G
+_-p—(ŒãS©Ù¬bV&¹£ö¹›;zO÷úZ#RÁM˜]¾c®îØñÆR=<¼ÇÄÊÉá]»F§Ù¶¶._¤ÔR
+G.=BäÎÚ¤ÅâV9·ð°õ:a¨íDÅ‡V¼´i¥×Éå`7¬ìÂÆÕ…-…d&Kô“¤[åå¡ÝÃqénÎ{r5	XKþóMÙtËÄlK6ÛxrãÒ[üuàS7é&“dÎa=‘E³ÜÊ:—î$«Ä”¯2sŠ%*£ÁÒ˜ƒ€£‘h²Ó4õxÃ’BÚˆÅà>ûŒŽì˜ó‡>¿yÌ%Ð‚Eã:Žè¹MÀ©ÚZ©£¦þeóÒ0!ÍhyÔ ì¦“ÿcŠ0ºltª2’ w-kÕ+180lVk.—…ÃÅ_CÕe(«"’\(Ó+NÆÄßËËdTQu[¦¿(wŽÍåsÍ«gÚ:éšÛíÙX¬ÅSù6£cûZŠ×Ž×6Ž¾kzÓ½Ã€ž~õ×·â¦ž@´òÏ+Æöl›Ýµgdš>²j‚j¹¿ÁH¹‘å÷³ÔxC}s¦ÔÝØo¸ô7È”Ÿc_G9ãel%th–I;àKm(¶·tÎÏ—òíåûÛ»FùÒÚ#áp>$Û€ßü–3óè£SÈ‘¥7ø‡EÎj ,« )FDåÒƒ]zÓ°Z=þwŽœSU6A#LdBtÞ¥C$´»[ëÿ_‘&,\GÎ‰Zþ-:¥ù¦(Ì•>km`)ý£ÈæhX¨ež%6]|k)î÷’{ôTÊ«—1ž†´ñÇ™xHþx‘ôx0ÉeßÒlª–lSwï"fTéÔ1UÕ§xycQ¢pÙ“x9‡ÓâWDvLQO´¢¯Ò3öÁžöìèxkWSë†L.n§üo[¬—kFžn³|˜Æ;é‹L’ín&Ù¤T.Pížo¼Ýƒ>«b•6mó&êe¦6Ö5©^;÷TîY9ºeÇèd×à‰“7Ñ´•ñ)öòËÈ}Éµe:h(6•M¥²ÃÝ©¦ºú/Jé¹÷ ü´e‰&k~´Æ—ôÈÉ+ÍœµW¾)©ÜêåŠÄC=u9{8ÑÊô`ÓU‘iøõcŠ‚¾Î‘…´â´HVÖ¶¹«-_œ_Ý5xäi9,}þ;Û¶óþkšÛìŠ†ÁÎƒÌ; |ê‹k;ïèÍ3úÄöê©}!Q²R­a0êúŒ„dsI'p?*<#ei#÷Ÿ@îÂ@‹‘oSÖëôDÈ‚.ÁÐ!åY¬æš‹!ªÉŽ¢~³ú\‰²ÓéjÍ‹F1žæ–Vœ,’ó’ºíÆücåFî'-ÿ]ÚšjKxÆgeôÚ’Mßð§<û
+7ºŒ¿ók•·ãœWž}÷öCÞ¦Ú!ÊÞ5.ÛåZå¡× …,?¯laôkå‚	›zéw²Ê,ÀôÏp~’Øµw¿GÁ¢m>JK/ &n!£ÿ+¦bdFOÕtíYÄ€Q=éëØ¸£Øcr±
+_1³in±—Bï±†šõn_ZÞwY4u“PlxøUd“X³QX¿~6;uŒÒ»ÿ[×®¤>3I}Ú«¯5“ßÈ)ÆÂf­ÇÈ…åpÁå©%`;‰øèr;BmrZÆºÞðr9j ¯”ÚPòe—Sµÿ˜õqg‚*V¹Ôí‰9e›"ÛäØüH0©ç'7o¡§bÑÜ;»VE#ùÀÁp"TceÌUèM;’_Y™+rÓíÙ¢Ë©ñÖZ¶Ãl×DÒ•ÇÎ\{*;ì}Û¢Œ+¬~Ø×Rk	¹0J±+ãòøBL®?vìj¶žf6„ÒÅð%F“™É¸=ä`G¤¸í÷?@‡ý4ì‡á	‰'êœê0êEGVFîXz™ß|2@vÒ5h9­¸,Ü*Òõg…-hA¤9s.æAA¤°cÎ´ºÿ˜9nN5GÚAöš`C¯§ZªÐë©zŠzM’is^¦ÁÓÆó/ÐÊCxŒç½¥‚}L@p‰îd«to‘vÖŠÜJäe-–Š1ºÐ©hnn€-ä[ÍÌÔ:A×Qþ)þ€O-uí–òVÝˆè4ù3h y|^Õ×²eÒZ#ŠdÌ€0
++oÆ6>ÃnšÕ½˜@y+ãuÑºÊçCW~*òVŒ±‹‡s/>ýPvcªòýWj½~^ËbnOK4ºU6ÉÑ¶-Ù_Vž¦±ùÁÁcm§ŸÌdCœ;xÒUùëH56Äjƒ5ng *ƒ¹wé£(tì\¡K`ÿ16Âø“Â0ÿýr”<Œô.½Â_å!«ù§ÄÃûO™ÂÎ™]¦9G"™æqI~ç˜hYŽª°™4€“×ÛªúÅ3Ú.Å¤J0Æm$˜;˜»	6˜ Pƒçò‡ÿ­K@~™Á4oBL­œî»é.bè)«5„+¦9£¿7¨Lx|õÏ;µQ¶ŠÿEáXmë9ÐÞv°çÔä•ïVÞbl}Íp{~ÌO{3™­Ý]ëã°º#3wÒv¸ÕÿF¢·‚Õ<¡uÇ¹/?õ0 Š!¶®‘8Êþ¾¥ògxè¼ÉSôöäi8ñ·çµŒœéy_O›.Øª?ÝêJ]lŽeôÏU…Ûÿ
+ÒZëmu-÷IF³û	x=³ù$y›˜ÅÉ-bLéÉ)šÊÛpV3&q“1‰ô¯I)“¸I™ÄMÜtÒæGäh¥sš®/š´KÑtA·˜.}wF—(¤¯^Ðú¶"}í‚Öï–å½@Þô#ZòÒý8rINô+qcÈ²Os	9Y=ù&T,gDœ¶Ô—zVñ«&TZ}LˆÙe”ÉjÝK´ÖQèø+ôëO	d5W ö¯äÙ½ˆ›?ãéH&ºCŸbÌQŸ¬wî¶×Xød¢¿N¶µmhzèQÆ¾iv5½s§ÙtÍ©Þ)|Ì$ˆ—CVì5jóªL4ï·{í{ªT?‘vÖ×p‰Ù]œÑ\ìx¹/h•n}Wh(›]‘ÛßØ8} qmÊâRã»W9võoÎtJËÉGi/ðsë`*¿ñµµµk]t€­è@çÝƒìrËta×Ü© #èªu&ê@{2…ˆr{%Šð|™z»CÖÚã‚é†—Ýg‹=âYnÌÎZ%r|éua³K 	§A|k†õqª'kÏ	&ñT;þ`ŸÔ J2œ˜!‰½&M
+¿%ž8‰ž[^kå:¦:/úü¢¦Ñ:ÐK"òr«ÙìýiZVyZà¼8…jW:ÌíOcâ"zr2&®1X©»¨?_ÏÈ¾IÒºÏšˆV ¡t6¤zBÙ2ýRå71Ÿj—#ë×MZ\J¶½a¦Ù©dq‰¦#3åBïÉÌÚäàÓst¸òÿÈµ¶}d.’c•Ï}â7œ¿ù3œŽ<Æ'Ã¸J£/ÿžVXe–+5m)æ&í>%WçOØ%YRXß")Š?›\•O?äa^SoÏ$Ûj‰Ñ³”}õUÎ›öµçöŒ°—(ý-UY¾ÍqNç–>À7òV’%³ä	ò^š¾@Þ7ïýðzŸI`Ø/’1?
+‰Å*$m7	væ@zÔÔ…wT(æ· m”Ì‰Ì˜¬˜ºHvƒ¡kðø&"ÚAVÂ‡ïy‰Ü0¬G¯î~ÂËÛ¬6*f1Üå©f"}/Ð÷}³ÇxÖò$ÐO/hÊáÝ@?ô³È9JƒV<œÂòÕ«÷‰/]Vqäýá½ZIç O@Ò„‹w¹Oô^r³?ðmëÏÈÊd²]U×6
+?ZÐzkÔ ùY<«6Ñ1õŠ]ÞÖXÓÕ ÛE|Õ_X<‡¢dYW±¸ª®x¢×ß{žjÓ¢²MêõÔ–B37 hE¾ŠÝ±‚5Þ„×[ï$]’E²X]™ˆ¿ÛÄ7+¥>¿7Ôj9çN¥â¶áûnŠ|ƒ25m^áª£J¤Æµez]ÔCí’xBÍKëln0Éb˜Ñ©ó¢‚VðÙ4ô»vîp±ŠzÛs%jOÔ=‰¢l°øÚ™Ý¡P[ˆª•›$]Ù![Ü6O;Hyí5i¿«»4Êøm.[Â5‘¤/AD{ÎAôçû›)7«2N¹hëfôËÛà‚ð•w‘	ì—gÑ«KºçÑ£÷Vñx.*’Î6zãu„£Ö<&€ä1‰)¤dŽ4®
+'Qö‰þ¼y-wÈ®W0êÞÇ¢Þ;/JtÌ^@áÒ‘S!ìÉVZ®<ÒŸ¡‚ÍEvv9
+”ÓWø éÏ;rÓ“¹¶íkæ²ô{O€Y%Tgö¨»Hyô‰Ê™é‘];Æ¦§Çvn]IÏêî¾öªVôo½m`*¼)º±·wwfÇg÷FŒIv•ûé5½Ã:üzî¡õ3+×=ôð†U³µÜ3Kæþßqr”œ%çÉ3xÿÏˆË;¦ßÿd‡¾¨wèýÑî‚sç¢ñä	¬i;Cn²afyŸ;áNÞ¶ =’6>àŸÛï_Ôq3úØî\¿œÛpÑŠäÖ{ôjÔúZÑ©%Î}J‡©€*ô<+ÃR–MßÈš^VêÖw+ùJ÷lÚ˜¸V•ÑÿÎ¶­Ée›'çÚŠíuÀé–œom+²ø]r8$Y=![¹©ÁÉ¹?ž°Ãä9Xùmúhs¸Õ_w¥…|{r@"zŠŽDƒƒÊYWwSåí+Fv\3:Ð3|üªÑ0²dXŸ³”':Y`2Ó”Ë”{Ò­ñ†Ê‹ÁO[;êà´Ç=	Ÿâ¶Ñ@>!ÍâV›Gz‡kÅ*¹YÀ÷DÞ¶ÀPÑ•	7÷ÇJáÞpÖ$ÆXrß¶Ý\‘¬ÜÅ{ý¥ëØTîìï^³ªg¸»ü^…ûù…þ;Ë¿ûª=;gÇÒ—ø>±^{ÀúÜDö‘#ôj,‹!æºFƒ mDô[ÓKÆt¸‹ž#çqºQ.†ØÃ0`fLë÷éXÔ¶™[¶Ù2Hø÷ñQ|#zYåµg(ÖëÇcºÃo—È¤ABR.p=Ê5 Ž‘_…–˜ÙÁgî;“4ü•V™q!x|®óÿT˜‡EñF²šüFì£ØÈ~{þò°žVu®GÊŒö®ånªµuoZ¸«Ù ¡‹®˜K¨·°ï1Z~£ãˆ›âjµÈ·˜Î‹^]=3±¡¯¦P?Ó” Sø””õ™Ê—9e½m›»¥ã?*?²µLœx#5ÑÀØ¥ŸÿjÓ™úDÁ_ùÏ#‡®éíºzïÁþ]¢ø 6jå>[ùÓõw´ú{2™©ÚýÜñ'Ÿ8A_iÌ¥šó~U®UDWo¶+ÛàÂ8ú4e%ïXÇ´ª`újïd&Ù=42F[¤Zé“ÿaåÞÚpÎgù*ç€Íqw©—ó+c/ÖB¾M’­À§Ã(ÝÖê‰Dç×Z=oïr®—{Ýkš\Lª3²÷èˆ£ákÜã©V—ïõTã­{nÄ7æ'oÔe^{Ì·OÐ@¨÷ÿéI—?aGC×æÖÿö„‚é"PEŽ,þïEÀ#žjwè?ˆwi)!I½×†`¶R
+íªtþHdä~ š%lœ•ý†€Õ‘yÊÅ©©ÎR¡8ºªØCç¢³}öÊûu‹SþÇ£¥hÛ‡=ãúúsÍ«ÒŸo\ÙHù¥ô%“åÀŠƒÉdo¨ò_éÆ±#gÆ‡úFNõíKý^AAÊ(“šS¬a4Û˜Ê¬èO7&Ó—~l³ý¤æšØò¸W#÷ì’vêkÎ¯ˆ´t¯š-õE:¦¾ÎC–C÷öVzo-YE_ƒñ³¼B°¬§Â,ÒžóÖ­sYXOãrêXæÊö‘’GÚÜøÝ˜ô°>é8i†é&}›1ñÝ¦ÉîöT‘þÿíÉF²³dštÉ$gÿ§Êo<OQùÝªËVYëÍèvbZ4ˆ‘¿ŠBÙh!S­åŽ1aD!ºñ8Èvöqý)Þb¦++œŽZ>*æiàJø!Å›¡‡Hê	~âðÚ»éß3½ßÊ,{›²šq)U°¼£åÉÎÊ!ä…ÊÛEÈ"‹r)TŠd\’?VO7_ÏØO8gÌfs©•‰îõõ“Íkés•wÒè¡!‡EX*/$gs¹c#Ãê<lycò™1im¯]èç‹ÁoÇÂŠÛz1îK¯ŠÄ*IÆý)Þ®®Ë´e»^åíýY´œ3¼mXðR£F™×+ˆi7	ƒvÏåÞhóCŒQ `ûcá#mä>cá¤£ªñ)-(f<P½OÎñXh”:ZI”.]bN±¨PtzðbÂæH¤]Zã%½y×*Çã2X,Jn»„,¡Ï³3W1vìzºhÃ\¬jøU¤DÇgmToõø˜ôorþü×Ç¸µ½Ö§/½ÌØ›oˆŽÜõÎÊ?<âåá™b×|æÌ³'Ê+ýMJ‡µW^ë¾ued¢•ÑûùÿKÚ{À·y]gã¸÷¾{@‚A!î-R¢D‰–dmYÃZ–¼ä!K²ä½íÄñˆ¸I'ŽG'ig|qÓ¬fTÎdfÛ$MÓ¦M¾/I¿ÔàwÏÀ+Yî¯¿ÿß–ŒcàÅ|ï{î9ÏyÎs~ˆñïaúÈ¢ò©æ¡˜ÍA×=g7,½D.cuÂaËVt ~Š”pÔ±ƒpå¥OàR‹Ô*[‚½R}iÆSÏæeè`f÷˜~N8–'ÌÜ–jL`ËáÍ5`Ëþ°eá	ž»]êTÝ£ H³nQÝÎˆó¼LèŸAO…$B‚-ás·Ö›á˜ñž:4Q³pÑºá»pP%àÈ:(TPkêM‚0È*˜™²Ô!	ó>,Ç×å›`]1dÒDG%«V0wpî«û®õ ñONŒ’RCÑÒŽŽ#mNW„ëÏ~¹úpñx¹éº`[à/ö¯N½·r¨/Ýó9SïšÃ²9Û’kˆ¿ØØ˜µÏE‚ðcHÑ­ŠnWÁëÜÆ7!ŠGèø)º¢žF4gWìè-8`hu~Çš:œ$5žLnêOuMCYŸÆú-­äCøgtëø"÷×&BìÒsro¨˜ös5
+ßºL?7—‰1i¿Ë¾R¦°Võ->ÏÆn:Ï`—Lƒ]Âùt™ØP™È™Ü'£Ž’éœÖ×d'‚Éä¼U6|Áì
+‹Yíˆ¤&"©DbÏÄí£oH¬ééº®ïSÇg’é¹$õì£>ãw±õï™J¯Í>ñwºöw´Š|\ÃQÐÃ7@ùìôþ¤¦$jÿ}hãS÷!…pìajé3ä]$O#ÿ;, WA”,)ª‰’ÐVÆdÐ•ôÔ5Ã7Óã¬,Q=^³Î‹{Ó·ÂÕö }Ú#E‘Åi£OÐr{›6¡4}}¸µ‰ZÒ‹ùv,]Œâ¹0tu#V°4µ6ÓG6KžçMg	®h™¥€¡ƒbº2OÿR‹2ƒ[f0Ë1Ê&°y8?SØòûIŽ{ê“+`(ì@†û¥nØ²l#À+_š°%RöýÔ¾ŸÕ¹x	C‚fd3A†KÈV›Ê£Tš…KTóò:§4SRoà$	äÿB:K}Î¿€åÖÙnÖC„Ó¥y×—´ Ë2®¾ýv7úVÅÒÛ‡Ð¶`ÚõÙâê·­¤Y
+·ÞÈú>WýÔéÛ¾H×°¸cË}3™™ôòíÅñÀ:„U¤«X!™`zj¤ì×œz<ÚQðÅtWtx½Úøøª¬Ãuï{ÐŒÃÈøZŠ¶§Û/Ë¯Ë7þ!\‰F+‘ýÙŠÍB×å.uóz¬¦îh\'»i¦j&½êÌ*ïLD©õ…v+†ñçz4•õë.[:Ðit)j}pKd'óŽ°6¨ ûvåÑ6GÄ|påõ‹™Šebél/uÒÝåŒåat¿ÞBÿ Ó*Úxê¨]Çb½S£ÃsaÙÔ\*•¹šÓäœ:„s‚’©™ú'=¥y¥Ót	Àëñ"”Ø3‚5÷Â`¸•(–Ó´ Á¾û<W ºŸáöópá‹«>b¼W6§UWz‡hdµ™¾¢Ít…›÷\°Aæ>Rsþð1ã–jW–œÄ^.P`¾â€ƒ¦êa6óÖ-l—,¦iÄØ:Õ–†Ù)ˆÃŸ\@û~C¦ˆzÙP()ëÍ¦°¢^šÓTü&|¢1IGÕFŒ]Ë
+…>cÇÍkÙÜˆyô_ÿÄúˆ˜Ð·Ð/±=êJ|I'ªî´ÓEg¸ÔÔPÌŸtNÕ¦ÄóÑ¡§W³*·‚EWl•d9NŽß Á;#ÅðÉ½‡"éqÒ’Ö=_P±º
+2Œ#Ñä²>Ô³œmÈ¯D´Æ­Sj”8ú|g¼Íålpbõés4%P÷²­Û­HA¾Î¨¯£Ñt…eùhWÈ0T{€èDCTœ"±J<×AÆà‹ŒbÕéŠå–µã O±¢¿T¼äÕ_à_Ž/dI'ã#ô,=GÖ0íÆ€ÂFÁæ\ÒõÓÂ [öÑ^,(”lx|7ì=7l³l|E7{aè[ž‡šÛâc+î‘"ôÅKhl9Ó‚©§iåt¹äàLÐ‚|o‚ Ú}©Q¾Üì­ˆªžyØ*YÃ1Z…_yÓ@¿ýû¿`¾š»û£šËÀV›á5œXSœ!k¹èlp©v­¡;Ú»M	z©›r6ùGšË£èšhdÙ]£““ˆRª¯.?ÖÚ¶»ÿjdüh9ã­6ýýô¬•³ëWú›Š5M‡)¿nêð¬£0èi‹ZÜÝ«ãÃØm‡ÂˆÝçjoù‹µ	ºl&5å~­@óº1|©ÉrÔrÚò1H”8žtJ èz{Šý¼p=‹|î®‡E
+ÝÂâREr¸Œ1•³ž¡q+œÅë™†6×TÚ,Ä<¥¶Òi†šó6kÉ6J¿p+qD³‘U]îÆ<ó‹ƒ‰LI¯³Gs—Ê|Ñ`¨Úh8Ö<*d+9+(ª•ÇèŸ@&L{ÍWüû¹‰«Î,%Ì^;8;³~þmÍ·®Ùspã}O½÷¸¦<Øwåú¼M.Õ¦i«;v“¶F¯î2‡•„Ó®u]¸aG?±u¦ÓÖáÉ·Ž9®-änYpf"Póê~`–î¥ù´ñàº¾Æp¹ÔÓàõ„âåË2iœÌoÚÜ–\óx//Ò=ÖXÉÛ5".ºMG:ÃîT@sÛt}/C1èò‹öF[!…&Šö&<áb´¿ÏpÂ{íú2ú§- uÿ_YœÙIãÌOÐu²ÌYö£—YG}Àäö%uäJèUóp°€¨ú‚V¿y´ˆÜÍÀ–H8fýâ¥eö×›.éõb)Àñ’6G--|ð|Ä¼'D!Î+° Þ·¼O´˜5²aÁ×¥Þ(Ç]$/0$I¶ª€-'°%6‚°¼üÌæç¤S£HÍ°cÁp&SI2ÈTðÑÒµ¹dæù„ô„|Íi9ü¨¬&1Æ‚Iõ!VÒ?õ®¹êç¨Ÿ¡±·/ÿ·? oõ~ý¿Q©úêŒ¬áäáõñÑtÁ¦¨ØáTÅhH6õGW-‹fD'Á®XcÞíïH9“k£xñqV­œ)Þe`üøFÏ¿¤±¼†Þ´@#¯¶í}½³×å]›C³ŸC¢Ò4¯³e86Ðdoð2W8‰Põ÷ÓËµX‡÷_Ú3jÀå¢§E¬ÇN ®¿]¦>èe¢Yš-« vZÀÈºH) ‰/»kÈ£<YoÖö ¶ïÇ=B=jøpæàŒq=h™Ä“´ðH¨†úÁrFbcBžzŸØ2€ƒJŠÌWÀ–ØØ½YÕl(J¹xsöÉd‡9ìenœ‚ûe~«NB*@á*t‡ËPG¨ûÓ~F€æiæÎ.š‘ŠÐ)[Î‰á8œvË‡ç¨‚Šýrõ¿´Yå?”•wlÚÒaíH/?ÜwYrloºeEfEöîê«/Ã‰îdÝÏ¾¿ls29O‹ëÒ0“¹úãEdL^iÈyPH¹íì^‚WŸ"ùkVŸ!„wÂ24b!ŽT Qvb¼…ÝRþxç‚v±ÿtßÒÇÉ	êƒb4=]°|NZŸ(@´‹JÝ¯	­›"Ýq„M'Î<«¤Oüð’of¾ÉÂŸdaÊ<¼Ðó–[-9öÌCí`)•Ü%`)UÑ ø–À%i›†Ùué¾ÞzEO™6h 	E‰7í_¼2úáA¬°GÉ^¥·¦5'ÖÈÇÕri@Èx?Qð
+Í×æŸ]Ü!ç³Y88ìrï?xô¦ØPôºš‘u¥[†"¾èl`ÝèèÙé»žki#U×HØVýÑŽÃO%y§ßYýBõ:t#fjûh)ÆëŸ«†JÏmÅDè#LXzE¥^Bå±Ç¹¥WÉ.†)§,C–yËŸáZçtà&1Ô`T ËYÖ\ÀA;y¦ÌbÂ7@šoÖÎ:1 ‘Óž:7ž¿Îæ@Qt áú†Ý	úïhPEç:@Ú2•ð¶cžî‘ÍŽ²žó¼‘®6~ÑN¼˜¦H±â‚*õôx3“–JÜ\_Ieð3_/ü
+F?ªþ=¼Í@÷l¹»gù« !G›!ÿ„œ¬ÀŸÖü¾FcƒJr¾hõ5…|ý5X'¾R*Õf m¨UD]zu?¤Â'c­M»j`›Ã©Ü‹TRâÖêGŽ>\RÎ}_§Ï{!×O—Ç¡o|áÏõÎðÿpÝ-½—¼Hý»›žç¨­an×¯Gœåe žÍ¢Ipuâ¢H`Ø˜wËó5Â¢IÞã9(ÈƒÓ¢‡.!¢Êu¢¢³Í¤Ü)/í‚iãx3åN3Â„,EmóÔq$8Ÿ²äd, ]é—õ°§”]²•7ËTL“l‹j¡O²jX˜Í²ÍÖaÝ¨ÌÅ`+Lí+ÈÐ£pÍªH¢ªÎeØKø=C÷8Y:ã¿¶|îéG¦µî¸"wxúéùË¸
+É‘Ã}S=ÇGGç½­Æ¿T}4çÖÜ;RýÓÄ}ÿ4{û`õ•K?î80(%ï»/µwjjos.ëèÌ†b¾pçêåwvõ|ÆåjJß#„ á„Á×{Ñ/Ðu½z›±ªÐ b¯Š ²MÆV,ë—ž%k©h¡KåËÝ :ˆ÷
+ØLÎµ>fbZï4mÏ`Ë î˜§Žµ3mË`K$´fÛ/œ®(c
+¦G½()é \ì´c«^S–…’4p/zÍl`îgê¯°éÞ%–8Í
+‹wKÑóä\(»KMX°eru‡§Þö6nèj‘ù,†æ"ÍØ…D?MiÃ}=LwŸõÙø‚BÔ:«Þ ð†øÚœ3(S”Ã¼õ3È§Ô„ßèM€èueüó`[hà`×Ü]£®ÕªÄïz“˜»vWÜåÉÇÞrƒkM—G<÷>Ý¦Ø ‰4õÇi—ÕN4œÉ.³Æ¼í8àH76]ªNþó«ýGû±ƒí]ªÝPÜ•Ž{ÌKÌ§¾f‹ù¼a5ÒyRQ+=X×±uXµ®FŠ;QG/Ët¼xž¤œÕ=Õ{¢N«þ~N«NÅé‚gû\IŸÕ¯ÙÔÞö˜‡hJIÅX‹úÂ=q[ØMFè1d€:D‡£Ð‘)ºÊÂ—92Äê)<–°¸ÈKøYšçn±üµÐ”s7‡Š*VCiZó\züØ>“Ð0pdóÏ¥§ÜÁ¦iµ‰´œ[<ø]aJ^á©cÝE‘Zåšt°ê=«5¹‹
+Ñ/˜©,qv§ÄBrâ‰Òü;ÕÖ	uXä¥ùÒÿ:qîÝñÕ]Á-…÷ÝrÅƒ…Î¹¦e=¯O«v=LZhÌÓøD3ˆÛF_}¨åP¶íô§’zÌÏoèï;r¤BOÂ`ay´·1cÃ8ˆ [-©çÈR¶Ñu]†ßÙi]µAÚ£[‰zy›=Õ—ÝÐ‚ÉŸ^3CˆnWûI»W7Xœ9FsÝ÷“Ý÷§-W¢/’µQÔTø~µFh€!OØ2ž$¦(šæd-k£is.‚öá¹²Ël³ÆŽä„-©UðúRé—¡dçùëZ<ÿd'²´¨YÞ.¤û÷‰Ç*ŠöA)³hp¤ª=¬Fó„#™ñ¸<f<f®™¹±Tf=o61šXd•lÉð÷•¤°Í’—bý¬?Ø>ñcÁ÷Ø»þU*ð«¹tDÃÂ*¯ÅE(Å][&ÍLÕJÙ%j •rZª¬³ÙÆ¤6³/œQAçµ›äÄóçË?ûî·ÐßþÃ']o¤ú‘lÙëMy=…D¢èœ:ÕŒUüÑôdš`äÿUñšñUo»í¶û–¾ÓÏµOÞpdo÷#Lm¡úê¿ VDšµoþ’¸å Æðßà+w,àË­€€½k'"Û«`´G•“Š;S¡`L{ÆžµÅt9wèv-[ï~+¯#öÓ}ö%bgZT§ ßÖë™"W`‡Ž²Ó¦uln€‘u<H‚‘!­–^ævàŽÊXønÝ<P­?,Œ6‘ÔWâi †/®Èì7£NC$dZeWI	Ø<¶ƒJ²\Í>^Å´Þ*µµ_€¥<øŠr®ØP‰€ÛëÎ‹Ù"E¤–{ê³·FWa×d»Ë°Mp!¾jºC+Ñhz®¯dB‚rüeèebìzÍ¡’ÄjÀaª_G·ŽïkÉf¢±®à[†·<6²eí+bcY«GÏo,¼Šp,šÒÓû§§÷§—Æï+·ô¬m
+¥X%ºÎu¯µlvæ&âc-ÔÞÙ3ŸxrOª²ca&ùðÃºÝŸßçmnA±áèIB†yýa>Y~9¶6z5šö5Ûà®ˆ]·‘&›ÝÐ”•XU‡-ÖI4èö…n¤ZØ“-¸ÒAºñŽB)ƒÀäÚT ©±;H·ÎíÞ»ô~ê‡if1,m4?<ŠâÓ#`áhöÏ]Ÿ—½^,¨V1›rv‹p¶
+_·ƒl0¹²Ó{³Yõð\)9fN.&(^Š&=ø.[ö,IîÌÁ•‰ØR+iŸ§NÝç©cªiY‚-[éà33óŸˆ¨š?P›óÃŸ$#â©GæÔSdï ½mÚÀ>,è3RoJÿ†3i (âH§K÷
+õkÙÉäe<*ú"iˆ ¡Â(’™®Tj4«ˆÐØµ	UXû²A]3„ž‡Yc+x…6ðh$®“û_FE?aÝÙ¤1­«4¾ô–ÁwzC¨]ÃäØ	xÌŽ‚ŽS‡™lyí»¯¡ï|ÿxË@±ÍÃ­{{.[³*·û¾ŽÂÊ2¸ÑØXýF6-¦VË½g&çv‡Ã-Ý‰#ú•9„.%#«á aãÛÂø«v…‚Í.ÃéjJ¸ÐŽ\Ñ£²Ü÷;ä#øÿX©§Û‚Æ4;(’Ó1±Š®6¥JSº^¼°ýl€ ”CdÚöV8ëB@è Çç¾˜²NÐ¿¸æÌeŒ·ËwV»*—üÅEgéWÍEg©•·oÆÙ5Ï·“»8äË2þdëxˆœYå©— àËÉ>oµ6æ»B×€c@»dt6¥žóP”¹ÍR.UÉAWf¦6–¬†tæÔ $ËdÈ×dßp<¾ó‰¬¤t/ŸDA¯o¼}ä=Û4t¼²»cÕéÞÞí¹S£wÏ­gUÞóÈëÏÉÞ†œ?Ù–H4†gº»9òùwÕ¿AÞÍ7ò¬{øàm Þ®èÄæ •z×¯P­Ur„¥Åháª½` Ü9÷o¾
+“C¢N§Òuôiò"édÕ÷v†^‰¶ÃX9^FÛ#€»ÀQ|ôþ­lMgƒ	ßõðžC©«eá•V¶…D÷À6ÑøÃ=Ûkgë%ar³å$¾’ñÔÃ…Œit\´..å6ÇMëeÜSôÀ6Oe–ÞTÏeóßÞ‹Ö¤ûÖq~¿T¬OÈåÏ­iZˆî ‰›UEÙ”•lº^ò¥;t±6Q¼’êx},'ã‰±q¥6•Æ‰¥usº~dÍúMëv¬xÏìôà¡[nší»þø-ëí~ëÙ×<¿|ø{'v§RýŸ>üno.Ž)w¡‘‰?Íµ,O§Ïú3¾Ž£¥W9•˜ŽÓ•Äÿ½ñÑ‰{ž@øo—ÝÜÛK†³±ÆJ_C¨R‰øz÷!Bp™Qú0Î¥þrVŒõì§‹mz9Í’NgíH3”&×š‰-ÃxzZ,fëÒ‹ä¯XßL’æ[Qì6–FJ¬¼uŒ5Î/Y™¢C[î¸`…ï’.féÔ_Ìò–§{ÀSwëL§lÉ${»ÔÞ‚';”¯éUBo¢‘Å›ßu‹K†Ïp…øQ’oÌbÝ¦·J¼™YªÓ2E[NpºXf{#1@pü7hA¨²|ó”Ã¾šDk¹A¦+ýróÜdû²r÷ÔDG7eŠ_W¿—=8ƒnGèËÇwîžžZ6rõ5#ýè¾µAšÑpÙ}ÅmˆÌÌ¯·¸TŸËåÅ±v;ŽÎ4¦–f“‰–×Ï+Ö†Æ¸ã=€ÂšôÓ=ÅRÏúu=•ò¯¨#Û†={×,Ÿº<iqb%öÑ)˜úñ	Ù©Òüù£¬¿›Xò––S–· AˆÛB‚ÈSÏ‡˜øÌÍ²Ð2ô€ÔMJ@¼$8QÑ3'Øä|ØPšó<€9œ\É†ßr?ï§kÖõôó8˜¯„#ÏœçY k²©îÖ£G¹Sc‘Ï¦oaiÁ4˜¡~<’r›¦-»<féUlI‹B_…}€›k>êËQÜÍU·Êzñœ\ˆ&:ÍbÙ\×º’5]$%Þuri† Æ ©ô•Ùhï`M¨ „dÖ¡é9SñYJ¢\ÞMdÐ¨® w|èw4G%ËÖï:*,.¼Á@/ÑuèAk·{ô\ÔðY»¢êJ°+fÚq¢'|•f§ŸfMNÀvŒt\m´UO[ˆ»87¶³±¯HïŽû¿+§ÛÔê»ì™H¤ÕƒÿêÑ	ð[Ø§.kbÁ{Ž.t/
+iîL[«çe’F¸IÍî*¹=a«¢û}Åb8lT¿Üg¸ôLÞ•òùãvWØZ™‹9|öxê÷–&£•Dº—8ôb÷ù5-jØß‚ÑÙ4]5Ú×á
+tÒ/¦mgç©€ÕÈê¿á-Ø½kîÕhÒÐì6¯ñGÄ{´¦–^¦~ÑA’­–›,w£É1j©a	Øò‹ÀÐÝk¹³6Îãèb] å¨i£„Ç`ÆÜ'‰p`KåË;©}r‘¯X°oŽ4DzðB0˜çJ‘ÀŸ-+w·ðz|&ž×³œeaFp+ë—öi¼)Lî¡»M_ìŒ§žŠ€µ|ú&gÈJ5xo¸åM´ XK"ØÍVlIš0F­F™ \‘3&J}5€ºÌ®„Úº"kû3ÍòIu€:cÖƒæš3 2n6Ë@Ž2Ed“Óp*†/îh™Hôdu§¡ié‰Æ¸5êV<Q`Êa4en]‘,õ%;uz£¤é·#@†¡ï¬—7·¤g²Ù>_b×Ää•[~º·š¡¶cùm9Œºíà;í	oz´ÍFUß‡ñ™/œ½	ãók6Ý§ÐO ¸Z"YÀ4Ör)ÔâRlš;Jxº™ƒj•'×ßÙe·ºÍ¦FË‘VŒ¸ ©õ4°(›g«*×Ðgh
+¾çYŒG‘-êõFŒµëRgÉ]ýëcXÃxÓ>¬1\èÝóo¥¾|ÌrÐrbNî[B«…€å4†ÃƒwY…µ+å½žúÐb³b&]r]mZp`Ãt*)òd^€`KŽ“¨¼V`ÙC-F*Â±âµO	[zwø¬wGo,òùT×R_æ
+ùž£þ¾\p²î³û$©<õ‰ó\-ûfÓ›œ«½	]ÁZyÖlm›X?ÍÀËf=¬bñòÝ^T€j
+i?Mc…©XÓÜºÂÒg™ÇŸ^À½7ëBà³úòÈÍÆ½Ó„ˆœDªÇ‰ma{ÛŠT9§9¢‘ôhx°Å‘
+`ŸÝa(PßžB©×ŸHZ‰â(¦¦iT‰ó¾ñè}%áTT!g4{ª£ú©®=žê¢îø™ÿeªèvEL;<©ùçí4ÅqT·ª82áL— rkW9¿Ý¡ÑÜÕÙ•íØVÒ4§ÖHÜZ¼/Öé×Uêà“îfç×ªÏŸ*Ž¦PTõ»Ú¶*ßïo¬”ƒxÚ·Ékk´ê¼—f÷èÕâ¾¬ÀÒ>}3B†­ÕÜÒsäÆÑ^MS¢ßJ=DWÈµyq±Þ<[Ö ÜJl™aÃ±“1ÏËØ+çîl)Ö…uuîf	'›ð7…Y¶°¿ ,ÞÔfnp“!04¾I¾Ø@‚c€·<,²œbuj.D¬½lmé¹HÍŸ2Á ÁòW¥(Ÿ¨é±˜ Ã{X®ìÜ’eË“Ï óô4¾ Û”0qÙ¦³ÔÓÐm>/ôÄ}MJÐK¬¾ríåŽád|$JÃ„5áH«wwl0bs¶EGZBYÔ»|Aàj·iäÎõÊ&£HIoë?†^¥ACDWÔ†‰t'uwPìéÈú^âuQW‹Û.»b/„š£Ì­Ð¿…Tw1Ñp¸6aò‚VæG‚¡¬W³¢°ýW*]óKf³Œí4æ+4%qw´Qô0ó”ÍÙÅ
+©.@!@îDrNày%XÃZ@GsÉrB~Sb(’çø	TE8yE0’ýº_Öc5`äXò(¶)zMg‚ lÅ¦é¬×±:‡UW¬íXóŠÜ|¥pÃ\t,ïxâ-ïÛ‰ñÿå{ï§ÿ/aÜ9:»ÕGB¸Ñ¨ÞRÁh3N¯?@O—¦¤IcÓŒßÿ Æcˆ¬¿B!»6hšÎ®§!ËyŸþL0üq•ì@§Ov›F:ÈX Éå„ä‰õb²®Ÿ"ì!>ŒÖ:Ô—"‚(
+=þ[Ö’ AZ):ÅO/3­û‚È·ES–L²iÒU‚.ms›&`ìú±n-tPËäÅêñÜŽþã÷¶—~†Hc$jŒž>=úúØlŽˆ}
+äZ½šf;pà0>Œ4MêVÅîV+Lõþý<Cr`ªØ¿!ÕJ¢ÆÒxuEÛë¶]qêN5»:[8\_ßñèC_ÂÞ2*¬nv…lx”Íq ¬;L#³ÍNÖKs1Qº
+ÎL«¨==õ<ôàd6Ýâ©v€÷ÃïúW½ÿu‰“˜c³|x¨pÛÂt„¦×ÙÔþ4!…sþ´WÊ”§ËêÅ,þ·Ù–ýg¦Æ¦³{GN¬~åwð£¬ÂfÒ‰ÿB^ÅÖÛïÚqðèÂ½/¯›ÂÇ—Å\Î¦XGg“ßÛÐXý-þô¾”¡sÕû‘½'›ëó¾‡^ÛÖ…B[¾sÍŽ|¢§Õ×éµüQè² ZkÄ¯dˆ9# Í‹r„0—1ø$jðŽ"(gp…œ^¤D.·–õ±ñ­@:³œ.Ø2e[Ö®Ì)+´Çè·cøŸáÉ{.ìy»”Fâ·s˜qÖ7bbÐÕÈ;¡ÁE+2¡N…:UF@¦pÚÊ­g¡žÚ•pFÔR3ä¥ÎÍ—wæ'¢¯U¾9¸£%“©¹öŽ#cW¤Ó3--ß=ÕÿjÜÖÜ<™Â{gûû§ÿy¼zy É¹þD¦yî~‚«_ÈO„Ã…Ný	Ò¾çúWF	šÃ˜L¡Ú?ÛÓˆ'v0½¤#CV÷]Ñî^"0ÓO’ç‰›®ø\vƒsæ-sâ„Oäj”ÞßÌ6cXÆ"¿Â$º ãµ°nÌj,W‹Zæ66Í´®¾2WÓÁ¨]a ;½øß—%>Új:·¬ÔzžßÊêøœé|ƒ… Ê$• î“|´Mžz~¶½Á–£:À6O•”¹ž¹zµ‡c¤p+KN`sõF©êR›éä¯w-†åü5Syã óp©,˜m}¥$„·éŒ¦4(U?yÃMœ‚?¶uïÐš`ÓhiýŽ­÷|ºuÇûŸ>jU+r¡èNkG3pÞ}y[ëêÌÊø¿\œkšš=…”ýÓþ]h`³3×›)&ÂGž[6uÝ8É}ù…øD‹‘mjjV¢ë»ÐgÓY›ÝÓÜêsç«ônEUEQµ°zã/Õ—&ÂhP]çv¥'’ÑÛÇš‚xihü2M‡t_¦©ÙÌ!ÅÒNýÌüà,¢ÿàâ–Ó¿÷/BMÝý<dr*½ÿ~O…r¿É¼Ä`U±–&·c†î&·ÇÊÊ¦*\Í­žzÁüVÓ¼Õ´á½ï9ØÐÛb–{ØÕ”0-8B `Ë!½ð*2…zo6ïWŠàcCóâ]l¯jØá±°ÜX‹¹Í[Îœ
+™®ÆÿLì^¬_‰æ)
+™Ú×ç_“«|mo~‘ÈØ’Ãe”·2§¼±öƒ°ZªäkBµT¯+rcSá”ÑÁãˆí%–ÿåÆg‚ýHmvk=ÆIƒÇfÃÐÐ$&AœïFüåE×$à{ø»ÿ¶l_þ7C»n2ÐrìlKÄã3Wõ*¬+DsDüNµ´<}·;“É÷†í.rwúš=ªS·ºõ@[Ggƒp(	ÕaC¾&Gf²)Ýú]z9ø@CgððõVw¦<É¡âÊIÄD‰6ê…ÊUÅx‰„Œêk(ÄÔM‚È½c¬wÜå4{TpXfËxRÙv:±Õh¬xÛ ÙÉµ'{ÚègpèJÛtb¸ð@:´o˜]–#ˆ´æ†º¦r.×A‚ãøu«æF{’„Ø}î_c×áÈÒd5½z>§-ÑŽ¼›­vY0VŒ$IÈBpØÃév2Ã„ºÛ&¸R)ƒ-Cx¾LîÀ6O_“*6p< )p»þ¼ÒÝN Íˆ|8[¶µ)v5ìÔµ°Ø›Ö°ï¼•A^aÏ…M™òCÓÕa–'6Ï…–+IW[ã©Ã6f­x áÊ4lÙÁvmZ±>ÊÔºt•ÕÿA+§¦LhYzÄºÚëÔT¶+¤õr†]7@Øª3»œÊµªIY¨²|eŠ ?îû&Fgfèb^÷Œ-æõÅŒ¿«¾FÝ²ô´¯Š¦ÃÝ±,AØ°é†¦4´zº6gc¾(HÙ~ðø54µãèáÖ¼kS¾âÑãÁ`ƒî*Žglú®[1]žÏ>§¼˜jƒÁ^Hƒj.AßvDÉÁØüX¸ÍëŒ­v«UShîì-6{â­†ÏªLà ½Ú¡$ vÂ¶E<Ôc¿è9Ü¼ôYÖ3¦1Í*Pý†Í6uÀÃ$Z®69^]®8¿ÉõÁ‰c­Øçy@jÖj;±Xßày¼P=76K„Ïxªz?¬>+¼ñòZR-?ØÐ
+ÈIØ\:(Uô•e¼Œ§ÎDU;Q;®×NôbÅzÖ…MD×®«VÂ‹#[6/Œ>Î 
+“]£Ïtø,=ÏMÁ(R‘±í©!¯ŽÈ4LÊ¥ÿkØõgÆgc½‘Œb44šõ*çÝQ»®}¥ûPáeIy4;àFºU'aõ­DÁ$áó¼µªa|*žÐõÕî¸+=™Ü<XiõDl.%¦©F|¹îÑpO,¢ï6…YÝàÊ¥çÈY=µÙÒCcÈßBÓ.JI<*•C¡aHîå£¦³¶d0Á1òŒ™³ðQ“[¦p¼D]Á†0n·È™ž"(„*¢§¢ApFzEÝ”w:]L¡’lP3…ÊhÔs”7¨ŽÒ!”× ‡­_²LÊEþ¹.Û¸ÄÀ!@L.„þP*LMz7¯ZžïEË	îx··%{y¯¯'‰W¼c%úÇñÉýû&ÇG'ìŸœ@×Íz[¼@f±[C¬vL×áøh6•ÊŒÄÒ¯]={;Wf¡‰þiôáÝ=½=›J½==ï ¦¥nè™Ä^5º1»no´7©Ù±ªXêÞµ= æ§[J,É³¹ñ%Ë.˜/dy1õÑyñãrYÖk-Ù0ˆ.äd‚ 0´ä€ôÔUúšB8FÖ‰$l·RªìÇà,a]4\?éQËCìö>Ë9v[xÁ:6‘Rë	QAçÚ’C¦-*æ’¤Öhú€Pñ¹i‘ãâ2Ø«cäÜ–ÕŸû<u½d°¤öƒ"Ü}ä<×P~ËyÖù@ &E?Ö&Ã”ØÒµl‚I@˜æÇÀpµN\Î0X^®« gcB‰‚r¤¬ lb˜ö×SÉ0îQ;ª2û*Bbò›¦Ú/OvìèØø»¾dqYlY>ÖUèˆåPùxzK_ySúš«'V6§Ÿn,ø‡÷­¿Þó1¢ßˆšû#å5­ëÖåVÍó!”Ï>ˆŒ¹QV¼Á®TÔ—G*Áê·¼1ûü±–ÀüU=ù#ãÙµo|×ñW\7^
+¨êB·OUm>ôÕ¬ÃÐ¹¤Ã0lÕ»Rv«Íž^»ôÙ¬©»€¯Yé*¶:‡:…öh÷TÈéMDMÁŠâZ è‹*ò_v¬!ZÛ¬JX=~õˆÜÍØLCôÜ?~ìÎ¥É–»ähD¼•@d«iÂm¸j%p¹;¹L¡†yNìZ’q©™\ÄEÐT)§Aª+Áqx-HoáV"úp¼LsÁ–U$‹)4ãÙlˆú7³¬"(ð/‰Þ1s6û˜™9)ã(3$¶l62+¬<uÎSý
+‚èútaºš_ê9¸ÇülBÛ8‹öEÂ\‘½A=lnÓñó»ØžÉpcÕcOÌ}eõ­' 8­®zô±9m"‚?‚¼ØÉÞ‘
+¯øÎííc;â­D¡±O nØ•uÅÜ÷˜?¹œ±Ô°
+£Îs„œÖnÌvíÀÆV$$¬ÐëÁjÄZ²N}›Fl~+Ÿ|·fÅN·‹ì½	"p]Óì*¢ë½u>ÿký7£›"®¸)ý½-]ä%¤Þñ¸å„åó°ép¿ØX8ñ3ý–×o‡É'L±+ë·Ù"‡é˜è8MúRÐH.i°9l
+/ï°\ÇâÈÕd´
+¶DDö˜/%÷Ÿ~ífËö¬ôž«¡IÏk¯È j„×:ÿµTaªí<tÉ^¢ÔÍî¡ÿö‚ÞHOm.iE­k´CF—©U½ÅÚ—¼q×W·Í=>›lô—ƒq(‘´cüµ¿_»˜îÂºê÷6æ*)šµiZj.:žs6Tƒø4»xš®DÛ<——s§µúÝðT¡°«wÅÑLv0\ýn,¶µ£)àñüé¦3·ÜRb
+ðÙ È±õ¨šUëUè¹R°Ph°DlÍÑæŒî¶»´RÑ×h§¾†¾•_ÕU›¨Vµ!ß”mH“QÉDcdYzyˆh4ÊB;`=û—^fu>Ý‹Fiæý]4o‡•ì´ƒx›&Ô–á”—L¡‰ìéƒ7.nÍ“#$­ðÒ‚ŸÜ–>FŠ”l6ãàÂ^¦”ä…&Î5k±Ô–šÐt}‹¹‘YNFãýŸI«ÌŠ&rKDÃJŽq
+õ´·§Îˆ¨d¸bdÿ\Ã½.Xò«òèØ9¶ïš³³Ï<Ú|n~Ïþ…»ß¸í“±®@jy6{Å°¯3Žñ¿ï/¾úÉp)ŸÌfgÓÞ´UîA˜‰zŠÑýžÙöPlg)äêÌÏÍ¢xfþ²\2Ýöš
+ãAr8_…±ŒÃ¤ú¿üE]‘«öb×²ööÝ•µ7´«tëÿdš•f:£è#V[%Î¬E8f^¾pŠ1sNÓŽr±­ùB—gXÔ2ç»8hY?1ðp2j=/&ÇÇH^?¼†d)zê,E Ú%k&¢Âg¹œ×dø$‰õ·Ò7g@LÜ†­OÂ3¦[ï¹P…«éjñ¦½ B£`Fi‰c¦pÄ¢ätPLŽíë-ÓÕPa"¥Â‘Rmu$0Ê‰
+P?Aïø©¯'€¯$š¸Lç09Í*;@.¡a²š,Zi8L/~¯=âwV|ô°<¬Ùx"¥ü˜ü	¨>AÍ8B¶àdga>µâŸJR“xðÑµ¾¥4iÈº	]“>~ì²Û;½ê{Fõ_éóùšœˆè¯?E# Áb±¤2ø‰TOÅ-KŸ!ûè:i³lµ\ÞÏ’(kqy²‚g¿×r¸KË¢‹«ÏsÀl‰Öëg¯)êØkÚ¼Á‹ðV3\É+ÜÐ;`5f²™V,PxÙà¶á˜`U\SÛË Ô§ˆÅ¨'¤E.+eN`:%‹ÔX”qÉÅ4™<B\AWÐtÀ¶*‘Os®õjÙ;•§ï±†}])¥ .Õ¸¶L-Kµ¯ÚÙt
+ÜQ­’$JG|«%ÑÀ=˜!YÙÒÎ…Â•rJ´áÁ¨œ0ÑAÇ¤§!•ž&$uSƒrDJ]3ußÔŸƒÕobD<³ýý+¼KÕ¥á­‰ø²˜£<Eÿ¦g§0®~­ï¶~<úe[sñ‡]¿†eöìçªÛ<Æ²mÙÒí3/8’¡`Â(æWLŽ§t„?kùÁ9F¥Eßž	è™˜	ÜÇ¸ñîÝôºØ¦ ã4bvÐ÷ÝþXÐc`tÝ0ì˜áÁØÍŸcîÔ°Â8ntB	&®ºùæn»}u®²ÒHÀäOÕ2½ôyŽæ>ºæ-YÞ	SìLoÒ3®×í‘¶9:žñÔ…,/§ÇÍ°	EtNb‚à	‹¿†êHÁ;/¸÷/`}¾¾Ü;‹ ÙÀç?eyœÝžØ¤È×˜”P¤;[Àtn¥ÆØ³‹u¤æþÉâØ²À<lY×‚Ui/H‘Ý@oo(r[–NyêÄ®÷Ô	¾`Ë’Ø‘ÂkAÖ	"SûIj?YÙ'Ke}œ‹±y3Q†zš( KÐ’ëeß9ë&W#8fs&ShfË}LÌÌ<‘'È†—	î®äðˆùçÙô–J°wm|n¾yëà™f¬½ým›ö.»yþþ»xí[®Ì¯yr¾w·†6fÖ¬Ñ€GýA¦ÏçK¹fZm^#¿¶­·d8§(Æ»7ºÒaˆýÍfWðöÍû²gß‘\(•6¥÷¿søžX±·Áp®„p“;¢êUÇEÆb½Ýa‡Ý°FÊù amÏ¬jŽ%ZfZ*_sîi6©ck™h3±“˜6WÍIhÝ2šÂÉ’á¶{õPÖ›ó¸Øú´L~áeðN
+^¦ L¿‹3âÈø±&…Ò÷bŒeoë»Ét¯°Yš-–G¸[ZNJ„ÎÙ\X©ÃSÏLÁ–IØ©Å;	Š×‹ø&&PZ/Ñac§»¼Á.¨z“àÿxuCœt8Û%RÛœ…P!¹ ‡BrÍe-ÖcÖcP'¹A'“(høê,Æ/~PQÜÑ²¿¦©.k$\ÖÜÐÏ«ºUq8(GU!mñRp‚†ßvEÅf×¥Ii4ª'«C:Mûõÿú¬ò›’!ä˜ÖZ”Tÿqîêlv¾uÿpYz2µu¦mU:R&h¾gµjb­ÁŸŒÍwtysaz¢F`öJ½&Ÿ¢±;Tå i.àÅ¼1åÍÒÿob? ‘pŽš<u„ Z¾¯ZÅ x™«ò²¿Jdð%¡Dì`‘7VãA­²yàÂºÈ›¼ìo²J_×Œæ¶ôXõÀÛ7ûÿS•‡ÚâE‰µ™;N˜¿‘•w	Ž†yÙýÂþ8Ñ´ÌQr3Ôš¬¼yå=,Šî'ÚšF";¶Þ[þBË•ïÇÄžÈÒ­i¨ùˆµ=5y´oKzïÃ…Â\SêXÿãåÎmmó¹ùÔÇ*#wÞ0¾afð,R¶×*ïÇ^Z…öðÊû?œJ®í|Gb2Ž>•Î…<Íy®·VPt¿Vw(aíVŒVo ›$b†!ÂOVâÉ†¦É‰d4}Q½½êí
+ËO	]|]ë-‡Ñã@Ù\@®ž½’µºAÖ±‡-HøþO’Ô6›Ø²{Ž…lƒˆÔ¶evq±
+·\hp¬l„çËLciq™õ¬ =!#úÍ 
+°eÌ	Ç•W|ØhŠ!gr³¬hÑñå*1!Ñ<V?Íó`e<Æ‡ËòÜV~ðyro—
+hÀO2÷}Âý\í01Pl ëöXPÁ‚à®œscžÅÔÉÐP´¦û+CÇXÛ½V›ÎbÊÚ<_?
+EBþ
+õ Qÿþ?þ´k:nÝMè¶DVüðçd9pæ‰šè´ýä§HM>Õ<{,·O~ø{Õ¾]¹±DcÇ'ßW¹²Û›	Á ÊjÄ›ap ÚŠÏa|Ž®Ë? «ÃAŽ÷-äÔÆ1ÅîÑ»g£©.O*A3°µã–nÛ­0Ìêú'	:M`bôñ“èªê0°® {Ô°ž¾ÓWý¢;Ýðþüè¦h´ –ñö¥’1ì5fi·| Ì¤€é-bËáb¹O=”£/@&ÿRãà~I¿[&`ÃÏ2"èw|„u”¾¬úITêfB¢Ì..=ù‡ù11}#“ûuo½‘Ü_aå"°wÃów?øÆOÝŽþõQ‚VÐ_¿)Ñð[«[ÿ¶ÿtÎîì‰ÄV<¹(z[éh'"_|“…«VHÊÚC†ƒþ°ÕGÐ7áÄý;æž‚ñ{—^$sLïtÔr
+¦áèµK^ð+BÔ ·-Àcã‹¢¦îˆÔ+„,í¢ó”Ee>ó²ÚA÷Ç Ûô Hà ý=`¬“}K—Aû-\bé“ZïÛbñ ,år¥Ò¸Òå0ý ñzhÿù¯.œTRùê·‰â´6tõlZÙ¯([=Bôž–‰Ä–¾ž¢‘äî‰Û
+‘¨Ýc½e¿ºáÿ’
+ú^†_ëñ¨‡*Í“éí+×¯ªt4ƒŒƒÍê$jƒ¯=2»yí•ÞöFúRïa™[zŽÕ`6ÔÝ–ÿuaGTMj`‘wEe¹Ã[- ü2Q0b[Š°-3IÍ€'WD;œÞ†dá‡e™ŽÇ"G1Ê\l)Ô^×ë„—ÊZÊ|rŸùu¿KîœÍð[‡/Ð	-lÔpŸ™(Kð <L×{/Äq}µ0ŽW¤Ø¹Ö„¶ ÒÇ?xà-x%ŽÏ&ò^{Âá0¥lŒïH¥Æ“·Ð“-Æ.²=ÑÏ<‚Ý¬‚ãYßçŠ:›a}gÌß·5x5C1œºª)nldc­V·JíP*B2Xñ£íã¶F/ýu:êWUTbº2it‡­K“f¯qzlÕ½þ]Ï@aólËBáÔ_æó#a­ú÷XñøˆU¥Ñy¼èŒ{5·º±P>àŠ8«¦t©Ø ñ=r‡ùšmè~‡C‡fÐ"·Óé`.J_1%P¸>'-ò^ü'8nµ¼*¨ŽýR°‡ÃäÝ"žºdV}g3À½²°pB³Î{6àåÁ—É¶ s—0Ø¼d/©[V2NØ„°èN–uUî:e‘òED¤L]bëÂÁÓ¬O¨O´¹±AÕµ%AÞ[ÝšÛZ:p2‹îfÛñ*é•m{OFýVÝÀA{~gz(f8½}sóŠVg2 »AxWƒíø¦Ñ™d§A#%¢D>äëŒ“6x•Il5"nOÄ°a¿õ3¬‡lPÕ5ƒîbjÌY´7z½¶É‘H«[µk em7`¸j|eßÍe»U×hÐ°ÏÌjæ.½Ì4š‡íB·AOð¸ ÐˆmÄR4$¦kˆ³û—ÌÃ,b ‰q˜À–È=Pù$X ö¼x­µ"x‘UA°eUÐ0EU`ï‘]åð‚E`…ó©I  Š@è¶‹a+MžÙU2qû%+ââé&RX¦ÍäðÀ–¡`›Éùµ™œßvO=ç [Ê…@¶n±Y‰/ÇpõÐÄJÃˆg¨Ž×¶ ‘‘m‰€YÖ`•¡£ý=—8J•k9FdÄ¯T/û6J2ÜvJÇÿ1þàk ³sØƒ-áÁàåÎs‰Ä\±s2T8Tú›%žÀ'*ú@<UðŸ>ßw}7Žž=KªŸ5ÜêB{¬5s!Ã¦¦zýG˜€Bûk.þÅÊ1äÌºÃíË\®°M³k!RØŽ4› ·?…ŽÕôúŽÓøižÍÈZ‹ÂòÆÙ‰,‰]4æò/Ø2’²›|Ì›ÔÙ‰+È^„¶™f‘d4<—÷‘»…3c°Í¦•¶¬u›¶H°efjfªºL+Â;‰¥Áý23uy.L*Ì…°ÚÌDDÀñ“
+ºAÿCøÔ:‘RŠ!Š,êÖób›P¶'$c6Q›‡	SÍá/[¹%K çŸXXy²€Þ=¶"öù¯/î°[ZÚÆþÝLÞVñzã6=-°ûú3W4«N„µ©>Ò³§gÏ¹¼‚þ„hïÑ_¿ú=+›Ñ@$‰,<õ<Ðcãñh„Æ/ªCƒ¥@,%º>ÅêNYz-¿¤ò¸Úx»éÌw›‚†nÓ*x³ÐnúÑÛM?:Ø#²o°—±ZDˆÇÓƒ&ô”Ÿe`HVrj9ƒä(Êñ•Úï
+ua”kv#’à=û²w¯iã×ÿ^]ý½‚Mí+†fËã«n½*QÂÁX_ãŠ½É€§ú8Ù½¡ÀhNPÅ«‘gæÉ·)ýý¹!62ºqjYG2ax­ØPÃ°Ç¼‡F[‡•ê/²°‰xo:ùù`ÂA7ó¸ö„úÅµôwýVÕ’§ÉôQ˜B·J‰R¢R³¾¦„Ä;‰÷š~ñ”ø•Íe|x\æàð¸ÌÁaãÏíKµÚÀëÈDJ©ÃûÈ‚?Ø2Ÿ†c%Á©.ÃmÙÇ3å-¦×Y„;A;Ú!rë•âó£YTýVM3™ØaúRšéÃ7›>°¹8mn­†­oá¼ÈK¦¨ÅfDõ‹<ÌCp¦Ì„µ˜.æ™¯«ÐLƒõ¦³0Š
+€ç4xt&!ËShÁ¾c)8Qÿô7ŸAÓ4‚›ùýèÖŽYæðûýÚ~´ãdáô®Î>¥ëš¢âò´F£QôŽ¯òÏ?hÚû&®êxÅÍßw«F({‘p´É¶“+i·ßýu=˜^çîãéN—«ÁN2ÒH‹­ÊFÕŽtÃª(ªjtÑ75îÄ7žÃÊÁç<~)Š=…ZæöHõ7Èuôêî‘…@[XÞÒåK#WÑµ·ì¶œ¶ÜŽšxsÑ@ÿCÆ‘2[ó+Qb°Ê*O(0ì[q5Å²¯6sInÝ Û%0¸½q‘·-rú¿¹@Ž[¶šƒÍG‰Yø<1Y¼Ír«XA+j9·™•}•æK€CPð-–“ì#š–°†d‰z…i=-+ÌP½Sa×7K¸Ø8‚+$P×24U2øl%“JoP§0ôªcMÔU„Ù,g?×&†Öx!‚Ÿe+Lå¼–«¾×Q}“‘v$s*Æ‘ûv_±f,ú+£%šH®«VM¡¡m¦¡cš¦YÕª¨nb¸Ôäp"ß}]2g3<:rV›Â~›¦:íoÈõcw<d“ó<ÉlõÉ#÷Þ}ÕÍqÒm¡ò2ŸfW#Êô×äDEÅÖnø†ßaõè|¤-Gt5
+´¬šF{¹=yzèH* Ìúòþ¸Ó0ô[µQ¯þ°úa—A»uann£}öh6;‘ÐÂ„Âêë–>L6±ºß2=¡ãbÜ ÛDNìQÝ2|4‹™7ØVX_.<¡Ì”á¸žkjäL¨0Î¶¦¥Ñœ­‰_ÉühgÄä&tDÏ0ÏRÌ‡Ð³‚Xý´R¹Å“‹A—îÒ¬N½4h/¤š;]ëµGÝç`ù¬f0®§©ÁýùjFßÿ]õ–O}EýÕEÔÄúDè?PÒ¸dCœ.'©ž«® þîdÓÚËww?xà±.¤ÕwÞò¿ÇzšeËÒ‹ä£¤ÆY“tÓÙg¹Érº²ŽUâËsÄ¬•Ùyä/Kä`K®Lú`—Á<<>¸È'F@F¥óMôvS‘Ûr€<.É±`3
+Ølä\mèÔ½ÝrFÔR9~tå»•óµ×
+^À^¡ìè°ÌZ.ñøÿe®¶\*€>AØEßáÅú¼XB2>„f)¹¶ti áÂ{/Ô~[NGÙîÅôbÎƒšù%fsCõÁ…¥ ¤z‰@³OI¬Íå¾˜/NCÖNºSÉzZ%#èxfQß\MÓ-\A¿èiééL÷–âår²„6NþÅ\Ëüüªf¶â'v¦Þ¶£ßWŒ»FK¥Õñ—†1®>Ñ·<úË5‡âñ‚·úÛùÊÌ\×š5]s«zæÑ½oÃ3
+Æ¡x“¿­ú±áÃ£gÆ<QûìþxçªñØÓº]÷eK®ý‡ÑóÅÇ*vøívµ„]0:Oë†::<:É{÷o"o`-úÄlÒïK®X—
+›çÑ
+ê>p•]ÕljÂ¨þ_t-fS™p'€5C,Þ°ô“—ðOiÐ•¡×þ/9ºFyw²Ä]† TÊDÄ<¨fÄSqÁæ1®EÔÆŠüFÎ2­rÖ×_„h¨­Æu’!èñ¢Åú¶è\óEê”2„3+R¾Y]×ú…|—ž|5˜¡ù«o¥Yƒ,²t¹6þ]½`³º	]XœOEdüõ–m½ÕŸ£XeR¬¾Éƒ¹ÜÖRik>??ÑëÎ½kå§÷ßœ~ÛØ“+×½fô•Î®ž~×4ßUž\ÂX©\}	W6Ë¥BCR8\ú8;çNµºßéKA~ºsé¶4Z#p®xÍ¤‰Î 	H-Q“ˆˆU Î”Ý?pàÔp{Trž¦É¼ÃÂ%¢Zído!Œ¨%Ÿî“ˆBeúåg-MHïaæ5kòp¿lCÙá©ƒ-;Lîlfƒ-û(ë´)ÈFùVÓƒÚÒ ÐÍBƒ2—5Mtì«ÓeA
+…žcæJ L ±BÄ$$vä¬-½îÈ&à´âB¶ïÙ¹kÇŽ]ÛÔh<Yýõ‘ÃW­Äç×” B/äñÉ¾dÐ÷öä¨³!èFv›Õž1R¥È¦![Ø‰5õ$Œ|‘H›§4é÷²™3qEV‡TßSõ¡‘S·ÈÆccrFµm_yþÛU»h–E¿èm½=ME!ÐkthŒc‡ÅðÙm^_Äe"øg‚ËlãËd®›œe/çu@pÕ†©ö,™r€-«‹Ñ7ïb=ßòšÖØ°ÂmJÜÊ‹"]ÙòWX”I,°”¶X
+l¹lñÔ©c`s-': $;è¡á2-!“^Å¥”ÀÍlf^\’8Á®»%ÃpÚÂzãZäë# Þ çSÂ¶Þ²W0nÊò–¥RzN—óBé¿¥p] ê°.Óä+§kÒÞdÁ
+ço%Bûwímkwí:|´¥Ã…qsqiß>‚#RHæãÖm$¬¸¬=AÀçºÝÚŠ”Öw´‰œZ1ù­®#¥–®¹Á‰*Q£zÅ³Ý—åV+FÈã
+jÈ‡hx‰ñ½¦5á¯Åu•ÆHáNo´'}ÙtO&ªëV%¨Fh èŽÓ?éïoKô…ÍÁêÐ}gÞ6É6"ÄbÔšß€`ê324Çý¿¼!)eqë+ìÍxºÐú'\FfG8^*p?µ,õiÁ ¦dk°µÒÂæü]¸ÄÍóüZ<uØ’ÄÃ60±ÙÕu•*9¶Adô§¤6bEfÒ%P¯êmèD%éå˜ô=úô£}ø:z’ïªf«WÙ³ÑhOäU<èÕñ­ë ähÒNÙu\ýÏÝo_Œ@?Ó®|–:¤Å1P(,s mh¢`'JXoRÑr[ÄãnÇKaÃoWœ![ß•-*&€L_æEò!ü[êÙÇ-áàÇ-Ó¯ûý;*öûÇ=ª
+Œš®tÀËÍJ²6—™™DúfÊ2(…çÊŸT€×î·7ƒ÷–06Øã›·…	%xcØ€Z{{QLÓfŒ>çñ¡ÐÑ"P—GE¤|1“Áìú$Ì¶ÙíÉ/Çw,JVì€Ë^NUºhç“¹µ™¯]l’%¶Ì¹¯0yž+<ui;°¥Vñž:ðÏ•q6Ø2Îûºó¼/lÉƒ„×‘]w`K¾#óµƒ•Î¢ë`˜“ÃzŽŸdtúçBº‹›Ë½9º¸A”Oaö×š]Ø *S.„ZiÙ7Ç¯¾Ëš°KÞ¦….×fŽÿú«-‡Òéé^æ7Ž“×›—õB*ÈO´IûEëD¥+¬8\AÂ”ŒO7vún}¾ãÌ÷:¦ò÷cB_GÓúˆÓoºbÃÑ†Ñ¶çìv»WµûôîIoqu–z3WÐÀÊU…aïÓAV°ÝIl½Ù¥1Ú£ Léz¨_ueÂá¶@a,˜O…ìí 
+tÇÝtK¶zìÉË*ËÑsô£(ôú£ïoUcC©\Y÷X¡oÄu]k&Æ×zX3ª+¥C~YIF éX=hj.q›­KÏ°¹‡0PyÔ²Ærz
+úfE’˜džnK~½åZ¶Ô¯5-uHe¡{½i]or‡`K¶Òµ&Ÿ ˜¤Èýw¤^‰ƒ'M×3¼ŽÄ¾/Ý¾À‘!!ØPª2/~°eÂ	¶Ýê©'Ÿ`Ë¾Wxí“åBwXsfÜ4	6“•Ýv
+øù1@Â+øK-búÁÀ®,ÖãÜŠéKuÖœTWwª¬ý½¸žÉö±ÉëeÕ$°U#¶¸SZbT½‹XÐŠ¦üÀÿ¸°™§ÂäxƒáŠ¨À‘\uhk(×›h+¤óSã«ÑÇmlŸ^YGl5†“Â—?³fo)Þx¦z÷è²[§ú‡·m@7hüš¡ñÁ´lòI„#D¡w`â‹¦¯6ŽáPSWÊ›l.eZ—S	+7ú:K½5Nšq²ë	·ö{ýM.Xõ~bì”†È†®ŽŽîu«ÊåžžO»ÂžðŠñê¯”MãÊXm„æg®-ÐH©V»Ïù3e1•‚‘â4Ž[zãêyi<¸(4<„º›bšùÿ/;:À–;Ø»$cIcQå6Á
+Õ,.æµ·±…1žøcÚ_#oZÉ¸åc÷.øScä6]Ú2»¼Z_]™"ã:é·Ð™ãLEk¼«úGOd¢ksry¶_·{Ô&æ
+fWÛ\sv0¤¹ôFoÛ` °,£{íV¿Íe³yÎÜB¡}&ÁŒxUÁ¨agóŸ!!ÝqT¨ö£ÝöÖüPÀ¸rýŠë¯Ù¸2V¦=Cp‘áÖ‚¥¦ÔLÆÙäS‘j`ÌŠp
+ŽÅ|˜Q€Ušjø\±`°ÍFÈf˜Ù-Kay„‡ÆáÝ–AËfË	Pó^ÍJº¸ˆ¼¢rï5]{LÑt È.)°e	Ø²j¶XðÔ‰±oÖ„	9 çðž7Â9¾¶n1(èo"="tP:˜Î;Œ˜ìaôÍf@›—¹Or—™ÜØ232¹¥)Óþ|Ää¢Žx$Ì/æ
+–®êxñtú
+iA®Ökžs#Þ›U/º39næ< C¡Þ èâL#¼,šøøÕ-k×•z{ü¥TÓTóŠÕ£ûÏÚ4uÅµ·NØÆô]Ó›Ÿª<º{h×êá†|ÍQ
+íÎ‘¿ÿgî4±,QRåÙ‚(©3èböØmñ©d¾âîôd:8‰¸SQœ®pC ¯{0è9; îã@V‡ÒÛÝ¾€ËÈ&Ý\ŸÇwh†ÃgÿÔ4Q/cã«ËåùX¹Hþ€ ×ãkÒAC‡<£bI’àŸY\–¬e5rCˆÇ9#]båu™ö!³úß€éÄ]<]@¾±
+!…œž¿V«ŠÍürs² —‰¡ ÀvÕèGæ¸RbXÈäžÌ%Èe›M—‰Ïê2}px> sõ)Ï<G‘:)¨ÌÅ¢@§‘žvT[EÔ1iÍcB&Cd—ÃLù èÚ q>—¢«åÁþl¦`û×öƒ]s'P&^ôßþ¡ÎÎíÅâe¹\^i\ÑYÜYÂ­OÛèþPýÛ‰ÙüC5Q°jäžo<ö}²™W¨S©~šSbabo×8Œí6~pçôôº»S©e‘Õ×eU»Ò`¬¢÷œÕxÏÆ™¥“³Œ—1b9ŽrÀÈàÍo>ÆÄ0œÓú×‰í{Rhfè¦ŸwI=[Âƒ0jYBQ“¦Ÿ44d—ïAÏ…hÌ³™$²ožÓt¹)VYgr`Ëî?x¯k`]A°E¿ú„`…äEQ‡72¤NVb£ â“3y&è?0k“ÉŽa1‡òbn´žAf¾¡Pïq¤0ãF÷I(Œ¡4ŠæÒõ†:ÓP
+ÉÛËäÂÈYoÜ±áöžêW‰«1LV\®>jq¬óö¸VÆéçï,mJ=ûuLª¯9#ÎèéG£mA# @1ºáå†€¡`,¦ãsŠâ7Á#øùI¤À¼iãA„F!†UìZj,NXŸCäA(—á“·ã÷'²Sƒ~¬4Úª__8‹$ˆjUSË[î,íT²o=¼ãÑ®HÖ¥iN5¢VÿY£íMƒ}n`é£ä%â±Ø,1z-XöXžG¯~Üòý_¤_ðÔ£eÍ4öEzÿŽEN´’€3œq™½ÂÉ“MæUàg˜ÚËË:ŠÀ²îp©,˜ÀýRžùµŸö»©ýnÈ‡ßZ„,ºÔ>nyšåÀ¼ç("vB¹ˆnôMôÊ’;¡ô?ÿÓ]QÌFp¨’m¾IÁ–Û=Ø2+["É`Ë­Dü¤2c†/)C¦ŸóIø!ùóŒ´aèß"·ßAíwÀnË¼`0PëÒËÖ#ëZ›žz.2y5‰½p…J&xZ’;*s˜PsüDŸÀøjzôÍzêü1Ê¯$%·uÙÄ`!þ9¸°çèùÍ{—÷Ž=4º3¹vaôÌuã«WÚÖé›ûóÛo	fÛ™ÜúÞUß¾-:uT‚oG£Þ„cÓ[G7—¶åó«Z–79‚Æð®–—èÅlHhŸ?Ô¶ÅÐìwømÓ}Íª]õºs¥q{Üë¥9°JH ã›8Ò
+¡‡Z6g'_80´3›N¾õˆ‡ã³…xQA¹hcKd¸)[Ž§íöxÿp$Œl£ïsW+4%çCÓÞ2éîof]›fÅ¶)¤’³Ø qgŒ^èî\SRuaG[ºÁF/t§Ãî`ƒ¡±µ;Ãó—ñ1EBcU¥#é	ªÂu³—>Çôl–¸¥ß²= ‹}ö‚þ1ÈŽy£ëm{»ìé<QBÀÔ“ÐÜ[ä÷A´úf Ž¹éÔ0-I°7ˆ÷‚+^‡M$	>ëó*B¸ÌÃæËDüÀ±mÈQÇý0WcIl
+lC¼¸Üàd'AÈäž O<S~™ÌÃþaNæ%@wq2/ÝL°—ATÙtÍƒ-y¨eÏ…3Y'øœU!\A•SUËjFg€$ "80Õ”óº¶;=L­&ÀUÌRvÍá/-¥{\à'h¨ú­ê	AÑ×ªN§ˆRýÅw¾ÚÏÅ;}gŸ/Lïêš)¥F[rüpßöÖ8•}Ó‰«ß«þœ¯Ðq‡†>C±$Î…´ì*åõ§¼o/Æ¸LðÖmïTÐ6±¢û9¿”þ½×PœÊŽ—1¶§Âá6¾ßåŠÚ	Ö¿:´—¨<~[zyŸÐ.[n€L© N5/gdDÜj.[€Ë­ðÊÄŠèi\ã E
+Ã9‡[suN¾HSÍ‡ËŠz­ îgîÐ}Ti ª,O½ ñNþÃìì±swìÛÝèª·í.”wÑüp-AÕcè¯î_Üy`Çæ‡Îm¾ùÐ†‡f¯íØ‡¯\ÖëíoôcÕßCÜþÌäáÒ¿¾MIt¬ü×šö¶DÇåÛó)  Üý¥’“ôúí±œ²üòË	Ë>ÑvædjG­×FÍ`Ëê´”É®¥¬§ŽLûMW2Ø²0ä7ý8~ÓfÏ•ÈtÖ´Ù9Äfç0]`KÄiúyOÔ„~ä¬ø„gäµÎõíáP»¥È;H l±•7G¡ ›âÔ+ŠCr ˆ.õfË<¸BfcïHV4üÔØU5ŒÖE(+Åžd¼&<wBËk,éµ¾‰ž ÆX¼úÃIœh¤g¼và…‚2¥«%nCµ†\~L’¾$íð†U£ia[©*uü¥X·v“(I¹ª¯}¼%Ýç7ÐË¾Õé×IøÆÕ£ûrÙ•Ê¦$!6Üh=ô½àÓ÷Ä[Ý„¼þ,¨è»°Ýk4Tö#àôDì‰áD² ºB¬†(I_{¸©?Ú2×–è‹:¼tÇÒèèöêÁ¬ï²›F»¿Ý¢Zö,ýYÃúà"4ãß`¹	7Ë‡¾©µY56v×Þ›©î4­°%yl	€-Ó3¨eH=°Î¿QÑU†@ð>›Åã²Ç l	€-c@8¶†a²ž9ÆæìñÁ{È5‚%´¯VÍ_ñêºy?1çšr*§¹þðŠ”0†¼ÆS\¯©}X`œf„~1¹Ðë¨  zf™¸Q½šÀ1Lˆ¥Ì¥ÑO®èZCDØ>è†a¸§¥úûe»3¯-¿ñùÎËVo)g×tw¢ÂÓJãªxõ3*×‡4Çº1Ó-›®þvåø®Ýãsã“Wì_>‚6<ímõ»ƒ¾Žà îT/_­Âak&ãÀŽX«~3Ó|Tpt¢£û²cù¶ÎŽŸ£ññÕ>§î§‘Ž—øòáHÖSžtÓˆ‡†,>{¥3¯¡ÀöJOwßŽƒ#ƒƒïDMîêu7øÅA¶±œÂ¤ŸñxžPï¼iéE²‘å½Ó– ¸ŠÏ*éÁ»Âä5ø*¨
+ÿ·2ºI˜üx¥XAð€Êv•ŒX5\6ÄÆ†Ÿ@Àä•²2{ƒÿGÚ{ÀGv•gã÷œsïÜ;½wÍH£ÑÌH£2’F£QïeµÒJÚ¢íÅë]{×Þæ²îÝÆwÆÆSM1ÅØbL0å%„¥ø£‰ð%	„“ð%aGÿóž2sµ^ÿÉ÷Æž#ÍÕh4÷œ·>ïóØD´á¿ nŠš„mò¬Ïd†ñ¬‡ B‘‚YVVË™]Ô½ÁÿñæÄlÎŠ^uË99±.fî¼ †bfº"+v¼á¥±ë?;vƒšé¬|ÏpiK7ZƒN[tóè=¹>Ÿ/nÿ¦·œÍæð-AH¼ÍÉ¹£i{ÂO‚ZTûãË ¾ÁøQ2Íí^ÇÙ+èýqP/î£wèóÌýO0ûYù+¤^Ê§ë€÷Ÿ?·ö—äb’Wêè§¼ùa€pLÔ(†âÃæMžÖ2œƒµgu=Õÿß˜´K°–å€aawx8V£è‘ªÁðÚŒªãœúÃ„‘]ÑfhXGWÏÏîºh2tFoF/zjL/SÑ¨PÀ‡ÙÔ‘hBuJ\9ëqÈ®†“×Õö¼€$&Ísi ?,öËäbïh{û¾båLÒ„skÃÒér(Dc>¦@Íg"{gåŸ+ßJ;ýÁžiê‘¾ñ?ýKûÓöÏ`üí3WÒsé‰Zç½w³#yÕõš´ßa°\MZ~^¹@m¿ §¸’zv¼¡è·žý£Û¥…#šÍnÅ7Ü‹ñA[§@Dsi–þZì‰µçÉ‡ñÑ<¬P~
+Lœ˜{¿eÞ]M¶(û«Õ y‡¥2Ðjï†jâPu:wÊQ ¶èz€ôÞ)^R8Ñý¢¢QÉö+ b-ËòS&'k9] kÈÍáQÇÞ(']ð=gä\Y-~!&}{H“{Ëòˆ{ôše8ðsæ	Çªéú@&A“ˆMð7+S?D'u›J“F›[Ïnœ©VÍåÌ˜7ja`žËÆ6”ÆãVK<§n¸b««1Dïâf[oòh.·«gö’ôÔéDç-ÛßD³‚5šKdP3!•?ÒÓÿ(Ö^~Ÿý­Ý­¹=0nkl+%5§õgÂ«Öd¡ÉƒÅâÏFÃ)BìÝ®õn„ìC^$ÑÅT;~û“„¼íÉÂãÞ.øR4iW•]ÊQå$JÃ)‰®JV´(¥‹_©Â²¥5Ý®Ox kYVYñÔÊ*+¦ÛÑ®ï€×¹vÐvÆXÈc‹Œ48-/`y‘‹lS,}"_‰ZÒ,õVðó¦7¬€ý3S'B[xjÁ¬eÖzófüß%g$#b•0ú\¼ðë£þ%û
+1A=Æ¯d¼+¸-ÖóU²ˆF8¯/q-^ríÉ«®<Ò¹»ò³RªÜÕÔÛÚÜ×ßÜ†.œ[zêº•ýûçn}xq_åg—ïÚqüÈrû
+Jª*VçÐÖíÛV0võë{v-5Õöš+\¹È=zóhçé~ÔqïM'NÜ4?ôfËmeGÝÝt»ƒ}­Ñp8Vù»…æ¶l~igS"•ý÷éY_ãÎ™9
+µØÚW+ŸÐî!¤b+!ýïkšL»õo^^¬2Äæ°rÍ³¶“6w+â`\­®ÖšÚšÉÈÃÚºº^ƒ^öQ´F‚¤$R fòR°ÎUë¢ØÒ¤ˆ7rŒc„'3dLn­VÙf]X6J¯û{Dƒ¨Zï|Q`Ñ´Âìü·kô©ó
+ÃñXêéÿœybÑÁŸ>p¼í‰Q¹¾°ØÐ°ÒëÎ†I‡l.­ò@eŠ }k~g'2Î>²Ú¢Ã™ìXmTâUþýó@w«ªv]ø÷þµÏ‘giNïT
+Êøw› èJ—È+l¦OÕ,,ÀzY.ÀˆÍ BMê¤¡äú½ì…Z—÷€ Í-ñæ”ØLÞ0Ý*XËP0 ~yÀ³~îØ\È¤GÿYd]5 ÞêEï^Ž#z©ƒOÓàÎ,Ù³N\ŠèAA H­;þî^®¿á.ÝÊ?ýö/Ãi×…é/-t¦ÿP»½”Ïï+õlö:¶çšóê;Iå³ãu¥µ´ÍøØazb#É˜üžÝùÊÇÐ—ÞBöidúßËïfóŸOX…óqëÚsä µÃÊVåœl	&Á«ëGñdÂk‰#˜iöj
+òLøMçÄoÚâ~ñ¡ú=µ0y›ÉX¾‘ÄýF9¥ã, Ô'¶®dt~b!Së¬ÑÇ€#¬“Ã&r:˜¨†]•å'©k¥ý¦yn@YÓ[ÄPôcÂŒ|aV0ÜÜpgb¶!9'XÅº3rýÖ0†Ž´•ç³Ãa¸ÒÉò¹ew±}{>ÙB’ÈjF×‰—–+·bÃ¦5äŒ®áC¹ì†Æc¥·¶Œ/'hŒuönjévÐzÁè¢ö~—;jSlw¹-•SªF==±0}Âµ÷‘8|;•KÐJM©ðŒŒÛMH_y|.¬CQXð³}•(Ž-P¸§>>KÃp¬]¢µ¸UTk93«Ët
+Í„ææŠÜùÙ!øì<ÊìÖ²Ü°Ý´A¶›NßvO-Äßj:‰ÐR”%	XÏðGéêáZIq ¯!!V{€øüuY$«˜–æ=CÙXä8S–¤ µ3T‹@¹TfM–AÔÍmCõˆ	ó
+—›õ=@Ú‹M_´"–ÖÁŽ$¹Eº	¼	ûò¥‰Ê¯êæÚKi4t—ãp÷ÞÖÖ±`vGW÷Þ¶ÖN­å²¹GZ*ßÛ¹ƒ¸Ý¡|”î@‹úŒfSm¡Dƒ%ÿüÝ÷Ýƒô‹ê‹¡Í×6.;“úÃäÁÏ.ìd›{Ý°{GXl'‘
+„&©ë¼ŽìÕ¬N²àîq5Çº3ºn#^r5<{¶ «9ÍØVÀÓí‚œ¯Gù,o„AÌ¶ÊÐ²6YòÔReó8'œï¬8ß]¡nÄLÙ$†t±–{ÎÍzÖêË¬ea´Þd3ÖUŠ¡×ÅL1PÝ”‰V
+UùÅ‹9è‘¥Ë5ËÀ±ä£…Cùdº/h€Œ“Z¹"¾-¿£}äd×'^tÜõàêÉ›½@k¤¦àµ=ïBC /CwTþ@DHcw@%QÇýÞ®bP³2Zøëª­½@>FüŠA?‘e?Ú
+ì¦;Do@DÊ#îc¼ð-Y®4PìÔ[ÁûÁk
+÷«~•ß‰2†$Œ¼Aü³iUàÇ˜d{<˜Øß#8zÅ=«o(Âºö@?LªY´&Î»9›–N<<NÒç<ëã"3´RÚ‚šÇ­Ñ¼ÂëK8 dáf!)™‘ÃšcÛVNÏéá"·²ëxMÃ™`9œ
+À—3:t—ƒ ÇcÑÅ$u&Y” %Ó—0õXñŒ!øÌ=7†»“WÒ+]|©ò¯W¡
+ñ´×7tÚ§nèÄûÞßö®Þ"B¡ÙcÅoV¾yšædÿáopx| ëþß-_qÑÖ»#ãG[^¼í{6_ŠúÝõNŒGÐ½e¿Ó°EÚ«í%õ:üÙPKƒÀ£ÏÑÁ»ÈðpþÁR6éqç6.d“±&†­Yû=¿jé!›¦ãCÜ@‚Q¶<™æ†Wk“V0F2§{•—7ø‰V Ô(À·þuyS\äM“¬Í‹Ç?Á£ìŸÃZ‘'MwxÒ´5a]UŒX—ý¬“Aa*ës¡r¦FßêSc]<·ù¸Eèþü~SÏ-Wlš½úÖÛì3×œÝ¼8~ÙmWm;¹r÷½+Ýüàã‡OV3šÒ§æY¿;ïûÀ®®Áû·¸öøÊ›îßrÁÁ–Ss›®lÞ51ôø#}Ý±`/CÛ86Ø+-‰†æm;²ÉDÓã|Œò"V·³µ¡©uÛ®œ×ãõçx?í†µ—È1«Eè]Ú
+•Q®ô
+…K^Àä‰G\HØÕ¹3'ÒPBò!œ9µœOÈ˜_Ÿéô‰[ ‰Ì
+X†|ArEAÄÀ+.E5èYÏ¼mî×É¤ dºï’ÖqxÞŒ‰¾3¨‡ &¨Ê‘ju2Kuæ¾¼N·[g©RQ¤JÇ*wÍ<:J°%Ñ¦ÑÈo´³sÌ{ý“¥(¢)ÔFŒ¼jCÇ­½M.j½3ÐË¦^-É‚£Öº®½m½¶¹SþIz»î»Ýb°u~+XpL’ô­òÕÊ—H(íz¥ç«S=~KeÉB¨û´ ÅÊË¹Á@ ÂIëm·kH…öó¢tÈ³øyzJv)ï©:>~(ïX¸êÊžÁ0VTÓ§¾K”ÐæÄôº"l®T—– a3Õ;„Ë€2Ç\x®å”L80<œcAðÙToNXÞ9 $2S®:$fæÅ93ÓÆbn?CEòì–žçŽTšëFÓéíÃÔV5tø[ã§ŠÇ­V«æ‚„Ù fãA‘á¦¦‘Xj¥ä-$-Ö æ°ÙfõžööaïÈñNO& “ŸWžrGíŒei°¢²ýöeÆ›ú½ÃSÅ#G“Z¿_àÌÆ K3hšK€;=™ð²ia‹ŽumâŒGÙãMý"9Í°ØºÃo@ ²_$¬¢pt=nctà<i„¸Í´ùa-É@·-s§á!•‘É*ÈKPQ¿én3YfXËp^O†¸'<µ"QÉðÖCk	ß…ë%—¼Ždæ€µdæ€µTÑ‚ß{X€k<¶ª+ ‡SD”î8Lñ$ƒ'rþ%3”Ìèu“¹ÒMæ
+®7«¡Ëx¡C˜+¸¶u•€y‰:pR2”Ó¦Ž ?Ë ÈË|à :°FWl×k™ {
+Ä‰êi ºqO/˜š\Sá]<a{RáÑ|¾ä¸¹÷·ý‹ápvÝ­Óøÿ…°f	óÙ~óÔ¨|Åw,Îþ=˜{Ýº¬ù_C3M×Çé…÷‚=Ä×îHƒv?xo¼!p³0W±XÑmñù*ß±ÄŽ¢g:G½4[ÀV5l¢KÐm4¶´:Ã»:gw$QU\oÿQh×»ì~ã¦Óo6"áƒèn”ÞÑ{Â“îL…š5Ä¿Š–º|ñ„ÕBãÃka|`×m¤÷îFtä[E³Œ«Ï‹ñ²ýÊ5ìæ^#nî~“_µ„Õ\cò+ç*“CÂ•9¨É* ¬!˜ƒŸ›¯+±¥°–%Rx^–Ha}DüŒÜÅpíÍr‡¶3­·fýã(ù²Ø¥WŠÞq²Tíÿ©j¦W43LÀ5€U6cþ$Ä¿ì©oamÖŽ$ëRM:S¢™%§Ýd|r¦(G´–u&•kRÉ­NÕ$ŸÒÌä¨ç<og9ªö:'šÉñÁï0g3ƒ²öÖÙ/MNîÌþuzKWÃ«ÅŽ‰ÉBÏÎ[ÚóhÒÔ)µ2³¯Eô–q]8n±7…#y/êÅŽ¨#VùÇÁ±Ë/-:6>†¢6¸lügo Í§‡ÜíÙ´;ëBnõ:V¼½–±ÏúgÛ²Ù¶ÙÉ…öÜ«ìÓ*¯Z‚˜´ðÜxqÚçKÚ‘f  Óµ\@ÏŠ¶«48Õ·iÏà`ÿ3(îþÛÛ|)%ÔÓÐÒˆ©ðó“\_«¬t’çði¤;­lGNH^ÚDÂé®)™@ÂZöÞH§–ˆ€óu+QN+T¨8‚óÜ;°Öi”è~ÁbÚ£Þ°ã(m ä°Pá„G™¿nðÔB7à––5Æ­¿Z«PBóLr˜l0íÀ ·ªÓ¥ñ"å *­yfÕ£–Ñ´!-—¬Ò¯¥¹Ô9}R¯‡”ˆ<mñž~W%U·mp`{b„hÆ_”®êª4:¬õÃÉ†e{} ¢¬ïû&„¿[]]œæ3!—Ý|ïËÔê=ôþ_b|ujC²R˜9¨”Ý4Ì¨£ï¤ßø-±XU˜{üxqÊïkt!<b‹{½AíÐ®Í„Mä[ö&?ø ‹·ˆÒ³ögä3ÔÆu*{•·)ï€0Án | 2V®‡&L¶iÂSK4'LìO­×k¦/	ñdœ6P&Ø¼½£ºŠTWÇª«ÄŠFÀf ”‰Q*W­eE¦ªø™NqX¯ú¦lÊU¡±n1X‘ª°f†Ve_G¸*îhI*‹&P@¬ÝbuiV—¥¼¿­¾àu…ì™bÿîÖ4±YÚú†b³)×Nè1Í6…ûÂý»—ƒtïÌ0#\1gÜ†g7…›\šÏåòâx«½ò[Ü ž,Ø¤]Ým¶Z#‘z]sÚì.œlqïx.º?¶¹š£Á6b85«G·wæâcM‘¬«3•ÍêiÕnQŽ„¯{§;ÁÍiIÏ¦#—Õƒn¥»æ(»£³k¾n|Ãh|°•Díw0B|5K½Æ=vÃc¸š"Öh«»%ÐYf½Ÿ¦ZuÃ}qkáúíãíºCFTµ·œ
+4yÝQ>Gna|ÙCÊå4xÍÑÅœaR|/±4N†ç2þ3cð”ª€ ­ªJË=kI'b…ÙiÚ{°ëcfÆ‡W–Q9¤EL¾Ö k‚G>L­ð‰jàÈ	ð¦Gäó;eT‘…½¼Œ,3ÉGÂZöh`-+rO‚8j°ìO5ó7åLµh2¹5Ýþ'ÊÀ·&DŒ%FY ´¡ÝR"VÅÿ08aÛ)“~¤…Ë‡±Á³ˆ6ØDV"(óQ3š€–{z‡ž\9‹Ý»{a¢>¶TêÝÚ0´§~¬£òŠnMµÍÖuíjv¥ü4§ø|ÿlU~qÔ•ôúJéôpÔtÞla€y2˜LYâ`ÂØ¡b‹–Èýo+Æê5‚„XóM›ðw@ŠÂgS1ú2šÇÃ†5‚ÃâU…	 o~„ÕT.ƒvª!«¯˜JµX7ßÝ«¼pÂï¤ñ¦Ãa‰ié]åÊ7,c»ã/½v¨	Ý¹öy²”—âW2ÔEN*OÂÜQNŒQxD¯'›6Bì£\ Sâó¬‡\C1z}2‹y£4¸fl&lô	ÖŒŠ’W€‡øÞsÕ@NØÏ&
+¡nWm‚{SÞ°À5az3ŒŠMGUÐˆû‡ØP1.¹²é¶ãN<<ØUùUeõ1ô¯Çò'§Ÿ]ž¼dñÎ-Wg/¨ü]e5!ÿŠQƒÃî› ½©ÆmÍùöž°¿.ˆŽ#gå5\ù‹-MnWGóøæ¦:‡«ñ™ÕOòe¤ã¨ýû…Å©á„6øÖ¥M×´^+A¼¶³¼ö<ëSVz§r ù§nj@@’8ªß/`f¤/4ÃÌi³ÀÚ¬_Î0OpÌ‚oŸe™Í\Ãµ¾ÆÈo¡oQm¢±¦´dÌV¡?Al4¤1—}ª0'Â­Å¶É™BO:¿c~/j5èÇ·•Ãq"˜¾1Ü>}Éã§,n·Û±­e¹¹e8H@³s8×Û;zÅeãCûÜ…„Âs];pëhSccÓè@º}qÊ}öžÅmquüÌ£wîº"ï‰!ýìcÄBÜVQ‰½L-¼®ÍÆ2V«'[Ü¶¡ot°oñÒ^«×˜·h¨Ál_{–é.¦•‹•W`“qBZ+CÌòZ8à¬¦6 äÃ4«G@öÅ-·áàgdúj§e¦ë£pwà`[o3ÚC fQÑ–*³ ebÔä1iáˆ™¿”ö¦y^Àã oQ²¯óéîsù)yÕÆy²P^7ÈM¯ã£Â®’›°†Éfõšà;ÝÓ¸µ¥ò•[^ô>=±hn#”rfKÞ@ƒÓðÔµÎŸ0¢šK·¼»¡'ì	 UµÁ6Mt·ÊKaG.ï‘±…¬•‹+ä¿³òùØÇžºçë³âÐêí•ÿ•¹vee¦ßðÙg?³¤ûíš¦êÄé7"ÁHgØ•	Ò·`µZB?è:iØëm´Z" çÇ’lzÞÆ×~Lž&:5i]Ê-ÈÊÑ@­Ý5¸ÕS+œI´ÔV¡;.› fÜ´ÊëßížZãÖP#…ë¡·FB|à9NP¢Ô¸[À¶²Ìv@]5TpšZíu&jî°6™¶¬y‚ÌNŠàf¬òÀj-Ë< Ü=<r?T\ž ‰ÔHYÇÃÏéYÜÉï9“™©NËæª|coÐï-ÊÜ ×<þÕô§@®‚8êbËnRªü¤ò9z’:úãÌõ½Øe=_ÛpèMGŠGJØ[hh(¿„qªÓòõ™]éž Ëi÷ùÍ¹ºî á¶YiÚWLÆ‡¢ÕëŠ!ÎºÚæêg6Ë{Ò›Rã=6t inèÃáÆxØa3\F$·°ßÝ&Œåà“6Ãë»ŸÍa‚Ü3#ÌÆ‡»T;
+Û/D¹SúÔè[Sao6l¿Î¼I‡jÓ°ÃVÕ™
+Ëþ858Ó Ê
+@	WÈ¯+†Us
+\¹ö9+:©µéR¶)‡”chzy­‚Ì­}?“#â…ª`—°1ð½ØjÍô›¼ª¹N›A y2+v£Œá{ N3·Ìáç?ÈÄ¢ÆS€iÜ£ìM] `›6„'™ì!Ù¢˜4xo$þFR†² e£eO)·b²xo„–0YþqåcgL?<€,Y©6PÀ<ïãçˆ+^îV½Æ©Ç!úz†o\ñãÐögª÷ñTfÃÜüÒÌls®<[ù2ÂñpÒâëêsxz¬ò·—96PœèÝ}øÊ×`Xþ ¸ïÙ¶°°my™àºpýû*ßž|x(1“Ï„>>ð‰è`âÆ›.C×âõ½ùÎ®úhå°†ß‹t+	[oá¢Û'–Ûš§š’›Ñvb6Rù§W[–Z06¼u¡Ch£[Æè‹±¼é¯Ò½8ÀÛöxœ¾‹ÆÙµöòAºë©¿»]õ‚r7ýï¡ÿÞí©…òP|¸‡~}	½¡§W×³?K3t‰)±
+wÚtÓáy^I†ÍâWN1sWHžXsN~µ”¨„5§FUø°T$aZæ¨âññ‡P¡ŠÐô1
+ÿFÙ‡"Þ¦d„.P7Ë½ÇÄŠóAK)(ÐIžªÿŽJü,pYm{þ9‡‡ëkÞöî¨œË”AT*Ö‚|0YµÉZ-~’¦µ±5¦ub0&UbéLNgêAi~	rÖã5šžzwg6ïÝ¤[%ÙúÞà®÷l@ã(CÎþáãÅLñºU«»Ö?“MiNCµÜd¸+n9·%Œ)ÇüÁ˜¡;ê“öÓ‘…ìÖöÒb]¼#pìFÎžðP6ÚŒ"3ÔÿnàÆÕÏè4óöå¼½|¨pÛeêfª•È§,û ©®¡[‡ªèDzÒžØ}úÎÁ@¤V‡À*ýÍ¹“›bYúóý|ª‹QK“Én¿Ë±™à@Ï¡bwêè†Û:£Y—fÅQãÄLýðŒß"Ÿ$u4ÇéQ.COòtºÇWk½O /‘ #X"Bn†Ë=5.„?µ)`}Á*žs+"9/Ô*ƒ°«*Ë"ÁÊ‹–Ò@µ±»VæÖQ±»áû?,`!	€çepÉvcÖq„¤ËÌ£`&
+1ÏµËþ¬9aƒµ,LÀZöa-‘ÐR’ÕFXË‚¬¡HqÐt2–=¼0±,> UAO
+ÄËÙt €¢¦¦GPX%•i%÷‹”{d§Œë¶ðöäŒ´’7t€k&˜ƒ¹
+8[ÛõöÎúŽ~`S =¸#`¦½(üy»+‹8öåŽÎë—Ÿì{ìâvßgmOOêÝ™îÚÒ0¾Ò6„òs—÷ë˜<x«Ž§óÆßg·l^Lß÷Œ>3qEO3ÇŒ‚28›5ˆ‘¼$=ßDˆÖ‹ÕÏB÷¦Ópawuè–z/Ø:8‰°µ!jñe›š×»®…'Êô-3˜.Íß‡Öž"#^ê™ýJRTæ•ßN`J$HÔ¼§'3u@‚ähâQS#“u‡%‡L~ˆ
+E²Ã@¡‹Ã7¦±:¡õàã@]¬³ß‰„µÄ6ÿ7vk—Ø¡ðÈY€ËO†ýç`Bô\JO³9Šrº±W§°¨O*æ¿	Ãów•øÿïÒÄ‰7ì™Ú{ÝýÃój¥^Ÿ¢î¼íE·^T¿´ë`g×¡®®ùþ¼»a[oùH±ÿ¢‡ÛÛ75\û¾‡ÃOí;°ò¶·mÙïz½ãk†ã‘d¬g´.Ð{öŠ…Þõ(!·ÿT¥ŽIÕ²ÿØ¼£'?»'ŸIS  ¹é'¨¯Þ¬\§¼ÝÉ©.ÞFÿ}«§6¢(Õ.Ððazo¤_ßÈ²)7²ûÜQ'Ln/­\¨œ`n¯M\aœ¼ú„§FÈ?)	áûrVÖrŽâaº¾¾úÍôë›!Ÿ¢_¿é§¥„õÝgxŒ×U9,ÁæA”x7};ÃB}óaåzQç‰)w³7•+¦
+ÍPÙé€á/ÙP„µ,:ÁZâ‰ä€Ø¨øYiÃj¤8ð1L²¹å”ë=5XóõœÚüë|3óÙÒ="ºiBÍÍ„’	Â¢ZúCÌ¹“hW3?­³®t5§î<¬W{}œ<y™œ4ì ²î¯wl¼$­9uÍP»6E‡šÉ r9h©L9›Fc“¹¶K“½~±³s{.6te9p6…ÃõÆ½À{QžÙîJí­sæwvv^³ÑÙ`vÈH!Íw6n-ì÷´%PyÓ4MtØsj¢•hO/:­NÍãÃô·Ç·µè.šiiãWÔ®êv»t;h.ªL3¨†ö-1ÃF@7D“mZ¹…¥Jè%úÃeÑ ÿ‹ú6²ÒìVRgü3\©«šM²ÞIÚnÚ8±-Èú-vgÌ~â  64eeíÏÉÇé¹qSK´[¹Ty Ù¡¶Æù!÷ˆ,ë^¶Ý¸£tO°–„¢°–3î°$¡(¬%‰?¬eÔ
+×?ÖðÖ‚HÙ
+çŠŠGD¶´CÌÞ'æŒÊEr/š5KŠ«5“[4™Üs5—å¬´e%µ•Ï±žGm +\l# ’³ÕÎ`ôÕƒç„*P™A%`—B•‰†®";ªŸäu"<Õ—¬J¦½Í(/èÞE¿ïíš]êjÍw-NûÐ…›7fööÞ±”h=¸”!µ&º±\~Í‰qý¶%?Ôœua—¦©ÈáøB©òå]·b3­m‹éì>_WâWW]19<1yâèÔ4ºj‹/àÐ	á”K°_[ÒÑmÖ|;¦Û²…Ö¡Á|G¦åì¿¨@ÃBF‰Ãê1«ÕÃHê#®kÉo½W'HµhªÃjGz®Ågù½z±-¯ÜVìÝ±¯ ¯ïIøEËÐª*­¤–F"]Q+–Œƒo†=Š”Ñµgˆ_Ù¢|k²oÞðû ^—c-l*Ã#asŠÏ(ðzº ò|ÇgRø”ˆ³Â'¬åH¬%¨ÖðùL{ÐWý… 0$ÊtUUZPXËÈÏçáÚK(§ûÓ^Ž÷¦Ë¥tmè &ôÆÊ‹ðdFN:gÖ™CòÌ­×ãM‘éX©à\RßtjâcGvÞ7m†¡Çš½]+Mg-‹]wd&.l¸©/Þ¤Æ®ò‹æ}}¾ŽÄ«è9hÛÍ®S³ñ4ªáÊôH*'^ü‘6K÷Ñò¹l«J#/Ms ìFávú•/’H\±`o½#µÜY7Ø`¯÷k?ÃæÌZé¸@y“€G†à¶J€·Ê½è‚IP¶é¡AïnñÈË
+¯q, dë ²­¢æ’ñ”~^´Š¼»f´
+0åÈ hd¬5Y¶4ËËö™¼'xr(g«gý´ëv®Ž£²*aš‹ãTù?éÕe×nvq„ä¿œÞæ S«fÚGŒC9¨óÚ‹Ÿ³¼ß*?Góîl/ê†Ë°¹~Þ»éŒ[`0ý/64z’.ÝeØíÖH$Ÿo‹vL‡#-~í‚G6lµ¿	]HTKäö›µ<šß}ôØ.€—Œ£iåÓú5?â$ Í	h²eÚm¶ÓGO8µ 8wòC­Ú! ]51’¯½W­³VžÈß}ðàaü_ŒúéîÏíémhrª¼§sáÚÇg±SYQnCT18áô.“à¨/0Õœ¡¸%â]ž[¬e,v»§FEqhµÖ×…¼RVTŽ›|p_O××‹×ç_óXMèðÝÌt¦„?â¸¨œq½äcmWM@ÊÍÕIj	‘8—²œÛÆ$_|b%­õè^/l©…P¥¾ª|žlä=PÅ;°úkéÑý£7–ÊŒ®jÒ¹u^&¨svarÕ,F¿Ïî.wæÝ[ùBLsv¿ÞÞlÙˆN¾f‹ºR9‹×®é$à%È‹Ê±8z){lëÂ®ä†CH×üN>j„È¢;Ð¤†Õ@ ßŒ°ËkI²ÝeI´éèf¤ú#éEmâÏ˜hšÁxêÄ4*sYrýÞt@wÛhTäË:êé› *¶[ÀJ‘ü©Þƒ… ÊfÂÆH$Ó-%rcQÃkEš¦£ÿ­ðG*_§¦Ìxz[¸Îá¤[Ô8Û=ŸHôD,V5¨ÿÛâ/u¶¯[ûÓNI+KÊ¥èÀ(ß®p>˜aX.Pª¬ÂÂbÙM®öŠ¬	ž‹d•F¥ B’‚É9Àóçqáñ°x”8¸î8ÄLG5Tó¸Ð”5SÇa1‹Ý%¨wâ8 ºesÌÅaÓòÆMoÖ²Q
+™gƒ©f .Yð1¼ £”ùXAÈ8áQæC¦?Ö,À²ˆ<1“8vjÊ2ÀÆ°Rz˜¥k²MÜ'2S	}j0ñùÿ¼ ýÐÃ9=È»q¦vI/‡¥$:È’•÷l|ëTØ2g¿êzölžÏ`Ø>99M~ûÇü‘Ñ@9Uù®+dK7lÙínŽ`|ý_wSSÊQ÷û=/.Ìüò=ŸlžLø#¨ERºÉ?G7~æÒ‚üótSŒ÷ÅñN½ž;t ÀûxìsQ‘ª‚ìñW#õT-èw¯8ŠÉ]UEºG,?êÜØ—÷’›i„…Ž©Ãê¦X›Ocøê‘µ’¯]TéWæQ‚Cä ˜[ÊLg¸ß”7¢¤9O&`KYòPŠhžÔÈ2ÂœgýÜÓëÇ…Š"-/«mð™È>¥,Ê(Hì¾!å\KÅtœÌókQÓ›?+õÖaR}‚YSèÇËúÛÉ²ÂÛ’œ·(\òžFFOç47ÊQs	_!)Æ‘äZ½åèÁA,F97öòÒTÆ?ùÝo=Íùn;ÚŠ¦ÔJ3£·³û¦èhå×;¶Ö¥ÚúÝºfÁj˜î¬åúáäL6ûñÏ¾¿ºeÜØB4<¿lý2Â¯Ð›þþß†q@Ü|+Ô·0ÞþÉô‡ÃnÊyrÑÉ‰nmU~ŒÑ»z9Øè´è¶ ñïLàœ({Ö^$Ï“=ýIeXyH<8t7-ò6‡sžZÓl:Æð}ž:½¤”¼g,|W&QÀˆ+Ã Õ´'TO-¹‚Û¥%Åtà5Fe½ËÃ4N%·6£8Öu{A«šRx+%ÈÞÊ¹ƒ7`
+;¢›órÐo†Ñ‡u¿ Œâ4iŒ¬–Qþ*T³;‰@¹”1I}ùÞ·>šÚD¿}\Ò&ú±×Åt‚©Ò7<<wœÚ…p,¥»³¹œû~ÕhA‡Naüz¿.yéÞhWL%…lƒ…î"’4îÿŠ¨uF¥†FÿzÊp¨~#õsG·
+Ó5Ž|‚X?Í@îBÉN)œ·ƒë›‡…||ØdŽÓ§œ<PðK™>³â !î2³¹…×½îÈzCGÄ èòfŠqNr?2 îÒ%‚³"c3?˜<¥^OÍz=ç—€Š›þˆÓ›‡×é4i%L›Ì¬e4k™@—jâà;v®Ö>@¶Éâ¬ek©t?ÃERùëÈÂ¬«Ý¦“3‘6šð½~Æ>•Ë¤]Õ‰’TÇ
+'àWÊt'2¦‹è-S‹P×Ô¨Kìx™…t)¡tÊsI\”r&n.ã¿ùuÛto‹ÇYnoö–ç¡¦ím\]S®¶Ñ¤dƒ>Ë[&û‹Ô9õîûÆ7;ú‘ÄÆNO>†tˆ¥À|`t¢¥¨9G:Tþ¤[óØÐœæ²Ù¬7%FcŽT6ë{žþ˜áÑ­ªet¿v-uU§ù´³‡í•W5´c]ê5ñvïôFTÞi vxýyLÃï×&òmnÿO`ÕiX³I_oÚáíÍú>GV’s­öÎÎA=ƒ¼¶Ì$ZÝI¤‚?Û²öÔ3æ©áºYy‡ònôé”÷Ð›ò^úï{<µ„\¾ê½ôñÎÕZ ’7ä×¤Vù÷x_0X¹I÷ŠþzÝ}ôšûèÏ=â©±'ÃúmgxõÖ%$…Ë!IôI£8!ïVžPøq81§ÍQÍ
+þÔd@ÏÎGñFü fV¾Æê‰‚?TQcÞ)Om”é”élÀZr÷Á¾—…qXËâ8G	ð‚5\/)XË§'èúg$2CÅ”s<û(åL4|z˜7¥¸‘fü­U*äóÕ„³ .ÝS^µâY°!¦é§aŽéfæ^XÒ4Á¡ÇªªR”šÀû*?©|ã¡'vm:Ñòëo|bëŸ§F0N/äóKM?ùÑòe©T9ô2´œp.±”õ&\ªÍBt’t'm—¦c—nè˜x°'fKöÇãY§jQûv´uëŽ€mæºž—:â±fÏè´…8-¾ö˜ráÀóõŽXÀ-Ú¯h RyîÊ¸r£±ÛÁ÷j?“ßØµÂ.Ù‰9†á0Ã¨â6[wÖÓ5.›Û2Ûã­wi6'`ªY1äåšUse£‘ž:[N,¨ûašˆcœ‰¶¶ø“NÕÐ†>K¢öï~µÞ¡cO`¸¥¥ìÝ]W×ê!»éå½Þ“kÏ3ÎÕ<Óv+ÿ<<PÜ˜a1ÐžùE•°É-„=ëçk¥‹ÐM›Ö²„n^b2Í.ßL) Y‡º(ÙK†ë÷‚ƒLv§àžŠŠ7ÃT²öyoRCÖÒÈ4ÝEþ’Ü&Þ"áCo4ô²ÊKÆM÷p1˜Q>¤©Up\”„ƒt»‡Ä³ä†Ez/Ç„æÔÄŸŠÓãJL4g]ÐE€¹WÎ\|+Á_{ð['½mÝFå?í^=Þh	wFi®1ùÂôn:²Ñh£uN{»-xû_TÑï4g³‡ÓI*_A;©õµZœ!{e±ïÆ™ØÄý¾£ôê¼ª÷ýD5¬e ?Òu	u^Ù‹Òhà'WÆ½*QUjƒ¯}ž$môæöRÕ×8º°¸,"Ê¬ñ¾^ìêqž{M&
+†”e”	kIK kx»ÅZ&¸æÔà;x€±ªbÛqd}NØØb–—S+ñ-&±Tf;	Ðê?Å™ PC9<-]«µž)Œ¨H^”Láuø©œF£Tµ‡MtÁ°ÆçÒXRjRqaÓe	Ä1'BÖLHDÒøý6“_Þ¼ceË\Gºâs•`†'¶|÷à£S0svYº~ê±1\ùÝÜ­Åÿ¼lb¼»ò­þ‘K.»±wäÚK‡PÚ,¾›½…àR°#@p<Øˆ#Ím‹C“Ó­¹³?FêÆdsÜC“²CW	DX®§Iéêº5œ\(ö]¼}sq°¿ü©w©s¾¿Í‹Ï` -Äø™`½Aù„±G×¾A>I ð^§´ÒPvQÙF}àm0÷ªGÄºU¹BÌx\¡ÜÊÜ8ÓÄ*§qË®ÂnÛ­Ø3¬isF´«WùÞ’Ã‚°–áÓ-z#Õ#&çv«pnç'¨åeß;V–
+LPC›p¦†fF¬
+‡`š=Þ&&"·±‰Hˆž9„èÎÕõõd¯É¯{MûÕi:éÊäÚõšÙñ`
+Ò\[Þr¦FøøAÓ¡‚µT'Í¬S£»¶´¼Å7f.õ°Nù-WÓ(î¸3‚øÊœùŽþWÌEv‡Š u	)X&ÖGˆ‘/Q&nª#6onÏ´f³•+¿på"ÑzKjz¼Ü1›ïˆ=;×ÖWy[zKç„Ä})	¶…#SíèáÎm':-‹MÜ}Ï¶åûóÊ/)Œ½#›í0~AêûîÇ› ÜT}8iÁ÷yBNÍpdÓAŸ/„¾ð«ŸZ¹d$ó$[¢ÇƒÑ»t§îþ›f'1û¿Ñ­í0ÞÇ #K“>Œi¬îO¥Úì ?úòM®èntv¦;ÇZÃ»[‚.dØÕ„ýy}Ôe?pÑ½q½r¯òðwÊlcÜ ¬ç•ÇÙyœÞ˜§èyª uÆÇ•§Øžÿ ýîCô»±qÇ;”‡XÌzˆ®ŒêóÐç)ðWx”®ë'éúÉ¿æc°ÁÎÁæ‡_q·°£Rîco^Ñ!4äãJš½øµruH¬ø”GÖR¥êÜˆõ“rÜ%öãñ,ñž(ýG€îè2tëuÉâ¶I•c÷jA}ÎUsÏå-ÑrÀHÔÍ¬Ñf½"ôw…î±é®r¾kqaú\Ñé7\§æ¶E°]÷§QÅÞ˜u°1ª[œñ •XBžp»áwV.G¬_½ÓÓ-†½!àm>'ö¹¸5¶©Ùæ"˜ÄâuVÍéöôMNºhbfbìâKÆ§Ð=‘žaáœÚÐaŒZ}¸y¨!Õí/65OTp›î2u^KØÑ#îöÁ˜f×°Ç«ª6Ñ6ÜÜGÏTj©ýiw¤Ie-n[ûƒªæJú\¥PÈnúSb»á!ªÇÛ¹h	»|„X‰O³×…G»½è?7—J=;–é	.=Aû±½¹®®/±ýd$ÚÒjTÿ? úS•Ö^$Ñ½%¡Ijý^ÐgŸ œÈá¶ùêÖ‘Ãmç# 4Ï|@-É\W’Óî}žõ-5Y˜7™=Hä·žáÝß¸Œà—åX½ˆ¯%´42¾¥õÚä`7eEzéìéˆ°§[èîv"ÉyÀMÝyå²âþ*òªHr¯3[è…¤iü(ÒDPX&ÔÞé÷ 9“4+½¢ÿ¦@ÒB­Ö¡N7@CÈFmî’;	ö%r•úË<­	[ÄÖîx¾×óÆ{·£É»}°Ú¼¼9ûQØ[ÁÎ°¿#¡9	->™LÍÖ«ŠÙ½M¬‘0qº¤òùÊçi~ñ0&ßåÜÆÙß¹8‡Ñ–ÍöÞ=ðUÃ1èÂÀŽü,J2¨íó¥Ÿ¢Ïi*buGM\{/›îSN+ŸV¾§¬*Iùœòeö¡™~ˆ¯Ðñ•_ÿ%]ÿ¥X®¿N×Ÿ£ëïœá#Uæá‰oÒ»ùcåûì.¾WyŠ=~Oy‘=hÿuf›ª«;ÅŠž¦/ù4Ø<ºþ ]¿H?¿†~ïûtý*]¿
+¾ðu@$™ˆv°úp¯‰‰9EªÐXòZKUk9þ²Ç§º,AÉWÌ:p¼ºSƒŒ˜ÞC š²VTJs}Û`®f%á1Ó˜e“ËiÎrÊ­Lí±‘% 03Ø'Î/¢UwX¨;Ôí$Òâ¦[ÀÕÞ0Úçxœä@ß„?Y¯Íb÷XƒI›t® ÎÔ V]ÓÕ–†°[°+ŠtFÔ€›X-.2×—¨ó%êmÖ°ÅïLç->¬U¾¥ªØf8:ý)·?á4l§%ÝhR«ÙjÕj0å˜›uYøŸ	g=«ldâ©n#HÓh¬¡%oc,w M‚aÏw'mV\—‹ôÅŽÕy¦ÙhÒ‚iÚâí«V-Ö—ªsy`{vÍnÛo±ØT‡Z§ú"1G<dµÃô@™þœfø°a¡6³¾%Ñ ¹­ñžäê^'£aWëwµoËë†Uóíö =ñâªþði#»ÝOê—;p\!£Øì©ƒB@Z³ÒãiséÍ»ÛêSc„![ôX9Ñ§ï’¹I(Ý®†½sóÅb­~jô–:­òïè5 ŽÇ„÷½¯}ŠÆÌ­Šf8» ÛêÅñ®*õÆFv– ée×&kÙ@éÖ®^Èå|ã¹¹´‰ÂµP†×‘Ðcs	Ïïs¹IäÑ¡/ãæ?+ôçv	<âˆº4›~ˆleÀé©‘F´˜Þà²Ìz`r<§¦Æ:â%Õ”0× Òeƒœþ7]S«4‘ešÂCÊÅ´Øü2Ä¤B±•… ÀMX&s¸²¶ÿ‘rãÂÒrö%¨}TÕ»Z§¶º§N·`G>ýµ§nç¼ßû[B¾4¾”9Ö¶’}òÍ3<‚70²SäN„Áp?2§Þq	æ›€þï]ÿ…ˆF·¹Ž¦ºº$¹“»'$¹òM4Æ|aâµ¡ø+-,õv¤bw¹´Ÿb¨‹ÞNãÉM¬Ïa»äå¥¾ƒ_TešÅXñ˜3íÐI…J|ON¤ÀÍ‘EùsKŽ2—‡]"»fÒ1x=9Š¯¹(^›»K¾–U˜Y¹{àÅ·±ÞsZ?"j§Í"¨XÁÄ0cÆã½ s·AnõZˆ#ÿàMCýó|uQhsš?ïYß©–¹= \e³jÁ#‰¢€M&§«âæš[„t‰ö3Ûy^˜~Ê#)7ÑA&(5}yÃ`”q–JµàŠy²ræ—3‘H~÷®ô“ðþ¿Gü&Ðèn?ÐÓ4—uÔûnýÒ#ÅÖ&ïgG :ôùô¶lûJK¼å?uáO_¸Õ:mO!õ=t£-¡ Šª©ÍÙìÖ4Æ;1ƒå0,žñð8DíÎ‰±8z„š#h0¿[Û+MhÇUd_×Ôã©cÕ
+vidíòñ+Ê ²˜47¨‹W0gB­¯Öê|Pm7ËŒÉá!XC+çÿE:`£ø¹°s6
+»‘EpmCÐMl­–£Ì(.ÙÞ=Yd4«“´š#¬å¬eÁÖ²ÝÙgÚEo®öyÖëÊ^VMÀ¢Jè1µ3.mŸR!ÓÄÉˆYÒ&)'›‹ú÷*IDÏÎŸà±³÷ƒÙÉýüìkzç®7µ#¨W~4yU‘éûƒ‰s•×bƒ][76·øìÅææ=¥ž¹àußÙ}åÕÊ_3¬%;Œ_îy|`Â²ÜÓå&d+a|tÈa¥Ûò‰örujÉÅÈi·<™p8ãIæ¨÷4,v5n}':|û×¾BŽ°¼TéO£"Ô7ˆ›ÇËyRo«r‚ÝÌ?E‹ü¸'<µa­¦bVŽ‡kdmÖPç¯†Æî
+†tDDëœ{¶cÊ…G˜PèíìÑ.f8ÍR±`cd2cž2c‡LÆÔÌ±rôþc®†µ¬Ý žõ äF—š6ëß¥ pÈ6Mº¡#¯9¦læ¼rILá ®eºIºÊA!Ôuþq×†-=¥®É±ÖntSËÑ+®¹âH‹Ôf‡.*ô_ÔñîÛ¿pÙ_!•_Ï½©¡–ÃCž†ÊW7Žï9<6;;|ðÀÄ<ª· Y´÷ÀÁaÃ¥Ó¥>Olº»º ^¦±'§æê3sƒÙÆúÌÙf„‚ÖˆÛã%‰ŒÍê3T²˜{©{n§fÙUlkëÞµ¯ÔÙÙ÷>4*[Õ¨ÖÐW¼ƒÍRS{¹Çï 1.½§ÛÖ^&’<u;•#èi(ÞˆÝÆy#ö‰mÐïod©„!>~°@g]–ñöyje¼}¦}
+×€¢¤Ú•$
+ºïOÞf~Í%«bâ]öÇÄaq	¦°PÕ˜ÂÛ…\Ëäa-Û,.ÓâÔËÍ*=²õæ¼Þ„øªq?óµô­fÆÿí&?ºÙdõ@ZHÀ§%aÔKRF©ô±$^‡'ø|Æž”rU¸<ÐkeP}Ê¦|™O‚¤µFVR¯ÎÝ2pº«Å˜Z0'É5üR;¨„¡ŒI.¤)ñ—ÙŽŽŽf›§“³ýŒ~ãsŸÀ¸ò«Ê•nÝue,ÖîýPr&›ëóV¾m¯#†Ãõz£¶Oò—ÿzæT©pªÿÓlæ²Þ›v`èLÜÖð8È	abq&²“tKGc!ËI>[<MÓo+>°áN-~5ËÈÇÁ”–ñ±S„ÕÉ@/ÝTÔ3ˆ±]­-ÏUþ ¶\:‚+çÚ,®½H>Ëf7Êt7œFý c‘A\,Ð%Ü\Á­53Þr¯!nàò ùaöÓ£Õ›Q¦ª,²+wxÎ×átñ’:aTÚÙYáÉ/µòÁ}¹,z7ß¹ çB}«æéÐ2ˆ(=ìWö˜¬mÉGÃZÂ`-ó@ÜËÀPe˜
+²–	ß—‚N”)ç$»e8C[R·ðÎvoÐ`=º¬‰3b>É›îñykµ".# Gâ¤`zŽeõ4ÁØIÒSù¿•b—–EùðÅÅ«¦§/k×œNÒ‰Õ›v{ZbE»šÎÒl93‘<zÒ@#ìvùµ¹ºÅñ¼Ï­Tn ™2³ãtKY™vEùÚ¢;O4»¦¾ñ0"‡ìWÓ‹ÜšÛcP]°BË™üƒnA6ŸíÏÀÒæaGV~7ƒ'¶hV\g¯|˜^Öf÷'—‚ùÅkÇ†K+¥Úa/äæ#@B·FÓÆn¥Î=B-íõ0-@@Qï¥·õ°	Ñ}ƒi‡Á,å^“é:ì©E”îË@L.1n2i{M¦loÕ6×¬[TÍÇ…%†W–XK¬åx-¬%×¼šœo‚5Àˆà‘Ï6)5>fq™æ¢s@—Od9×	vW³®¢Y—¥»„·íR.e•­>±â€%»BLúã4e/P#*j4G¦æ8éVM ŒÕªOf’j¥½ÓžRÛˆáªÕ§LNL&ñ˜ƒBAWœÓ€<ò‡5NƒÍAö9õo®YQ7POÜµøæ^ô>= ¡Ìžr'=šÝ0œ–ìá"@#\®>¾¼ÏˆÕ§Ü‰¡hd"‚nßë[]é`oƒ½Î:ç¦1 ‘Ö1$Ò~Ðý)ºížß‚cˆÄ?ùv|cS=GT—R5W{ƒ«9f„]Þ˜}dsRsZ°Íæ'¤uÛ¡£,l¥ûUhDº±ÜV×Ô=ÖÝ˜ìØL\…†ÔHrû1Çº±Ú\†-á÷'í—³¢à÷^&§K«S¦â£ÛP7Ð[#‹ÍÞÕ¹´Ì¾aÍ›ÎÐØ¶1}…ç¢Œæ«À­d0>¶›œ¢ê‰E\ZW…\Èƒ„M;
+ŒºLèžZëóõÆÓ&A ñÎG9×ÉždºêÇa§é‚p5Ìê1nì×XÖ<ŠRB“-œ©M±°ØTPÄqu=\Æ?ù?ËW·ÿÃÄu×L“onº¾_@¨4y ‘èÞ_ÁC{’ÃGckè>1¬jàø]Ç††v7¸:
+“áÒÁWƒ!×þÙàz3¿‰Ðœ¤v-ª"Ö*Ç'@Þg‘ˆ³¡Ë{;aùÊËVš¯»&¥vÄSôžÖ+=¹]4:¼¸¬xÆ{H ë÷	‘íœøØÁ;6	íøžd?ÚgºÓ9Óán»eÂ	×ÊÖ2±|£lC¤ª¸Uvø²mkÙ×“­`XKßkI‚U3Á7ÃÁ›°:WøfC`t‘¨öa‘ûðPù°Ò½»A®¾ºõÙíáµ0©2C†µÌ`-³e‚‡ÅëT™í²×Ïþ‹ô2(±…õjÒSM~¹×µjFãžu•Ä…œÃK\(ÉZ…É
+g€ùÕï|ÿ;?\ý!jZ@-»¾Ït q ®^ñŸ‰³.ä¢{ç½•‘Êf_g²>«ÿäÌŠxRuêO~@¼‰FV¬¬}¥÷ª.ÇU˜æÂØ~ÆW³Ï!äj©‹wøŠK+ñk„ÐØO%áwd—Ð6U²­K±3µx÷À†AÜê"!=ã›ê'ž\,Z¯}_Ê¸8ÀÇ>K>E5=ÊŒ²€†íœp6á*F9¡Óœ²…Fø¬$¸™øL7ÊŒú‡ÙIHÞˆž—‰.ö,,vsvÏ_“Õqàˆî%ó¹*XhG“ØaòÏèšªçü@s}9ì©e.pM«É‚Áq“¨s]¦ÏtÄúLG¬ÏSËPà‘Å)3û/Û‘Lépå	HúKð¸ŒWÚ\“É”zXo¦œÑ¸ÕãEà÷JiÜ)3l°ÿæ?¾îN$
+^4³zhò÷£Ûñ$ˆ\x#)í	”SíaWìÖÊpeCàÀÂÂùålnkûî¦*ß­|—f¼[Vn(œ}í W"|%lHÖˆ¦uÍ¥fÑ‡ÝÆû¶$aô‰&jsÁƒ±ZDÆ§R ˜:¹ÿíH#cèy•íµÞµÏ“çŽº«K‘2äÝÂñþ¨½PÔoÆXé„‡ð2…—!!Xcžì
+Ö2…,zÖ7ä+šLÇ6q#€Î
+¦ùàçÙ4T_ANÕº*ì×¼xƒ|WM.Ÿ0ÞæIOln6Ã/‘Åì	OmÄpÂ#G	×¡Dv€2@§*DeÎöK’›fí¼á² ZÒ4ƒ-åÊ@Ær/¤…Ú¼Q‘7æ·/´µÃý©r°MV¾•[Ù¾%C­‚%Ñ©Ÿ=õHÏeK£d1ô‹+Ön›ØTùwOÒÓ²¿ü¡w{mNýšüæ8!“é#&ì›-a|ËÃx¶#‘nLz’.§ÃUö¬l|WºÅe¡¡óiºÐ%}j^«ßÔÕ¹«ùùÙ¡°f¨½òIŒßLóÍ¦:t_ÑHOÁæl=´TÈ·´m™ËwvwX\L÷êƒtµ)õÔc<¹)'Â…PÅ\E†¯¥­å¦ëClÚS°æ…\…—›!ÎÑN+Á~ÁÁê¦{‰f™šqJ˜î$¬e9ÖfÙž$Ð;œ†²>o·2[îNÂ’
+I^?R@=#¸Ø+á*n$Æ¶»C|h‚ ú0„Ê"a”)àswÓ¶Gžv¬ºë\u:ÆwW®?yø†Mµ»­‚t«y½+[GòŽ¨ãñíQìtÒàÙÑ{´´\g9€öud¢‘fÏÏÙX¬Åƒ†Þ?wº7°ÐßEÿâ•Oæ²“	èDjqý_ ÔüwÞwŒz#›C‡VŒ4==[êó¶Æ.d$ê]Øªé°•­a¶€‡#,Íc³ø_a³øËÊ{Á"@Ê£ð¨ìè$nû£&·%m9¬%¤ÖrÂ9Á£Ló–Äí‡GÙX€5oUcŽM™dw¶ßSc\ê÷H¶˜±OsáH?MÑ«œGÿ³	ûB~,n“Å—÷gÿ§ön¿YC7ªø0]]¯ÐsRBÊå4XÓ8ÜeR©„Ò‡Ì²-â£q™³Àüt¾:+ý:¥ÃšøŒ `Ü%ºuøM4‹Ð…“Ù¬eöÑh
+*MnáüÓüÉ©û“‹€µ™gL~{Ædµ[MgÖPm7ˆC©
+†ÊáÜ×ô„‡Vš)*•eL ¾ÚŸmrÓRK*†Ì ”zŠ R1M…GHI˜‰šaFæDLhfðí».ýÄ$!á: œA­n.46_ž¢Yhï[çwº\¹(zªò;@`Ý¢†Z|DÓŒå½«®Z£Þ”%_xß=§PÓñÊGög™Žá©/ŒÂ>¹ýi¤Ùí.cûT€„`c3¥^§aä¶ºbG4èÆ:"ÄH¦{£ˆøòím>‚!RÀp¹ièZ%sî,¨;>Kæ©])ÃÊåAôo€Y|Ay˜þ{X•Lµž‡L®¶G³4mŠ“&»~£iƒ@1O¦ªÐR‘¹¬Í„mçk»˜‹‚ðš2å€µ,UÃï•“Õ°–/°–Ãcp½¬ ÁØ™à‘ÏÑrA„Èlr.ÉNÅ=‚:g@°Ü®Ü(  WT;•ÿ/?o4UgÆÃõ¥ÕÚ
+t”<Ê…È:¡ÜÏ¬$H4\!I þ,©%¡4wø3%I)ÜB×·ˆ5'©êìJ•ø€6”ª´¡#l§±Ö¹‰É†a¢…\¯˜½ääØüŸt‡àÌ^7÷<c:c¿€œ†QU˜<ú9I®¿¶mÕ;[.Y¦.)ºF»ºË–ÞåX¼}·á	\‰’)à„Ç8ˆë?]º¯ zÓáÊ¯¨qõ¤
++¥éöþ¬ŠbXˆž÷ÄšFâÝWðNwü×ñ˜êI|¸©Óu¤%ïBnðu¦BÉ Û 8ˆœf1÷eHDÓ˜„ŒßuÄ¯Ú=FÿŽzwÄ–i¡ç\wúú5<œ×Ñ/œçDßÒL[*ìsb¯Hš¬†ÏîN‡"=‰@kØê3>ˆŠjÂÈî,>³ÅØB}5t¹®@ê ëÜ®³#aÿ'[/÷qÀâ©¬]ÎÛßróÀªAÓéŠô¬Ÿò=	‘5CTøDî1Ál{HP~ûD¥ &~‘ì,…íbõÈàÛ1”z¶û #“åWØ‰¼ÁtˆƒÄÏèäJ¬Yc–‚Ê$ÃÎåª0: ?±°Zæ9ŒÊ²eÎµÜ%XIú|¡Õ¾U#$ÓÄÛìß»gÓâî­Û©GŽ8š*kßÅâïðfÃÞ vC5¼ÃîÕƒ-OÌ©Z5íÖ—í1#èT	H:f›cõ?n»~ûÊõ…»N?q‚¸-QµòöJ§×øÔ{aªãëÀ/šÂÏûé¾°T^#‘¬{×X´-àö`4-¨ÉpYm12‹zl<ÒÒ½6¯W#†êŽÚ''Ú¶‘iLƒ‹0áv]™exó¼âRâÔ*‹4ú=¢üÃKÔ(w³[Ó&Û£‚PP¡£bêïn%ÄoÜâU^Ÿ¬[å¦ÆL®
+‡²ìÏCž0Ás¬šÄ|0Óâ2oÓ¨÷‹éˆæ*Ÿ>‡/-Š[”nðØÊXK&ßâT²„eæ‹8¯®%Èé=·áMbê"¼$ÖØŒ`'ÃrL¼]®°T¹èg/þÕÂÈ…õ,Nö]zõµ?oLÏoœÝ69;‰ÚVÞzÛ–½;6<tÏÒþ¿?qáå''Z»–Ð…÷c<ä9ñ„ñý•W¾ß:—LNfq[>?S×±òøäû.¿ë¾ãK=‘€;8XŠ‡:Ñc™`´½!ÓÖZyy%—Îæ7/7Õ7dPdtrn|„&gÞ†>¹OC?ð´±áˆõäÕœ¢‡&& ÛP»Ð á¾ùÀÚ3ä†·Ø¨ìSN(B)ùbq#ñÁóñ)ÝÏhßWA>¢_gí‡nú3¼Û%‰¨Øbº iz
+î;ÄSPÔ¾T (vU…Ðxµ0¥ä•=âEùÊ„h§(:ŠËG§ÞgüèXœj²/A˜Æ¸‰$)–I÷ë$¼Ð/·nši/ì˜Ï¶„ÐGlNÍê5l^½y¡)ÐäÒlŸ7Ò78÷F M@$Þ81<î°s:šÏ»Ò¡¢¡Œ^´Fc1ëœî¬üdjüÐÑññMÓÛON¢ÿœÝ”ÏÌ,…›K•ý†ü†§½Þ×1ŽÆPC)ß`7ô(M¬lD¥‹bÇé¢ÝjÑ‘Š3é†v‡ªcÒ`ZÏ~lú1—ŸVÑ*ßÛ1480°û‚ÁÞáa–®}šž{CYA:?"Pé…lZ«¯O­Àl7EX2ü†ô·°*«1Š@Ï8©ÀF‘Yo5ÉmÊè…¥ñgx.gNÕ¡Š+Ûs[MQ
+@§V×‹ªÊÐVS˜kÙïš2¸^}ÖË!Ë5jfó‡QÉñ)Óä=W§)–™Ü½pfþ-vM-Õ£ŽâŸþ9"P
+F/LíNL5 å£j ˜¿81·4D"Ií“[ÕÐh`üÖn/ •U»ýxÃDÒë­Aä<‰®"äñÊßX.Ú°a^ÛEãƒIšvÛýF¨Ô×5üvÈ{€@‡í‰á®˜5J]ÓéÏÊÛÚ8þ@Ê¹xY—á³!~ÎçÖ>N–I;=çmÊNårÔÅ³Íjÿ*heðÁ¬î&…ÚýQÓÍ…Z™ÂZâY`-‹«p}ƒø9Y	Ã,™'`‰<Ê®êQOm¸ü¨)ð„µ(‡5oÀ+\D3ÀD¸½×Âñ-‚Ãêyá¼ð}Ùxí-Uf”€ Qßì©µGà
+Éí˜)é€àL¯C{Â¼/³1	$k¸ÌI@M;—þLÆ_ªÅªÔièeÀTÁ`'N"Ñ®`¥£¡êh›*µx~]ÞçvM’J2è…ÐôUUôoªjD|+“™¡Y‹†5º»¬†›ÄÚ¼=‡:3ýÁ°÷‹ß@¯¾3^B!µQ|¶ˆ´ºÂÚ)º7!Ó¢$bAõ“v±ÙðHx€‡ìƒ8ïª÷5×-õÒîXPCmt°JªEsµÕGúê34Õ#mÄõ®×®	4z°'OdìÍÓ×÷ùØÂ1ì7®=ÇbNCéTæ ÕGDÙgVx§hX¾QEÖf™i&ê<ë	  ˆb™ÑAG6'ßHùÖ’r
+~Ï¼Tg°ú˜Ò.—ðÌ­Ž!¬8Wø¹½³`4™ŽÂZ¦£fFf3'Ö„éÍÀšS&ÑýçÍé^Ø/,®cþLç<n@X•¯Ù29h”ÓÍ¨?aÓH „¾ü¦[Þ¼ÃîAYX2Oóƒ/Þ9<ÖT°ÛýÖølnH#îXKå…'þ§(¶ÖÆÆVÛßô{tã
+PpâŒ·UÞuÿ'››|¤íÒî·QŒž(¸kßëgß‚Hd²µµ×1±4¹¡0Xù×ÞËa?Œ­½‡|ä”’rrÚ÷’r— `ÔD8è²fâ‹ëM®â.“¥J˜ö ¬%ùÓ,}-j¸\àÕî•˜9xÉ›w°_Y¯ÜÆóç4qáÎæ<µÒ`Û¤»„µ,“ÁZºÎ€é­æL; çY_E3îÖ
+kÞÔ€?ÇÍ”g fr –,5°~=U4õx&ybÃjÔ9wK{®‚AC,+—¹ôzæåõi4LüÉôÿrXÓ¤=&9®€	ã–@¦üÁî«z_MÄûÆ‚ÔÑ-Yò—-ü@Âƒ;ìÜo½x¤avã;œ>=°Ñë­÷›j±[BM®¶ÍÙÞFÍ©[=FçTb(eºÂÖ”ªaWÈzt>Þâ¶º,0W±Å®Õwô´Æ0~»£¶é½á™Cÿð—°u1h½áwõlk RÁg:Šk_!äNÄJ¥ RÃÁð7Ú]šá3@|¦)ÚÔEÓ8wÌ6”ñÆìDWý¶¸Ê¸æq°èm‹¹;0Œ¤ºÂFocGDµ¨¤Òº…I°.í"˜ÚŽ=kOSÿ›§÷-£Ì+{•SÊU(»£Jg”^ÑzâÖ0ÃàÃÜÉm´Ý³>8’z¨°–IXËè®—=ÿš#ãkÙÌ€ë¯ó _ ÛiåröŽ‹ºT£àa=}z^<5•ùs«µP˜{£ù
+Èáå€}-Ÿçk	§ŠMYdƒumr˜%k’è»—K¦³i­dê•‚Ü&Çwv`j_×B[ÅoIðà¯WIíP)qÀ^Ÿçþ8q×†É¼3i§Í¨cuº¹·†+Ø°­uc*³ÔÖºØôP¡ñä%kŠ#CÅ»¾„¦ÃKÍ[æÛ7•[Çãé›Þa¨«‰ög¼qû¦Ëš‹'»ó'Æ²Ko|ß©+N^‰~>P—¬wR‡Jg†#ñ‰>À9ëÑNCu¸¬ØõE‹%22rºÂ#CqÿLwúfÐø_•/ªñåÞã½K×´[^`[nRÿvhP…Ïi<Ož¡ùž“n«QågœšÚ/@:@L\©àû$lòyÙY5}zWkƒ±PÊç…û.Ä4mb:§]øÉÛ96“…µŒÈÌØ6hËðÒÌÛmF"™EÁÎÏA¿ž5•)ó)œ´$ÚªZ8.­õÂ<X&HÃ¹@˜Kt‘Ä<A?Ï¶·ïhGC(ÿÐEžƒ4?´”˜kG¶tÇÄ²Û“
+<LÂüé|åk*¹ÿYä?ûGj~ÝzÙT47§]}|b¤PNÇ4N"Ç{!a¨éŸ6ÆŒMþTˆ0ŒVJkß&Ï“z%¨Ì  äÜüCœªÊýº¿Š:7çlÐ›‘”›ðÉøÇã©uÅkÔüŠ â+ð|r¶Qø™b5;^à„-Tâd¯¦Étúa-C~XËY3t	Ö²ä¹™ìÕLyÎßÚ7k¡À÷Íð&>xhï4Ñ8oä!vš7N,Œp½œÓÊçŒ¾s:çg$ƒ•‰uFè	'âÖ?ìy[ß5ÖÍÍ»»ºw¶dæššNÍ²þ¾BHåô¦i‰NÛö>2ußÃô¾½òÃ¸‰é=c+02_gÜU·¸µ|Ö…=LÍu8,6Òà¸‘À¡D¡®ð16MÏä‡a¦³Dó–‹•B™‹SçM›¶ô¹w2,4”MÖ¿l²þ°>*³PãeœÍÌÕ˜±*|.áTÁÌ=¯Œé,5ŠêI˜Kxñ¢|P÷s¼3œ1ž‘r&ç‡ÙK>ô•Út±J»˜É‰à•Ï8ñ–+~ºÔßÓÙ6›H$IØ°¸­ÆJºÑíÆºŠT2$¡ÿ¯´+ŠêJÓï¾¥^-PUU@QìkA@H! •hPq%ˆˆ÷%.YÄ$Æ¤5¦;&jl;i;‹±muŒ‰™ÎÒ™‰I'“tb2vc–ÎééIçäôIÊùÿûî…¢‡3sfÏóýõÞ}÷Ýªwßÿõû-	Ñ¹ù’>WÛ£ÒŽË<åœ€üš£¢=íŸ¿¯èðx
+]ÑN}]_^É4O|¾ã¼Q‰ØŠŸh“ˆ¸?¶,Å”äÍîð5úÛ7~¦Ç ”X)ü7s=	÷Ûƒii³KK[ã—ß“ñÕ¤$ªƒ?ü3›ª	­AFqo</­„g’ÚBaTi1è(YmMÇ-/ˆ@ÏÅÇ5VÔ<´’‚‘q\\DÙ•+	~Â‘¡(ó"fÒ|ýGšÇù!ÍÖtpa„ B¾€Æà÷ÐÓÅŠ-ûX †§¤q++aÁ|Å™…‚Oèb3¬Ç:Ròi®äc”½qÏPâøË«E‹bGªÊ*iº‚‘&@˜x:§‹ãÐ5_¥µ‚1Ç…‰•„)KÜ[ D¥¥ŒÐC‹%õ¯¿~L”LÞ,•TÛK]7
+¶.xS/Zôú)ÓáíÖEÕ(Á<©µIÞ.Å¤˜L©…1G?—d©Y$së[;~>³•H1Þä¾«ëŠseÛˆ4¾ÍíÎ©Å;6(&1Nw@s ªâòØDQoRÒói%v%J/Ìúˆ«À]Ôê‹2È£d—Qï1’çLCøÅð3$ufæ&4öˆË°à¶+Ã<%‰{ Ë¨Å_`>Ýi†3“/tÀœÌDXÝñÌÏœ3]ôqâ£áêŽ›-Ðè¨ïw$v~°ÓÍ<žã¶žñŒ‰ãžÏÙ#˜¶½…]ÃsAìÓi"ˆ4ÍYP ­FñÔ{ ÍI?ó¬‚Ùù?ŒàKÄ_8\&1_	Ïc(C$f¯çÔæz)½Ä©}X!êYK$MéÛ.^"qÄæ£Ðzñ£*ÑÐjëE1ƒsuWoÉ…U¬ÜfKlÕ‰ÔŠá€HS'ÅÍøå5RèØ\S“Ö5Þ^èÅ±‰	±on¨mÝ’Üì‰šD¯‰õxiEàTÍ†’"n ‹”…¸Ìö·–ëÜ$ŽœTÛl	&¬Ý®‰ØCö+D­J:øÚiJ’Y’TXè¾'ð®èÌzP}b@žÒ½YßårùÝ:=-ÀqK|¦7.$-ÆäW’]ÈÕfyWó–ã]n1ËrŽˆ!”œ+¢àO+ü2jÎ	‘Fl~.×ðøQ7ã~èÃc1¤ÍÃ²ÆŽ¶2,Ìa~C^Ì°Ïk©¨¥¥‘pfÃqÏºÙ::bž«eHs™9ßÿV¥¹fÖ•¶Ž³kþ\pÃ=Ï<G¡­æÂÒ\8»æ’fã?v{ÄÒÐn
+Æ—†öˆW3MùúY¬j±5"þ%£Si^¨ªU¹aþ0Õe&Œ±r(Ï˜Ô4-&µd<"áºâœ* ÐMrºS‹™Ñ„Œ¸¦v‹ C¼ ÑJ=è)ö|Q²¦Æ•îâ?Øy8_Ýcù“\®tÛ«æ¦¤TÆoiÞ5¸ªba®j*ÊÎ®÷Mïóu–—O‹½óJxô’Eü©YÙuÞ‚:w\ëR:aoÍW×+ç¥¤–»B¢ÔÙ‡¯I+f0—áê>g&îfÓf‰t"<Å¡Ñ°ÍD~d¿d²G“(ƒÖ6'¾ÔtãYéyàÁ~ažpXx4ž†„utÒígêö1á<ÝŸž¦“p•W›@…j•pŒš}\pÕ•þ÷[G¸Cì¼†ÃE:ì‡i ÍkT`›ã@ú,Ð'€>ôÓ@?ô¬Í / }èK³3/`5Ð»èp÷
+ûèþ¼ðsño.°¡r*Ä¨3Â¾f~Þ:RNãöˆá!Í£GFêzj% ö\Öbh°Ÿs@ŸC>­fdŽÂÓ<€Ãøa¢3ìþÃòÜ%Wƒ:K",YÖ¬S5ä0­è=Ê»:ÌëCMÐÂ·Y~ŠÆàYÜ™‰èÃŸk]j0Õ©†¤iG+ž!&gÉ:·[1›@ÚL.´•å¬z,Í®šíqšE™lÆhÄrDgq)9Çgrš$U±y£³É:§lvêKSfY”*cÑlóYÃ;WöVTTˆ6Å DyÆ-:®©&ˆ—«&d”ÙmIÑÇ÷¬šâ9¤è<Ñ1z{¶Kµ›H…Q'IÛk(.‰dr™ãõ[‰lLÌ$Ù‘®sÛ‹±6+:Å	âŽC”$gËô.¬Þ¤¨R¬£ÔæLE7i¼,YH"HØž,s²]g5$ÛÊ\NY•TÕ¤æTÛsÜ–›d0“‹‹SÒª‹ÖE©ð8¬ED–õw‰æT§#Qï¯³³0™DöÀ¨wP\QÅtBrHJ4‡¿}M¼ÿ~):#/?–¤OÁÞ¤ó¨á¿ý8UÇì¤°ÙAóéÂªÐFðÝ	‹“–°’Äb’„Œa¤ÉéW¸ÇÍ`‚‘žÁ—ÈpE.ô"}EC‹T«æ^aQÇ±_ÖÅ\ê
+³8g2sŸ¶6YØZTGuqÍ¢)UóìêHœ{´(£=3\§Fz¬ì¬@ÄZ‚ú5ÏE:Rïæ™Ø“Ù—A…³“í5ÕF´kÑ:§Ã+"Ð@|NG…›:!0	;]u!bE³Ò¡žÎ‹DÒèÆ*­(dD ;ÍÁ?ï­Ï+hLœZ5«t°¢®&u~Kx7ÌÈò»ë¿úiøRAôD?÷d\ß_í(iv{®Ûx›gÜœŸÞY¼xsÆGO‰kZ¦Ý·³mA]ó&IüuÙÊñ¶
+^§ê=ãcÓ=æØ¸Qêôs€.8•ˆeŠ¸²V;oe…#C
+éÊÎªoœ–œÕzSVn~U|}ðõg¤<¡ô¤!á(æ<ìúè<œ÷[YâˆrÙcyõ #@?zñËÑ•¹^x”²ÌIŒ‰/Ävˆõˆ|Ÿc:"­akçÇ™† Ž˜¸YXK°RØA÷»XU<¼‡ØM4JÉ4Çêam_^1ÐÍÖ?Ã ·½­@s¬ÜqY+sÇà`°\ðf‡w•1:{T«žAtì(ä3CÀ}ghLFÍG€¬ÂIs9·G`‘—’Ô?˜êÂ40Ð	‹´Ô]¦á:q¤QgP4Ùe—ÉiLv©ÑŠ¯! ‰®«—t6™´Mn2¸->#KT“ªÕH†$`Á±Ñv½+Ýì¶‚ˆìWšisØ”©eÑ¾dDí–£ôñåF7\þ.'¹xqióî(ž¸´Ï_ãrå8üƒu¯Šbò&Ó¹ú¡þYf_ñß'ÕS+‚,z=I&é¾,Ù(Ç™¦ä|“]ŸW¨T„N“ufIGZf´#F3±Â\6*ñe±ÀQË$IÖÉ^[tbL¢W‰RsKƒ³Í¬ó´w´Å¥èÍ°fX2”h=‚¸ÍÓËªNï^+’m„ÆIÛû$ñ"E‰:©Z¼ 'ïî
+¶{½AQ¸tîíLºnœ”~)eÇ’Í
+Ë„ÿ{,Y¥PÃøjP9ÌWÑ…A†Ÿ¹0<¶óS£¹ [!¼"Í±ÐHLs|"¢Ê–²`¦nfÃøû¨27+ß4ƒÕšA¯,·:"Ð]¬#Î“NëèìMBþÇ"Ì2ê‚ŽÚLZ‚B‰«(Hý‘~	cö§ÆÐÜ…ãš&–/Y=x}$Æ,¿­ñž-ÓætLÞ³cj×ç£bÌº÷N¢¢hÈ.Üºwh(|%üIí½•y+ª
+ÚïxhCÿê5,¾¬Ô3:¾lFfjFnkkZRrqGÄ—íçˆJŠ×›gýÓä¶Ù"š,ù˜XAö’o€?V"ü#2“„â§¤Ó’V»IB?qá.² g<'†ºFP'Œk(þøøTq¬ˆÐëú«U˜÷ÖÎòé'±´!Ôã¸î†¦ô1à~¬¬gœŠ,ÍÃY"õ5¤¹Sé+dŠXc‘æ:ÒÜ{‹í1Œ}ŸN£¹®†víáJnT—ÒB”ijê¸tÊÀ*VÂÊ™Î«þá„ÑÁmc0JqŽªw›	Ó­„‰¯¬R –yV%*%éRÑPØ‡fkÿä	ãÜ?~å›Vpˆd±øy{øû÷ëúª«v„“Vö–ÖY-‰Ñsr;Òc$ÅW`ðd[×¸‚³Š7c‚ŠQOã]¥z³åë¨iµþ€â5ëõÎºÍ*—ù“2õò¯GÑ·®ÇPç)XÕCœß%Ém4‘t‰ÌåZK5¬Õ:“äQ«AôÔÁÉåf—)~r®ËktYeSßì ª"K²+.FVE2ø‹•2Ô±ºo¼ kq.¼÷i CÝB6 â`qÌŒ©aÑ·°µ¸Ë:âxÂc<Tƒ7¸ÃÍš\¡ÇöÜ±ñ¶ð¡ó\ì‡ûn‘æJ9Ž´Dð5lÃ•o¤çsÜ{œ¹(ÎZéLd‘*óÀŸÑ::2…»‹ð8O C÷«±F|ñ‘0
+æQxhv+óµaøKqT	§‹ÅI1OœE²¸ºtÐ®$ê­(c¶QÆ2q¥Ž$B²¢ÌâGWÊ7•^4Ä¹sg5HŸ&‚r_è õ’¹¦xÜÄhD½?;¡k~ø*À¹ãâaÂdZêŸžkNvô[šMë°F¥’`q¯oð>ªÅšŠŸLúÄ#ž¼‰K¥%ä“duY2Ýq~gù»Í%Iz£Õþ³álQ¢,éA†\TzucŒD1˜œ†þÍ¢¼iÈˆÏRû«CH…å±Qøù]›™¢YƒPE÷¶n
+ð¹ax½t^Ñæ_#3¬šrn$BšóÖÑe#9ã)©ÞÓúò5ÔÀ ½ ¹l%³ÈÜFÆžÌ#ˆóƒƒpŽ86®‡ÜiO1ÈhðqðuV?NGø%–S"=šcŠ4ÃÞä¢ ø—5·méÝáçé›0)ü^×é]¢xümÝ=éKë>~óÌ5I2å¥¦æ¿’Drä>x€Í2}ˆO®^¼¯­Ä_PØ«HîxÒV&†ßØ‘‘Ó2'ÍÝ|˜ˆ?Fu÷ëêö~9sB“Þn’Im ÁãÉuèrbÔ¢€öt¹sí‘Êió,þJ’¤ë(½`ÿèmÜ¿³'½ðÆÎð,%WYq‰Óþà:iCøœ (=7vþ°GÉ¥=Eþ¥BOUÔ-x]è‚­¶‰°-€-Èè
+Ø*aÛÊ>oƒ­¶;ŽÛNÖ·2Øja[[#l-ìØjØv³ö+Yÿð™Hïß/l a-ÍD¡Y˜&Ô
++„›uV	íÂØ–»…a›P‹÷r¡I˜
+F³ô·ÆQ«oÌr¿­î¶ƒTÕF=Ëå #N€s€ž$¬½ãù«@zœ ó.ÒÙ˜m»àó"èg#hÀåpfÜ»æa-ï‡ó-Âlaº0zœw	ÁõsàìFæ¶À±
+è»V˜/¬ƒª$ºMÐÇVè%D·ðiŒ"=nvB_3„ja•PHï4Oè€Þn¢W‡ ×
+¸O´^í6À§^ø.!ø¶í0Š2:ê2¡”Ž Ž”Ãš3Ž6ÀX&ÂÕ!øö`dsáLí¯îÚwÃ¿"¡ˆ„D½ø°”"–Oëf«³õë}Æñ¦¦¨“ÑûÍ¯XSl)ö–˜Çg ÖããZÜS=Å¿Ÿp5ñ.ïãIß%}—¼,eGêÏÒ¾ÉÈÊÜŸmÏ¾–s5¯ÌŸ*XXVx¡èÓâ²¡Ôœ—¿~ø•ïUåOœ_=PÓT{Ç¤PÝ_&ï¨ŸÛ00åpã©¦‡›ïz²E×r}úü¶';Ì3ŠfvÞ1[˜Ó×õÒÍ—çöÎK™wú–×ç§,¸ÖSº¤€%[—]vfùã½gûŠW\îpå{«B«¾¼kõÙ5û×~tÛÇëö®¿²1oãÛ›goÉß:eÛæíÓwvžÜÕ·û™;~qçÇwŸ2Øûâ½÷Éûì÷ÇíoÚÿíW<ÿ“ð'~ôÐ3‡?<øÓk´î|tûc×>:ÿXçãŽ¿¢ë¯<ñÔ/›NþìW[Ÿºëé×ŸM;•óœpzÏ™é¿™z¶÷ÜŸÿiÆ…Eu/Ä½8ýÒÆ—Îÿ6çåþW®¾úÚïR^ïü—õÿºðüË‹ÞÊÿ}ÖÛÅï¤ý[Ö»KÞëÿÃõ2>øáÊŸ?|ÿßÓ®ÞòÇkŸ<þé[×¦~¾èú/>ýò5í½ÞR+|Ïßbø3bˆ†ò;öÞ&“}ÃïrÕpü´ŠÑ"hKS-	ÙB+£’w=£A/1Z×>ÀhæÉaF£lû–FÃqÂ‡Œ& ïüW}Á…c€Ïc€÷Y£á¾¤‘Ñ²`'ƒŒ†û’]ŒV…²("Ë0f¹DiÐfò*¥U £È»”6ÐãŸPÚ´•ü¥£°H(mÅãb4¥m@ÅDJÛ±1“Ò1´ŸÒzm%¥c)Ý@iä£f±ƒÒ‰ôø¤õtœâ
+¤£ŒôøêÚýë–.^2è;á+,//ö¥¾êþþÞ_íŠ[ûWöäùúäûª{{}´é*ß@Ïªž5=óiÃÉ+—,]0½gñêÞîˆ#>v¨ÂW8.?°°°g\…¯(Pô‚þÂ¢1òf§"[-]åëöt/ì¹µ{`¹oÅ¢1Çy1Œ¸}]ÿŠÅÝýØÁM=Ýƒ«aìxœÓ#?ÀíÿàðÿúæßøÍ‡—ÎñÅ/žs_ö=÷Í¯ßðûÏ—]|ûÔ§þ¿ÌÝ÷àCoÃ²3 ¬w)0àk@M…åe@¸Øg/0åa±°¨îQgðÜÒ1Z®`-{_N>|øáåçã^?ÑÓR Fß%‚–½r¡Ü(O–+áÿòÈ3sËî|iZÛ¨ëIc7†wwŒ?çrÿà1¡endstream
+endobj
+132 0 obj
+<<
+/Ascent 1386 /CapHeight 1386 /Descent -423 /Flags 4 /FontBBox [ -123 -423 1323 1386 ] /FontFile2 131 0 R 
+  /FontName /AAAAAB+AppleGothic /ItalicAngle 0 /MissingWidth 1000 /StemV 109 /Type /FontDescriptor
+>>
+endobj
+133 0 obj
+<<
+/BaseFont /AAAAAB+AppleGothic /FirstChar 0 /FontDescriptor 132 0 R /LastChar 208 /Name /F2+1 /Subtype /TrueType 
+  /ToUnicode 130 0 R /Type /Font /Widths [ 0 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 320 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 
+  1000 1000 1000 1000 1000 1000 1000 1000 1000 ]
+>>
+endobj
+134 0 obj
+<<
+/Outlines 136 0 R /PageMode /UseNone /Pages 190 0 R /Type /Catalog
+>>
+endobj
+135 0 obj
+<<
+/Author (Codex) /CreationDate (D:20260804102844+09'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260804102844+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (p95, p99, k6, Prometheus, Grafana performance lab) /Title (\376\377\000L\000o\000o\000p\000e\000r\000s\000 \307t\316\344\2728\302\244\000 \3011\262\245\000 \302\344\325\330\000 \306\314\320l\275\201) /Trapped /False
+>>
+endobj
+136 0 obj
+<<
+/Count 66 /First 137 0 R /Last 188 0 R /Type /Outlines
+>>
+endobj
+137 0 obj
+<<
+/Count 2 /Dest [ 4 0 R /Fit ] /First 138 0 R /Last 139 0 R /Next 140 0 R /Parent 136 0 R 
+  /Title (\376\377\325Y\302\265\000 \305H\260\264\306@\000 \272\251\314\()
+>>
+endobj
+138 0 obj
+<<
+/Dest [ 4 0 R /Fit ] /Next 139 0 R /Parent 137 0 R /Title (\376\377\325Y\302\265\000 \272\251\324\\)
+>>
+endobj
+139 0 obj
+<<
+/Dest [ 75 0 R /Fit ] /Parent 137 0 R /Prev 138 0 R /Title (\376\377\272\251\314\()
+>>
+endobj
+140 0 obj
+<<
+/Count 3 /Dest [ 113 0 R /Fit ] /First 141 0 R /Last 143 0 R /Next 144 0 R /Parent 136 0 R 
+  /Prev 137 0 R /Title (\376\377\0000\000.\000 \302\344\325\330\307X\000 \310\004\314\264\000 \327P\271\204)
+>>
+endobj
+141 0 obj
+<<
+/Dest [ 113 0 R /Fit ] /Next 142 0 R /Parent 140 0 R /Title (\376\377\306\\\000 \311\021\306\224\325\\\254\000)
+>>
+endobj
+142 0 obj
+<<
+/Dest [ 113 0 R /Fit ] /Next 143 0 R /Parent 140 0 R /Prev 141 0 R /Title (\376\377\306\224\314\255\000 \305\354\310\025)
+>>
+endobj
+143 0 obj
+<<
+/Dest [ 113 0 R /Fit ] /Parent 140 0 R /Prev 142 0 R /Title (\376\377\3011\254\365\000 \2560\311\000)
+>>
+endobj
+144 0 obj
+<<
+/Count 4 /Dest [ 114 0 R /Fit ] /First 145 0 R /Last 148 0 R /Next 149 0 R /Parent 136 0 R 
+  /Prev 140 0 R /Title (\376\377\0001\000.\000 \000p\0009\0005\306@\000 \000p\0009\0009\271|\000 \310\025\326U\327\210\000 \307}\2560)
+>>
+endobj
+145 0 obj
+<<
+/Dest [ 114 0 R /Fit ] /Next 146 0 R /Parent 144 0 R /Title (\376\377\310\025\302\340\000 \272\250\263x)
+>>
+endobj
+146 0 obj
+<<
+/Dest [ 114 0 R /Fit ] /Next 147 0 R /Parent 144 0 R /Prev 145 0 R /Title (\376\377\254\304\300\260\000 \306\010)
+>>
+endobj
+147 0 obj
+<<
+/Dest [ 114 0 R /Fit ] /Next 148 0 R /Parent 144 0 R /Prev 146 0 R /Title (\376\377\324\\\274\370\000 \302\030\306@\000 \327\210\302\244\321\240\255\370\267\250)
+>>
+endobj
+148 0 obj
+<<
+/Dest [ 114 0 R /Fit ] /Parent 144 0 R /Prev 147 0 R /Title (\376\377\326U\307x\000 \2738\310\034)
+>>
+endobj
+149 0 obj
+<<
+/Count 4 /Dest [ 115 0 R /Fit ] /First 150 0 R /Last 153 0 R /Next 154 0 R /Parent 136 0 R 
+  /Prev 144 0 R /Title (\376\377\0002\000.\000 \325\004\270\\\310\035\322\270\271|\000 \302\344\325\211\325X\254\340\000 \314\253\000 \316!\310\025\000 \271\314\264\344\2560)
+>>
+endobj
+150 0 obj
+<<
+/Dest [ 115 0 R /Fit ] /Next 151 0 R /Parent 149 0 R /Title (\376\377\0002\000.\0001\000 \2560\262\245\000 \2560\311\000\301 )
+>>
+endobj
+151 0 obj
+<<
+/Dest [ 115 0 R /Fit ] /Next 152 0 R /Parent 149 0 R /Prev 150 0 R /Title (\376\377\0002\000.\0002\000 \307x\325\004\267|\306@\000 \305`\325\014\271\254\317\000\307t\301X)
+>>
+endobj
+152 0 obj
+<<
+/Dest [ 115 0 R /Fit ] /Next 153 0 R /Parent 149 0 R /Prev 151 0 R /Title (\376\377\0002\000.\0003\000 \263p\307t\3210\000 \310\001\307\254)
+>>
+endobj
+153 0 obj
+<<
+/Dest [ 115 0 R /Fit ] /Parent 149 0 R /Prev 152 0 R /Title (\376\377\0002\000.\0004\000 \272\250\262\310\3210\271\301)
+>>
+endobj
+154 0 obj
+<<
+/Count 3 /Dest [ 116 0 R /Fit ] /First 155 0 R /Last 157 0 R /Next 158 0 R /Parent 136 0 R 
+  /Prev 149 0 R /Title (\376\377\0003\000.\000 \000k\0006\000 \275\200\325X\000 \325\004\270\\\325D\254\374\000 \325i\254\251\000 \2560\311\000)
+>>
+endobj
+155 0 obj
+<<
+/Dest [ 116 0 R /Fit ] /Next 156 0 R /Parent 154 0 R /Title (\376\377\263\304\314\)\271`\000 \2560\274\030\000 \272\250\263x)
+>>
+endobj
+156 0 obj
+<<
+/Dest [ 116 0 R /Fit ] /Next 157 0 R /Parent 154 0 R /Prev 155 0 R /Title (\376\377\314\253\000 \000s\000m\000o\000k\000e)
+>>
+endobj
+157 0 obj
+<<
+/Dest [ 116 0 R /Fit ] /Parent 154 0 R /Prev 156 0 R /Title (\376\377\306\010\302\334\000 \000t\000h\000r\000e\000s\000h\000o\000l\000d\000 \000-\000 \302\344\310\034\000 \000S\000L\000O\270\\\000 \255P\314\264)
+>>
+endobj
+158 0 obj
+<<
+/Count 4 /Dest [ 117 0 R /Fit ] /First 159 0 R /Last 162 0 R /Next 163 0 R /Parent 136 0 R 
+  /Prev 154 0 R /Title (\376\377\0004\000.\000 \310\025\255\334\326T\000-\276D\310\025\255\334\326T\000-\000R\000e\000d\000i\000s\000 \276D\255P)
+>>
+endobj
+159 0 obj
+<<
+/Dest [ 117 0 R /Fit ] /Next 160 0 R /Parent 158 0 R /Title (\376\377\302\334\260\230\271\254\306$)
+>>
+endobj
+160 0 obj
+<<
+/Dest [ 117 0 R /Fit ] /Next 161 0 R /Parent 158 0 R /Prev 159 0 R /Title (\376\377\254\365\310\025\000 \276D\255P\000 \310p\254t)
+>>
+endobj
+161 0 obj
+<<
+/Dest [ 117 0 R /Fit ] /Next 162 0 R /Parent 158 0 R /Prev 160 0 R /Title (Redis cold-warm)
+>>
+endobj
+162 0 obj
+<<
+/Dest [ 117 0 R /Fit ] /Parent 158 0 R /Prev 161 0 R /Title (\376\377\254\260\254\374\000 \324\\)
+>>
+endobj
+163 0 obj
+<<
+/Count 3 /Dest [ 118 0 R /Fit ] /First 164 0 R /Last 166 0 R /Next 167 0 R /Parent 136 0 R 
+  /Prev 158 0 R /Title (\376\377\0005\000.\000 \000G\000r\000a\000f\000a\000n\000a\270\\\000 \274\321\272\251\000 \310\201\327\210\2560)
+>>
+endobj
+164 0 obj
+<<
+/Dest [ 118 0 R /Fit ] /Next 165 0 R /Parent 163 0 R /Title (\376\377\307}\262\224\000 \302\034\301\034)
+>>
+endobj
+165 0 obj
+<<
+/Dest [ 118 0 R /Fit ] /Next 166 0 R /Parent 163 0 R /Prev 164 0 R /Title (\376\377\311\235\300\301\254\374\000 \254\000\301$)
+>>
+endobj
+166 0 obj
+<<
+/Dest [ 118 0 R /Fit ] /Parent 163 0 R /Prev 165 0 R /Title (\376\377\000P\000r\000o\000m\000Q\000L\000 \000-\000 \3011\254\365\000 \306\224\314\255\000 \000p\0009\0005)
+>>
+endobj
+167 0 obj
+<<
+/Count 2 /Dest [ 119 0 R /Fit ] /First 168 0 R /Last 169 0 R /Next 170 0 R /Parent 136 0 R 
+  /Prev 163 0 R /Title (\376\377\0006\000.\000 \263\000\306\251\267\311\000 \322\270\267\230\325=\000 \316!\310\025\000 \311\300\263\304)
+>>
+endobj
+168 0 obj
+<<
+/Dest [ 119 0 R /Fit ] /Next 169 0 R /Parent 167 0 R /Title (\376\377\261$\000 \254\000\311\300\000 \325u\302\354\000 \302\340\3268)
+>>
+endobj
+169 0 obj
+<<
+/Dest [ 119 0 R /Fit ] /Parent 167 0 R /Prev 168 0 R /Title (\376\377\254\304\3165\274\304\000 \326U\307x)
+>>
+endobj
+170 0 obj
+<<
+/Count 5 /Dest [ 120 0 R /Fit ] /First 171 0 R /Last 175 0 R /Next 176 0 R /Parent 136 0 R 
+  /Prev 167 0 R /Title (\376\377\0007\000.\000 \325\004\270\\\310\035\322\270\000 \310\004\306\251\000 \326\304\301\215\000 \302\344\325\330)
+>>
+endobj
+171 0 obj
+<<
+/Dest [ 120 0 R /Fit ] /Next 172 0 R /Parent 170 0 R /Title (\376\377\000A\000.\000 \000H\000o\000t\000 \000S\000K\000U\000 \307\254\254\340\000 \254\275\325i)
+>>
+endobj
+172 0 obj
+<<
+/Dest [ 120 0 R /Fit ] /Next 173 0 R /Parent 170 0 R /Prev 171 0 R /Title (\376\377\000B\000.\000 \323\354\307x\322\270\000 \263\331\302\334\000 \315\251\310\004)
+>>
+endobj
+173 0 obj
+<<
+/Dest [ 120 0 R /Fit ] /Next 174 0 R /Parent 170 0 R /Prev 172 0 R /Title (\376\377\000C\000.\000 \000P\000G\000 \311\300\305\360\254\374\000 \326\214\270\\\000 \314\(\262\350\2560)
+>>
+endobj
+174 0 obj
+<<
+/Dest [ 120 0 R /Fit ] /Next 175 0 R /Parent 170 0 R /Prev 173 0 R /Title (\376\377\000D\000.\000 \310\374\2738\000 \000-\000>\000 \000K\000a\000f\000k\000a\000 \000-\000>\000 \000s\000t\000r\000e\000a\000m\000e\000r)
+>>
+endobj
+175 0 obj
+<<
+/Dest [ 120 0 R /Fit ] /Parent 170 0 R /Prev 174 0 R /Title (\376\377\260\264\000 \302\344\325\330\000 \254\000\301$)
+>>
+endobj
+176 0 obj
+<<
+/Count 4 /Dest [ 121 0 R /Fit ] /First 177 0 R /Last 180 0 R /Next 181 0 R /Parent 136 0 R 
+  /Prev 170 0 R /Title (\376\377\0008\000.\000 \302\344\323\(\000 \311\304\262\350\000 \320t\271\254\262\311)
+>>
+endobj
+177 0 obj
+<<
+/Dest [ 121 0 R /Fit ] /Next 178 0 R /Parent 176 0 R /Title (\376\377\300\254\270@\000 \0001\000 \000-\000 \000p\0009\0009\271\314\000 \256\011\311\235)
+>>
+endobj
+178 0 obj
+<<
+/Dest [ 121 0 R /Fit ] /Next 179 0 R /Parent 176 0 R /Prev 177 0 R /Title (\376\377\300\254\270@\000 \0002\000 \000-\000 \272\251\324\\\000 \000R\000P\000S\000 \273\370\262\354)
+>>
+endobj
+179 0 obj
+<<
+/Dest [ 121 0 R /Fit ] /Next 180 0 R /Parent 176 0 R /Prev 178 0 R /Title (\376\377\300\254\270@\000 \0003\000 \000-\000 \000R\000e\000d\000i\000s\254\000\000 \000D\000B\274\364\262\344\000 \262\220\271\274)
+>>
+endobj
+180 0 obj
+<<
+/Dest [ 121 0 R /Fit ] /Parent 176 0 R /Prev 179 0 R /Title (\376\377\270\010\307t\305\264\000 \311\304\262\350\000 \2738\310\034)
+>>
+endobj
+181 0 obj
+<<
+/Count 3 /Dest [ 122 0 R /Fit ] /First 182 0 R /Last 184 0 R /Next 185 0 R /Parent 136 0 R 
+  /Prev 176 0 R /Title (\376\377\0009\000.\000 \302\344\325\330\000 \2560\270]\311\300)
+>>
+endobj
+182 0 obj
+<<
+/Dest [ 122 0 R /Fit ] /Next 183 0 R /Parent 181 0 R /Title (\376\377\326X\254\275\254\374\000 \307\205\270%)
+>>
+endobj
+183 0 obj
+<<
+/Dest [ 122 0 R /Fit ] /Next 184 0 R /Parent 181 0 R /Prev 182 0 R /Title (\376\377\316!\310\025\000 \254\260\254\374)
+>>
+endobj
+184 0 obj
+<<
+/Dest [ 122 0 R /Fit ] /Parent 181 0 R /Prev 183 0 R /Title (\376\377\254\000\301$\000 \000-\000 \274\300\254\275\000 \000-\000 \254\260\270`)
+>>
+endobj
+185 0 obj
+<<
+/Dest [ 123 0 R /Fit ] /Next 186 0 R /Parent 136 0 R /Prev 181 0 R /Title (\376\377\0001\0000\000.\000 \310\205\325i\000 \305\360\302\265)
+>>
+endobj
+186 0 obj
+<<
+/Count 1 /Dest [ 124 0 R /Fit ] /First 187 0 R /Last 187 0 R /Next 188 0 R /Parent 136 0 R 
+  /Prev 185 0 R /Title (\376\377\0001\0001\000.\000 \310\025\262\365\254\374\000 \323\020\262\350\000 \255\374\254p)
+>>
+endobj
+187 0 obj
+<<
+/Dest [ 124 0 R /Fit ] /Parent 186 0 R /Title (\376\377\310\004\307t\000 \311\310\2738)
+>>
+endobj
+188 0 obj
+<<
+/Count 1 /Dest [ 125 0 R /Fit ] /First 189 0 R /Last 189 0 R /Parent 136 0 R /Prev 186 0 R 
+  /Title (\376\377\0001\0002\000.\000 \254\365\302\335\000 \307\220\270\314\306@\000 \274\224\307\004)
+>>
+endobj
+189 0 obj
+<<
+/Dest [ 125 0 R /Fit ] /Parent 188 0 R /Title (\376\377\000Q\000A\000 \314\264\320l)
+>>
+endobj
+190 0 obj
+<<
+/Count 17 /Kids [ 3 0 R 4 0 R 75 0 R 112 0 R 113 0 R 114 0 R 115 0 R 116 0 R 117 0 R 118 0 R 
+  119 0 R 120 0 R 121 0 R 122 0 R 123 0 R 124 0 R 125 0 R ] /Type /Pages
+>>
+endobj
+191 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1675
+>>
+stream
+Gatn'hbtIQ&BE\sYL"Lga$RE7c!*_13_^LunP!;7EF"dTf[q1>S^-kgmoO_A,_I*ZRDS08\(7[)=.`bi-DBp)h0$:?icH`3?]uTJj(gqM)DQ[gcGn+7o)Xj%]e)gpg9L->8[@44h;')VYdqYW,DjOR.&>=SalUkB;hKWMgO`9=(gTcVTL4S++0^WP`0]!,AWp+aV_;Dj4a[3m\2_*JI=D"XbP/3c`,Fh*Dbn^*hu4b<Iu<b(1"t1[:Hn,'e4(`Y:qAT-gD\\5_pVc(<hs"V5q9q3=<Yd(YM]rccg@X<^$LoqIHRALbN3KihMWn\#`[4gRd"W_`YrR!MdH-F*8ru;k0aY:8s-t"iD%1YUalthjCf$MW"%bR_[[41D?B8(-<([?%s9RpN0#A9MX\t^Vk>8]\=Shco?f$k0bUN(EW+m9\S.=ffu*"+f6]WmBd_MrgIZB$G`e%N]1W>;/sAZon<Oe-V&Qqg#Ss0?gZ!Mb;@RU$KIAkErKq>Tf\8rrK8ekGSO,g3K%'Jt(6K9+;Lp+//<.Oh\i?a"&=7=(gEoILDV@IE%-^eD)DL:CMCYuX'<O)@3`BQ$`Xt`r$MlT\bQ9<&2&].H)c:"bb(.?S&NL_oocbp3UHZAZ(,N:5hImc@7n6"FZ;st[S2RC71f"W$K<p0re'hu(S'T@DMe7I]e49WMeel@pBhSf&nEbFY*H"LC^jU2A(,5R]=fk[K$R,a+/42;Q.B6ZOH4A?&cds4+:AMrO5HX4U^(1k)8j7t4P6ag6W?G\B3?9Uf1J%ZJ-0Rcq0ZgVXP9O4,Bi^h'4.B&tP"i&D+h#ffY%/sE1'G+r;-jA/Rk1W(.C+pt=aB`:BsaH8&K*pO$go-+e)b$nCT"MdA9IK[T#`Bqfu*nVrB)-.Lm+LK(.k2e#6_/WM&+X33g01fQQ8[,Y;h]J;:6k+Ah+CSgt#&S<=H:91Y8UpTCc6Zdlji]G,(tb[*;tn1tef7)G[[tWZ!gO]AP1`Z_0RIAJI$jQBP^O]HkX`\3(-;`eGd-fQ7CfZEub6)%I]*$*Fd`K-As<l+K'5.fKtO8&m51VM<+c.$_2Ed$T>hPH@,+Ydms]F6JOXn<7Du6q+PUmArDPO\McNb,3_t<Fe[uY$;l,!,\5XQtAWM.Ea3*MCb[B7X<+?-dd7s,)-`.%;,VO9(g3f3?/p$D+uVk>0AaGNZ-Y#NGXn<i^><)"Vds_OFf!O1q'&TZUI_aeE$Ra_n>eY[9/YKT4N*6&RC6`A6'HbIu,?9OKLL9J-(P?I0UNsS4,Oj*(i2-pA/'A*t?sp",QTsBP2NrBD2o=h9QIBjaXF$O.9[;o*tr(r'/iAnpbl@JQ7CiK2jbDs8-Ll=j=mipq+4bQjjHk=q%D:j90eiQ:Bjon%"=k_6-c@G5!#e[<#)h'8I-Lq/?;4*8c/o+H7&&21(AnN'6p4_qdR&Q12ns@'H)oM!m=ZL,ri3M>4SqDf.dre)g-$>>^ACWV5T3Gf<;JB1#E!8nN(.nAdtmV6B7l(Pda_'U(kY0)9M)h56L=F6'buq[ZWlrHC=t14!uuE11bN`2;]cr%e(`Jpf'bXkhSar?QBQ%[Y6/iUU)5WhH3TTt]Ip4)'h3qra>?mP*F%S6lVN^5"B?Vue%q7rG->#j]XJin\W9R>]Us]jA.*amF0sk*+]3\GX^0k!/d]Xnr~>endstream
+endobj
+192 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1041
+>>
+stream
+Gatm99lCt@%)(t.nCXPfPTRg=kUd:7'SR44[ZH\*6I5jQC=a1-o^DNoG%E1!N66Ysc"_E7Q@+(@j9RKS19M_&M2k[0di0H->(%U:.F[RH:0*:f(TCS<G=i=ZU,>#<]Nle\Iht')P$"h7e_ZKi(:kj=3N;I1qNENJa]^UEP]CF$Kp)2I[F+^>!j6*(F(_W^Vol-il5I2)8#@';H7FL3LXWT9o95)*_WB%q`Of4??_>^0X5b#'qL_g%"8BN,CT/I2D96h?jUmunp\&N]q\r5ZHNNgL^4I,l\4BM<AH\gXrRV&Z+$4[%r9<9[X\pi&X]66+0U1-N-MA1?n"YG)"g])+A<@cY9WT-Y;pYC]0ZpBPj67+0eFo[O,_fE:(;WfU"-OZ!4>%p4FfiZNQqWT9is$GSYLsJK`SQu$`d^.GZ(r6\jtP)b^i5rX=F.U8I+m@lYU_4.%-:nG*]QV+$@`qs3G^Zk+Lb_`X):5]jN;PtEJ?FU7`:&u*pDGC=?K-`)7WcCK&71nMG,si=FFG2dOi#[SId92*(e+1'YaI*P%c>4e9YWBHCrZ`]65k1V/Ah&Rkf(7P0B@Rb,m#b/n?8n>*1Jmhs'pt5]VtM8/%u"7_U8J<9/*ARKlt[#6d.;`530nN&<1FVr]&9J<ggDb8j%A'JG\3k6a_&eDR^R6tZrZLom@:`Tn8Bf/ccIbSXb.\f'f9h4>r_0be?F]-<5pKd+bFT*dHGqno;K[+>r/"ulKHNK3dl*8j&V_uuA)Pd9p\+0Wgu&7cV<\>3?lj_]4#5*N&`KfbJ\f-5;rPV?h8,A>]T$$`>*0$Z+oD9WZDNs[Zq;_p,'RL)L$f[Nt2]a(*9hCgqW)q@/Fo8nKAYXIk@XYKfN5[R,kZRL%9mc+UB/oS4#2kOgV^Gt6@(\?Fa9`,3SGg2);=-1s>f,lsO*76E@?T-Z>fB5Zrl\BZtd-,hO$5pkqFJI4p7NN"uU&q'0%tfmF/Y8RnR3HPnB>F1gcBsQsBXp%Z2O3AP!`Q>*+V6%\c-ns5!XV``eG6fg[.k/?F7Jo~>endstream
+endobj
+193 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1709
+>>
+stream
+Gb"/*92cfh&AIV:kbF=UMUX5WV'C.lV^e0D?ut'1ARdg,f9!sOrqkrO=ic,:"S'd5bQ+^m?l;,Amf*'V`dsCNf6i"Q!dMG0T3jWu#`Eob]^`4n_nfgUpWP<GL&`RB.jFija00)%^t77P#gQPJLql"i@d@D*_0^g.o;bZ+1,G.W3=j,BlZ*+AEjV?ErI-(d]?P5rVb>;R[Y\FtP'u:b(6WPdS#H412Es<OI;jQ8o&\ulnSe<>^Gpc>rpq4>nJ<a*e9uNgV.>`/%$MhVII*Ac3_pj>\ViUjN(17I"YYSK.Mr5FO7L+p@^,\%Gq=&<F4=TeS(3f?h%K8?U0EtDCn.iqgLY6nG.U?k0\]9YfAc'Hc."r+foT"WGYHWTbLfje`^S3SKS&U;lh=Ibm`bY=\&5g<UME]=mu/jZ96=#8K-4T6-mApUT\53^//`hT[YVqY6ijr7oVQ!WY/G7W<IikB#7Q!hY9*0F9k5"B2eQ/3S)=,(m9b(UclaE9'mThicmgaYb7d=YIF4GWhacY]Yf7Xe2eHhnIk37T'2rKN90uqtkr7[6@-r1^QhJYS7%uM(Xm,q:(hFm8L"siWU/`rs<2&L'TI3I1,GQ>k7$W:k665k5T9(.T7'.U#Q#=7]NN^e?Q#s>?S&W:te/>d;To"OWEaGK*K8DY2_+9=4Ll(f#ePj%LB%]=V(eDC[oRlF1Pef6<I4d*5861soMXKh\!2"jKP*Of&6QLF6!dJA"#VDrg!'_sW')N'e#g<u@\X7>q0WP<i!G)Q2"CK,T@"+i?_6dOj4t,LqTq"2$T1[8Z`MN+_/e'*mTI@p5$kbuRUlA`FX9#Ge1e?%k9c.CZolaY%=._d(qbD(m?"s.Urg`nn34DC3K4l5Cf>^V;`p5l^"Ahfe.@2s]OL81]%iY4_O`"8ZZkagq6Hcf7Qo=4_`SR@8&7QBm[Yd93-ahi7(n*4dC[ec9#U:+mG?)Kp_3H=)A<P3$F*6MPn(WpBXn'0P4P/8@9"*Elc_\JV*#\MgeUL$\BH<_cIYk.,Nah)imZjc7HQ;2(,DLcd>0S*j.$Y[Q_[-36<u)DIIIm.hpWEETQE2e)!-hbb8K`8g3raG*K,g(*j,Y=QT$i88q*m7GM(/eibD5cDjbNG'DdfgY^a6[EPPLn-("DRPHgO1YrDbk3P0.rVmQ<IMHNVkWg\1D$Y:H`OcKT7QAU<,FA9k'ZNmHS]GmQN+AW!M&5l\q#Vah+!Wqd7XCr'1h+i`6"eU%>8P0bNo=cOspo!YYCgpF!Z5\XDZn?kbr<K7h:7I2q0&6hVO,E?O-lfi^qKA36nML=\XpJL;_,pR:?Q9/8:>V,]nF#NP-*P8Y1HhLk*eb\pol0$MB^lcRZC=`Vggar2GC9<?M;2fV22#ZXWo^`c>Ytna0W?LgF-"O.In7Dbc5.jM9%SPA\'!2M)F11+dM(f:f@D`rY%93crcB`\D::>bsit!%&;.4pe5$o>TgSF5:hdOuSEfmD"AL\R3-^&Y*PB>=HMq$pg(2;k=WLoiSQ>3[cUc\<@<dUK+2)U@>#Gc0fM\G*#5(S-G>&L$AW^Y=0U*>=AL&2gWo=!X_W'+H5H,$2fE2"=:Um/?r@FSi')HTp-f\C,kF5LD/CA=ZK0!DP7?<@)DJ:>'r^#-!?<SKQ=XY"I*D$_P'TDuf1i]]pCU:C()IQ@E0-boW]HEF[@1=1b.gsXJge9o."+0:0pFT~>endstream
+endobj
+194 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1297
+>>
+stream
+Gb!Sm=`;bS&:Vs/)"%IM1,F:KJCHpEJO5h_O++&N+HCK<8FZ5=[>X@hfqf<6C88e2S)%5nc8Wd&CBB_bWk[G]!:8"hd;o@uR(WSWb.qg8p1C)g,NZ=GCI&."3;1A/oYj@(pc80PQ5$WJ$pI.W4VF982+Fk<r:Cke7S3o\aac,Y.6:9`3qNFgmmlq^3n's3/eBLn_8GV-o\tW3+Xn1l96tIB*ul9g9ohQRSf^X5mC[nZ#Q$TppL3b-Ae1']h*lH_5rQ_KC#b/qXD'`D'A7S*-R0"Tl;?mo_cRF.lIV?>g2c!&NEQ^*6]Fc0WT]V*'J()$D_c7'5Ir?#BH%n56,D+I&?e#UZZ=ods0GAH8b\/2[@+_9X.[m/Q+"-LXJ()BRReqB/&A2*>[=0mbsbKn(Y.m<_:C[pbP3jen0QaK;pa,7hb/[rWIi#(+GL\3d8oTO.X#jm:i8<bY//6rYVK1r$?[F@8J'Ill\a5hU@_-2O&8R>3>au3QcJPY*N,CU+,fsbaa?sk2$_U:[F^;+eJj\GrXT2G%4$LV^-YGsTd<7:/m@-)1Qq9+ku]]=>lYTtV-MA$*^p6Mrbkg#f!?sVlaMYo@T5^9d3T_OK;uE1M=RKO$$+W(nte&h#l0bPE)Ao\3MB&,=-+qE)`DK;%9h^frjl^2-*PY)`@tW%WDisVB5<$20SXL#<f+5LQ7/s@IHGu=@(Do`88'dd8\FK,?<'s-:mL5k@0d"b_kU1u>\Pcg6kJb*&V2G>S/1%[o=#f:;sAmH].*;#[\an2<j#m;;K+c!6WBB,#-j(P+^JShT?i%D&nqt(,p'd(D-)6`XAQ-0o-@jT=K5g7V^bPdfU)4Hik*]X4LZok:G83[I5;W\M#3?tX6gGh$3*I,%dk\PB2f:Z;iY8b+!N+h+B_"J;hCiZGP%ARoQ@_$ht24m5dPoh1S;N1DA$RpS?gSP9'CtX%f<0RC^3b\KIYa+h9L4d_VUbL-S![ofC.SqC&`)GrDT^jA90Z=PI3^!V`C`g`?r0*,F1,SEb>/:I=p!c#1nENG@F]Gq#kZ?d)F_RFKra[[iaJA3?A)<b^!s2<H-E`L1ONSIQfAD*u>G/(6=c.`jAJE1)iaYcFc>np)m[+fb)jo8nqQt0.&3H5CZ$j@W39$+P'=Rdn][e_0;'*bS6\a1\</=>[Gi,8iqQg:@to?MF]6R[lYY?4RtJFhF]FedL,'`aX8pYPo)d?NGWBta*%DEDN<W;^V5,%r0T.GcNUY9*G6I`<8LC25^IEgi+W.`pANJTaq$BF85?!M/\MskN*u8sIH8n%~>endstream
+endobj
+195 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2729
+>>
+stream
+Gau0F>B_$q&UroH^rbh.l:<T_\@YHRbL\(5m7;WcbEc=)N'p9@dS9?%4+lX(_&J]G<SK%k%Y2B#4q%W49.'/3N'F4]`m2Tjq-1rdYjj(f2:lYlcJFLM^Q5m'%ZFiOj$*oH)g:ah`!uTRZsZ@D!QkIb+`QOrA92@ik$Tsm*P3;2jgC8?E?0]@Q>mS>E1Sr=,Fhr?V+L$d'\j#`fQ`Es_0:KV&hIupEd`<6iPW\p(RGP[]_ug>bKGCKHGe$8T)Fq6Iq.MO,^7O5H1"Nan6B\.m/`e*)uV;P]d&^sJYVE0m6tV!XY%&ig'L^ag@%aiiZ-cr1<p-lFFpiU&8i\fR",idU;0KfU),-GJIQVm$NrB%FTR\L:`sWFO(6r`&[i-"=Jif3dFf\cK2X7g>N93?!;Iru/;*Ve)s,Wp81gY_>:?J@@U+K3@7LG34S2MSKG',M34+8C@IUNMN0-s;l6gfPn^P"j"&0030GaKM_XIkG2A&PU5V#mno=W/_TFJ:[N>G#(;#esO=dg>+Rt/j!F9#s_(7g:#TiVe@-l)\]"pnI2O2</=QE\9.:bYb`7XYls)BV=1^hL^n]6n:(Mei$,])#[6m[I5oTe$PH4,BTO+E<c#WN=6;_s%.]UO$;21Qolp`YLiB6M.i>d(TAc*6j!jdB&&l[O=ujIEmV!2'hZWVdKp'AP.^1YhM?J5W1>6lEi1#oV/8o>!mfhNMhm7\$&q6AHB)*2&mNoYoH+fKgm+;/8C-c_,tV10Es10!/c^?_DZ;:M\1\Em"Wnf=mkO>bsrppN7R^0]2:7eMdU['_lX_#cE.9@_gpSW$s,o.W1T)2Op@">3?Ud3ampR5@u52oFn]J$Mj\7&,K7?H?tE+IM6#j<S;oujdN*aX![e1DVd4(37lR3LB1HjYPa0T:B*6c>HcUB'k[f;O%XIm$B!+9LD,D2llkM=,X@:K!CWkb0mnpGL5,G*c8;dlMIO4Qq^'l8b$,-i]F<X?BFUf#e08C)o)?sG!"mFh,4f*p*U1H=KBks%^k/lFNKFB8#e-m`<%(?6mRRH;pUO!sPT$YA%d5(@dZqd734R'LoX[dpJ'-(nT[t?)thTtA-1TaHRLY8Hm,`U^d0QS-:eGJe2,CAC'ha!?ccp7f:FU86RmKJ7h1m5Zp(:=Eu4M'D^8q:)2^pGeJ'#mQY2ID6L\1t;2OP*I`I-"Ooj+ffSketfT@lll&9^=%K5a-lD5Qb&^j[9S;Mf7H`LeNIC1l7NLVPg7ZcnXu*b)TaK"WHk74b>EuJ`^H`5He-Ip#kG3+TpT[MF:\[6O'H%B%&&Q&O^kqpnL/4MU"M_?/WSe%FAdl\2-.,1s0W.OM0n*8roT4b<XS+f%s0G'-NGD)3g;_q*l)!O"GY<;Ec-99b5]@kb45S)3fGN=pc;AI\lC5lZ&C2L,c$Wqa42+f2SBB7J1=6Bai`g>(>%.L'L`$;!FVuP\)S5&0$/RIiK``UjU+Thcqjmc202eBQS6u?rC/<R""$tPN.niR'([52[EN4Yj[^*=<K"Wcr$9b=8C['BruptBs#e4^ONDQX!?.j)ec*uMF:Z@JMCD%0/NP3]4Up.msASE!CVRVoRC!Cjg;!.CA+1rdEGYaO_192+L==:5[.tP>^4g[a=K$t27(*t^.5&D(6`t`N^3[A^\Ms7'$5[CM:!8<FD$6(.RdDbMJeT;\?AbC68+!6]Yn"#36FTB_C6NNgaRgjgM6HH=_Y3u,DH$3OgOq5dD4CUmm'GpH2FHN/X`d(&DufK*Xu<9l1s/ZDR7J]$$lHeY47Z/A%uY=R/UL._ZN/t,Ff_4+VXs-DIMbg`=B)^*>;hj1l#_*6RnCWa'5I$e,"6K^DBV'lhoc&jTOT[McjqQp*$2rV5i_llAdirYcHpciM!tp(pKHD27m3Hp[cDbF+GPER&MocHp=6(X7h9ZX^64,7e\NW9dXtuJd=bG`i7h/EnTmPrI>Ocb[&Zbhk-6bif5^rrl\>$9jM$F['*CST;_i!QUai9ebGMV6)^k0CJU0.dH[p]:+tn5g%+dulI0U8Y"/e^/l27kG$?g[p/!EFArGsg2Q`i8oa/72Xq.LMi%R)QTR:HiG2m>cNGAh/5ErsV5S]%QUG0&3jc;&"N*T?NB!lsCbI[LFh=,Ok[U_>'jm)iVWTJu[X[L9Z#FqCp?67ppiO0+2gHEji#!4DqHhD^#?tB@?<HDHLQ7$K+S(A'c2ldIE]u+Z@p:nJkp">!"'4J0LN]/7H!p7gUY/p?1H2s<O!H_[r'aMU&*rlg%q@Lm86O5%c%B8.U[NON8`?^;Kb2o;7mO*C24&hd$D0`Q_iT>Pte.UJGR5E$S`!0@\FNlieA0rI91u`._MYUZ:(^XKS[s8pAFU^&EbaRO8f;M^+UfD/c\R3o%^XmeI)P9lfmN^<cUi.8H4jljXj4Ap_[IT^*"$B:m:K:5f79cNcqM9/G*o"6$'@10'Z%cmKp?dIPBfeBk@gaTHGGUH/VD#;pChJ@SrSG:='l=9[s&lGT3+shq8(DAt.(UgO;Y*c]%'47Y=fN"l7/5c?0"NG/N+Rs(ag!T_aXu<nr',Rh=j-FqQ;hAn>qWa+"L1+$[hcqM--<',V[cs'o=4gh0OU>l5`]fo4TE2nS?FMYMA4qS/V_WXcISXnE.t"6Houks,!6T7d:t"/:lht)3.),).BQZJkGQ(ZP^.]NFbTWLq/qD]5F2cTRc7F@rpt%Th[WZGC$c^=r)+NL+80OC5Q9"+h#~>endstream
+endobj
+196 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2214
+>>
+stream
+Gau`U>B<_%&:XAWcjQBE6"kIb3Q_a@U^`kMPaKC+BfVC^8@Y*]&r-D`mcn%:a0oNBA>TJkNfLLCG.%2?@Shf/+MGOW/%%H;\*nkL<3m5A<a.G.T_;u]cP%<ITQ<_,r82"g:*'6pd8#+\Hr(<[61Us@N1,>!2-8(,NG^HB?6)ct<L1EMD52[GQ$1QE:oVoF'AaX21qgC+N"2]lC,T^0GgiT`J48i/f@GTQrTW1TU#NP.qZjmmIJDioH>n*&\sg<4ZQ"LC.$Q2eZ!pgLZJPG:9KuYXM"P)k'O9,r4gMc>/>f\+#&f-&Ks:B"XAIWGgCDY\fPCdrI>Y0s7/e3B1e-"">YUOZAJIE9quK9c<oZN=5'=BrO;O>Wr%BJcSV`8J2JQV'TQK<N_.k\a`G_>T@K$2>WjJPJD@[L*LcG_hOOAg-`hi(MkkGTQA8`(d:1F[K#RIjE&V"3=^has"C'74r8t]]H/?O?1h`k?]>[#4;S&3V-OK[%JpR[]%@gFqqC/1>(,j/#rKt-M299:-WUQVR.Osmape->kpj+<U!'sAMi9+$9MF26>#%Z;\./B-81>u5I6ir*!dR/l8_8Zb\[GkMGF&9kIV-<t=[AQfOEMtl]6U400R)kF0g1F$J_?Wn8%M4G9IX_)gI#bFBa"@?"pdSNrf,]dOr-2)d=1&PeG@7efM$Y5t=!J2NRFWdr`+7b[T"Kj"abTR89`o)F]7>qO-6gLA7)-B6.Ru8_#H\r*Cs#iV]J[GQ3"-ic2#\?KT(oHC[At?oK0V]T($uNAi2Hn7s^^)5HL/bu#AN)G4\Q[D_8.9<MK_6JJ&EH;(]ltS_YKBIDd)osjNB[[A]-ZTGGh,B:eKLNYf*L`*CH%A+MhQQ`GB)Th+8JnoH+s^FlC2Dqk74p.f6N-^iEuC4<edfWNbt3s*CcM.O=uj$RZ-AEJ0q:$`E+g.k9BA-ZqiXHoN:M;85M4%c%GU+"R%0_lms!.N&>kPGXtkfnJsNJiO$VW`9s&D9_stcOD'g/1W,p-5bF2/B3#"(3^r)u4ke]L0:Bd!\g9A3*:W@N3i5oSju/Pm#V!,(RFUhNYk"tF=X`M).Z>%.&J?f=B9g$(F`p"C2:_eK.sJ9,o@c@PTCR<kBJY2cT5<=n)"GRI&fPuFR@AoB4Jo3d0jIq'REVu6Ii#cQAJRGPD:BjXR<AO?!H+JYR&IR8\=2tT1)2R-[^Zc=$gT8c6n<UkS":[nHp!rASY%"=S0"4BD9-?11Qp>l<'`!=L'=\:g*FfPM,f:#[kMkHIZ0om6/Zoe^eoRN*Ha&!<<&tE$e-ac<O]O*1%k4b9_-o#)0bZ@Nh3Gpf%fF9Q\#"?_mD:$MXdqLpfP@D7GTN167:hblA=<E`/n4M`V=Q9*ikf`XH)B.G86]ELI0fgBVkDrhC4u#dh\Nq0Z'G["L_k#e;1+?,RmJW,&M6J_8?$b,lngbd\*SeH;@)mEFC_*gm&Uqgrj03[hr9a-L;H6a:WQ9)RIFUL)R7Ma3_/b$BMFnWJMio)[Qd4+@2X+*G<uV+s38rihF\]AWn.$m-RL:[#?Zl><3U-\hX_OVduS2X`>]pZ@BH)=(][cb8u==g=MV'YIt1()KGUQWl.[cW5,I.7850]I9g15AN:.oq!t,]Z(F[g;aJ?k+qBs&qN_#jMu-]4"_)3@XTc;$R\N22WBJ0.HJ&L]/[Eu?>hUr!PDC)+.K-]V0qr3h8Ph^o]-8UiM9^<(Ei=S?]qPKUc-Y4'T6_,IlHd-she'$\=bJI"M1KpYJtrC9#8JF&p>3,mRoIQ5=78&$)?-1_rdV'0I4\Rs]&q02%u!%J;MDHSY5263OEPPGTZDgkdm7,q/+TN-h`3r<;FCGFXfXdh.sD3.:K'$Kk?hQ.4$IQj?*kKcT6%#Ck+Cdoe^n`bc9K$(4dnV4r8m.[q4%-!oi?Kh**L&*$OpcV\LX],j9qp9[,ATe2Q>+Y6qsqtdR:`2oZGD(Ug)h<l"N@OKkGf@h+asS8!B'5qaHqVO/CeIdU7V?IZOcLfk'_R.'f;;7glGYKfP4;bUf=t0I:+#EoOr]Y6[U!hQsCO`EpA>[5f!6<bMbo[n,DZns-PA['N0c<^4MrF)kc"P-jAudMKeJ@7l?q]iQjmj4&#0j'6KHHJpPMHXr^XBK7]SIdfVp\Bh@f\Z_j/Boeat#sSBdj010h;ljbc%Hd:mh'BoSh-a,FekIp;V^;j;8j@(]+'\cI@/~>endstream
+endobj
+197 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1679
+>>
+stream
+Gau0CD0+E#&H9tYfM8?.1l[NB5983p)TPUM1Sf"!rl.Xp%'h#WM+AhNqtAdVG6/s^,b,9#5*/OK]?fm35.b8hn\`6<GQDb=K^MJ;N5P-'Qm<<!I5i0h5'2SmL+<EQ`dc6m<,hB-6PS=!;G`<K/i3fC/J3^m=FcQtE)iBr_k9@b/-V5&Unu:M+NeG6@`WIKBUZ'NCt6L`&jp.2_Zf&Z5>d5"0MAdnosk%ac2$&3!:]=9Ru>nEIt)GBrT>Om_XJQST6T.6V'76@DN)V(81et::/d@*Mu2AKA<\AGh4hZs>A3++_R)-62oMcoh$jN,)fmR_j-;W"?mIQLE?%<OOl0]e.>8A1"u"VbE]rC`-VuPC15SAD)30d&84^/kprec0%TaUjrqm>5eG*[,BLV=e,G7kS&/-3,ll%S\D\`rMl9\%%Gf0]':d_<<*l\`RH#fJ;$WiY9jP8k"6^VE.GRk-.MuY'3P4fqJ`eY22MF!=B53(Z;!O;]E0e3l-4sa]`k<?Ia3EddMU'O<a-?kZ!EXPsLfmIi(TXD4]$Gk;"HO)_@S.b]:R)T!m^_?k>cmleei'8%DqfQ_)*G'QoG[F/U:+h%^T>KOW`J_(=i8nOB^b@4[EL)o.Q6pm.+f!ugh;E-7\k"0SU5CBf5/NNX1"BaGCpE?e'Mc")q]psGUj-6Y98irW/a?@Y>P,<0p0)I_2ZMITfesiQQ`'q?P2pT7C1Ifk0r^4t5+'>VW@I3;-9:f6>2o%8)MdiH*?f,<`hp*eaIr5D3Mk`tUmb7q50aqe%+?`<L2*SI9<WCQXlmg^@LfFb7,-eniuo;nF3A.B6T'cI+"*1Tc?`Pp<aMk*(l^Gr*Wlb[r2+`4.#Nmn5"fh8];6ak1qSa)&+aGcDI+TLG&34@q&J?/".5D9ZIeKhZa#uqZ_Hg*1hL#P/m#4"o'S>So5]/5'GO(2VddRCAmN^W\t"'6B;%$!=;Vne$l^9/p_s\E4eDd'EE.RaXm9P7Lf+ut;50%Y#4_mlScfH44%)Z-_;Z'DCeHum'b:Nd[U#pk#,C'P5_dq5_4&=6n*13]H[m7i\#$#hpnCVdHM/#H6120p&G/Q3R\9?mX\mUoo;Pli,).G\]1.HQn-5<(2AqlUk)il5fs>[i\2"BON>*KSPl3UXL@,ua-%jcCNt=ET-cCf:cBne9AYY(T<Q;8Y?^-rYW'SO49hIg0&<=V*IZ%":P22soM:"p:M;?.2"8iTd8'F'q#IYT*`(0'PO:@5djFOV3+Y<&C>^(J'RYk-:g[j+NQ*W#qBN`*>BA!nZ&bm5_AU!-+pIC@1V<;Zb35i.$@-;H=r-pP1Xc4,3os!.OTmLYIJ,dtE9nbueVb__?.ng]Z!q0fiiOZ.bl*g7]CosI$rnl:58mp,!Pf'VOC@Q-M6;**!@86ChRR%g.;u`k?f9E[gSCM<8$_,nG'C9%0>A%2^W.WpGEE*_-[BWbSpK7:Ko3J6Mdk*^[qhC/]Ic(#pntM@>IrQJ!P5`Eg#Q*B6QthC"#c@-Gg?N2;QF>\d>Dk&'@0;;'EhEm?*mX@nOd+=*<BuChA5X2t:dD<YpKL$Y/a_D!]%6O(GLnHi4`HV(/;8!7HU&\84$>u[giB-c11*IuMO8#<>=73L*1XTLHBl$g;SXs4?h<pQX7ISILR=)8ke!nBZF/j$D[l:k7l,8d"7J0CPl~>endstream
+endobj
+198 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2289
+>>
+stream
+Gb"/(>B<_%&:XAWcu_ed'J$c\Lqtd=3"uWDfEZZk1ujE'NCeNVfE']5hj)L+njPSd6_@P60?95VhgW1@m7J')pnR9U@Y2tU'HJ5n6lAT]+tBf^km?XPXj8T#\Rn_`SA9Wn[#h6\]S.[.g6s3W0k"<AUlE2q'8e,-$A"W;I_&#I(?UJ3<$3_#Tgg1VN?UDLq4B7+R[.W%E=!pnP=20f!k?md"=4hN_91cKHZFFYf'W,B]H*X<?6?lVXc#r7T&)j!-^<Js\:(&5_$MO0'$Q%B.NgP;7_],?[kMN10L.S4Q_fBM>[XRb-D1o#T%=]tF&^Uc2]jQIitu&N1a#a,#lHO;M@:?7\/#1D)>q8Q4@o5k.(n1N]\NRUEo/?seli&M./9\P<g&hE_?oesT\LFB3.(fT/JnXEm4c'GD+D1bOcWStL(HEX,RE37?6ooD>aO*BTN#,n3TZ\SbaB/W$TfTcXPb&e8NX>uX9?OOD@1K+M*1DlqT/a_r/7Jl<Zb]O_4(X]ad=VK6pqIKSb8ZaLuORc+Ya`G"5^m[Ncmm$P+lBVO1u+,g\GfVJQ(5;6Cm9RZV_3--(Rg465Un#Ej!EamL6`:8?tXbqD.s4#+'BC-7^kVQ'X38_9W?[E&>^Mo6E5T+"oFc4.]._c:!1X3>h'19.O1RTT&q&N-X`D0L3X7e^a!FE!']Im2*TiDn/@&2L6#agr%Y.bYg2I,S?$0@VWq<K7r;f$I2M<;4'Gkd)Z#8Cg[\X=Lgo$7):?,$/pV=it?L8@:4VV_dHWbhaT^tPUajF[Dm;[N#h%sl@l@rd8run2&+]H;,UgKJ#.&Vq8G/;p3<Q[,@K55fPK%Y#jcS?0a,k+Hq!c:<"bV?[#<&m.Vmrp2BEX6ZmKHV?pBYaa*;.YPLr\;rH=aJr0g)c]T:0BSCppBUqq:1$CHgR%hL*#%)Y>NJ2E<I`V"%,C+rCf5d>%Un5b:F+uiT=1uN!3nUIl*k+OnPC/mUQO7TknYTl3_+^e4d@MeUNYid\2Cp@Y]2^VpL_qDS&Fjta]<Jh9a&DJUmMI:I311Q3W#2FZdXCD7*+Y#L/=^s0.2hhoO_G5Mh:1q'!(gVF2@3InT/2`9*]XPeu.:U6$/.!cHNcAn[7*gTh:#S-*EdWR5g3-e6UT+d,E<hKHdd5j$b$g_uWIj\1Gd-G\96bjl<L0@-/W7P\Z:\0aUFddi%Y`M"ep\rP8$>QN&1&+%hroNfRN]`Bg>JrF:h"j?H`e81`U]JUWG6D:QIk2hMagE5kHRkLLD<d]Vr6@=f+1mYgL)AN(o@uscQ?(!K#Go],quS8#/3CMK8C,ao'GBfT+%(0CihSZL\p1-i(KRf1-m\3b4d_iGacPB8tDUI:1&4ohn/@RkIhDhrGM(P[s.hSGLF$,0'<`U&$KU^_s>M!@en@^6OnnCn_k:1pba/J>%pg4Z7RNmFl,;Cn#&Zi^G?tIIQ+e2!'ZAn57N!8L>R@r:t"Mc;q.D4m+XYGa-1>NKX,EccR.?91:p\ro<3UmK\@;q=cZp[F?>Lcqnr<+hM\-fBkNZ)/Situ^U)>=W3k;TcX/g#3:5G=fX3nEl4E(uh-;McT5V%5Y;QB$<g[3(psW]sKY%X`JT^J!+*F#[ZQP!gQa#X[cE9[9?.>iYC=GI.[2H%flSae@r1.Q8NL+?de/MQ-Ykel0@s6l\2heB4SHsQ^8!6=jQ*#5"4Sc$6!S@_-c/LRbA^c^BRcYrYEn4F67R+1]^a,"fer%El(jUYei<e\iC5?+4<h8N'GF:0EVEpdJpd_Q,m@fXqA67<tj_`2$%h3*jpQ;l+Q$8oIne_K4c5UN8@eo_m%\a1;>X]#2?n+KtLl`3!dk*-V[krV@@Y;;?*5%4?0(-`;:DK3`WBFLu?(H"UR9a&$r3Wn<>f>Y418`0@E=jh1&^jYY`N;uKao]UYd3>;I!c89Q@0%A_=?NYJeJ-tVH1JR.8qgLj(74\)cqF-Ir1C@b:>/EV.@7DC%kFSX-\X9kHi;<YZnmhP""UIa$irjt##[(p)lTc$/aWkKNY@aW5\<k?1e'5FBTZ^WS.q;rm5g^P$'6GBbX\ncRVJ=44MC3Vm$F%H9JpJ<V-ru`96"t8r%"n5]T#bJGM3<YCJ@WS6MftBb"-Nn#eYiO!#GYr-ns`-i8/[<J4Xhg/E+HWYCM`>LGKRm[CYUISe"$qVaIA05gCH;+i<)m5gdk+'^iq?LqW<9jlm(s&/+g0:5Ff("u7n'k9(p#Z3[[B?&d?JIsHCY6XK:47M?ph"QndC[EWWB*9uDcmC3PY-m2@P+..#\q#~>endstream
+endobj
+199 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2199
+>>
+stream
+Gb!"rCMt.Nm(7`N0jm8ueV`3E%GQZNqEif0Nr*BAd(-U>H:]+&EE]Hrrqe+7n"R-?Ss*_NS(`^ZigV,@ScFd8,(>S*!=nt1pJc[)d/O)41Ca:aE89p[fjRW9Bah3Is'+`pJ_m^C1[q4s"!\YLb"?X01Zc,s9/'O*Bp(t&E7SHtcq7tZg2l4)0]Oa/"Y;i\OL81^;j/^7B9!c<qNiUsr/j>Y"S9hA\K8FF3B97jSH41&4mDpVs8)4%?L8j4!<#-Ts#A)j&lf)c:bc*,V6.0DRQeQ:K6hIWjG[_"\jq)NZgcBY9N^[A.O<2[;k_:-@OE?a=gHKb#$dP:1k8".4Q'JpYVjp]e?V0ob5E[h]ubMF%=npR68je.h(7!o^FHRC(dYKAMuObNCUd_q1P`mT6H,&X/!`f)i\Y(KV]%F#b$"km[&[W#A6ufIkK\ZT/SLoHd7Q]+$9S]S$%.!Q@9to]!9T7mXMWiu='ep@>&?bsH1>P7,_3e'[oRNXJLUi)T[`/`@QL#2[n"*o%/HVQ1l[&#Afr\_:./j7][jf^#Zh,)$matBht)"6V+A*MT`nU,c)QG;BI>)810V-ek)_.Kg"#)&GVT.X)7Pu`,-j.t:\R&2^%pZ&Ho"r4[hs]@[3G//@X:3=1o_TFA%I=f%['ZFYc0AqV\i7#o#>p[ZXIN6Haf5obN[QY`ABEVQ#Tn[cF_KSc"r4`P&?r"aJnFqe.s3I[4"P<mh,?&4p:kOiSkJ69p\hpUNVgkY>c-p%cG7oio9oUFIiaO1=Jnor/n%l\h(KK$!lEM'3p5H4,\tAc["P*^YP7CfM9G$PVrQ]FTo]_Q@NpS!Ff5*5]L'2$aXkKi)hXIN`,Jsp&SDO<o>pi[*9o*&qte%lD$0H20GZDY*BZg.mrjf'8X*1%[ho)-*RlG$LO!*3>e'(8q%LlL<7NGRmu[(n2O9V*JRFm@A',UamgSq1eR6a0gssp;'\j`+ll+]N2B-F6I9m4"oa3)q\ug#6#ZerdCU2bB2@H-s4QoU3.(1"pcds8G>Lc&A?)lkMDDlo1Mf=e_r<>d@?CZ2/NsbuG,qS]JaLBCA2p$2-.1-!6'NB@.MSc.#E=b:?hgqZ?>I]rhbiN9-<O5NapQB_G`r9qG@1&Am*I7u0<d5jqE_6=?$aSR(]r,_iWg(1Vh76l6)Xj\$)RKdc8"NUV,a(dBS0F4$>GD'WC#^cCijeSmY5%X#OYLKc'I6=QmEO#]Kab,BL<1sqCjtYKU<NAUGF!@S,i#8[^\F^,(j'6bVo5NiT=BfN]G2q-R/a)&1/o!OSD5eU+jB-eEe!fGq<\5Yn<PtPedlQi2>Xm2.X!Y2iu-JL+u"cbil&#MrALM@XK14UZ(Fc,W*)4!'Z8XT*l^o!BaqhaM3p$.mK1\jE.5C#Toe0+]`'u7hGOo+$.\ikkB#U>\Xiq'NLgEld9R4$WhDF,=8K":_JAYE'7@\bX7(M^(s%eki+Wd*UO/#'a9fR;lgUd>E.e+C,?ap)BrKG$G:-[^eR!=0`2qI9,qS8<g;(?/m`=X.SKlS^l+6CaG;Y<*;5;K#ol'f1@16jKP&)p@q$dtXNX^?,cbTq"@WYqU00AmB['59JhTj6q;e_md1?h^/]0eHN`MI\'Q/8*-_$.&aJ%(#hAr%_EgoM:Ag>5\)(run6fTFZ!3W5,-Ree:XPp!.CX/$pZ!>Ia+-I8MV^Jc`CGik@J8j;jqCD(l1p1noL6el$1Ri&BmH!_\6]1,=e]+7?C*PS`kg'e2iZqgM?.?Y8(3.OK`RrO1@o1gi,R3:r(Zo-Ye'a*D[O81jB8lqJ3MB82%:Fkro;;E/?j1cK`/O;Kq]NnLG8U5b<=n3A=K?:NDC2/kg_`?+BH%OUV4$GD#YCk@e>T`__RLA@i]%G!3o(f(`'RR@mPl1<Dh](e[b>>rM@O3Vr17+]o6UmjC-lYpm(j[NKQ#`lY&BL]\"OQo\"WWO@EW$lPKQm6ZAIS%(K^3R/gP0H.Q2qmq(8umq(;6nK>Z0IeG/_`27qtMmI6C2$-dK0C;"X,g;a0=Vrtt:']tV4GWP`s5H7hB5q&/Y;QH5CP.UeI2I16E!ujNs:$1%[rn@LemI[e,^:(A7^ipmpQR+;QXHsH@)Z$@9\'P#B`.[al+>.G+XIgpq5,c9MQP'i.2F.UU\g-E902as/oVFq7$\`>XmSK@=/dXW)`U/]VXTN\E"^Jq\mf~>endstream
+endobj
+200 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1784
+>>
+stream
+Gatm<?Z4[W&:aGP3!:([F;E("PQKp>c.[8.g:4,oQamA97qpa\[N`h!MP:"84%bW&3Mu.[N^JBInT]8m4!%1.5k2mpk;WWi3J?S!)))Q<CLE;r(nSUF@IL?hN%eKc+<g`"DPVmUP9*Tj=)S;#&^#gi@%rG_6Q)\mUa02*YGUfo7mna/P<`YH=epVI85g0grhYCEfn23+j[)FnTqR$GML+f".>1a,LhNj@ror+hi77Wn^rPcIo62kE+2<EV(G?;,p_AP0XPWB>6D,A>GY!M;;L?u*e7&B-L-JPXW/.,7&HZQaTf![?Bk\u!`9VEtU.Rs$O&Z7,/Pcs<alD]3(6>u&0VY(H@o-lJkHjm[&Z')2>?P_eUr:8V(9Furl`/Rh?p0B*8<&*'LfQ?9FUA9W1+'"$M/';cRh6ILV/pDRI6_oq1DP3DIAsFOpn07'N#<#2@)<0lJh%^%;-+>WDBb$=.o[*eM%/BD+'Q#h_Tq(en?EMo\6Qu$\pp!kZRiZP]/HdoJZ_hQ*P5A:IE3TIA5T_e4rlC&'pZBfnBGo33.t)j^NZ-^Bnlk"]ecr52H)GWYQiq.6/CF:@?oXt>(jMpC,f#0EHqhVMrHg_2gH$C(%<3kpq@V_TpO+O1meYoM>$!gc6pYg3/5iA>7tJgltS<Q&m3Duo@Y\2fCRZRg0ri<&_4MCmd2+b%O'$Yj.n*]Gjq[C2bBP4iT(i]GYo`7R%hm\,H/I?\aLel#d,o-e;0ki0TTU3Ls7D?lnPX'`\]faI$c(R&k#;7+MdW<-ZK$c7j<UeU;i>DTgj!rOG\iQ>bV'+9TlSh_Mj;cQ"(:@m]7]_VS\"o0NimiTf")(&`O:LC2i(ao0`l.;ln-fGW$rt)715/e*D]2OD$(]$!ZBMe4h-(4V/`X/G4pDD;6Vn'guNEe[HH5I^7A[PD>ic9l@bs-f?^"g,(4h`$iBf-),iC%)%]FM[tFqWBJ`55D6n35"FclL5gQ5EAO:*j]S=q6K>&OYdi>E*`N`s2b(;qXZG:T6^$90g(NnqeQ+C=MZ7GpA4P-b+5WW<@]Zmu4?lXXo?&gFq!BA$kMod=6PS:G6[W\"kAk\r+5r?k_%Da/X?(t1K39tE0=^_\iEl)\+mju=0;pf>[94/)>]LptK!%V>.@'D4h%j8Q;X!!bdf3[onHg$=Kh7$i!$C'&h-dIA*D+)hEF;">E%0au.e7ku>tD0eM[I%E'r?B8`,npU?SD?UR8:-$^CT%@mb/rSgKVsIg63ZR7OoC7(+\NU-!ic-IG"JibL4T1^r(NdpBl'7^TGi=@f,H&-]n!i6!]>DNtmfug5CMb"fk"`Xk2'jkY1Lt`2IF5E7g8VUiRqDC'[q>3!:3Y"K^c+!fe0#B.ebA#6NqeN]4#qEq$"K=/HHI94&/Iq?LrLb:*b.%X1fk&+Y#Bi=l?t3tDuTeqjJ"LCgnEEg)_X)(`seOgM.gIi7=hofQ%1Z:qD*E?9%"`A'i8#ZV-R-'"G6?9'UTlt0.[o.PBZ?JI-l=ZMlsU]!ZoI/o/Wopp*-8E',$N:s1E6*nW[UB>2S#KYp<QaeKfm%R&ADb5D?-[1KE-jq$T=5$YoEOcqD-KX,:2Lmd1V@u)Mn.Y5'D`ghE,TeC"S5&_R:m>t1.#rcEEC0A&Hp@U0l0$HFo?J49G'u;DR#hW^SXk082Kc&hY0%X7M5lK3Y"JgK,rW5#Hocu@'I='eF.)]RY]iK564L+MB^@h6/QR(Ogn:q:@\"i"NA$K0V+11g&*pNi$AjaD=gV*Jd<3WAEEE:PZMC0f%n`G3mf~>endstream
+endobj
+201 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2232
+>>
+stream
+GatU5D/\/e&H;*)_%-XVAJ*+08je0'c-it5g8'`j%%&cb[?\akhs*1,KDkTdBhP=6o,)^D'Uq/>na<sJnW)U^_(YQ_LJpNGp;jRAS8^c?2hW]]8FM/#p,ZPBe4M6u-8^KB,HT=hHe+mZr6q&Gbpa=S#\&^D9$92^'!2i_3k.$jf,Z>^-+P4!'oWr`:gFoMF0b`!JZ8H7Rp'(B)7;$)Uc/Ij`%R)1:9fBhVq4]\Q^:dOh.m)l?<qa3]m,$I8hOG_r0d2kOPZ,K3ts.jkTPc'WDl?TLeQ(rp((R+N`&mo'Qbu.0S^$?K0d%FQ@VJ64`4Ha-`Q7gIR:<2cVW&&P4s[\E#I)j6@'*rZb6*MT5b@-W9Gm:+GhVY1jflX::#[,qlLIMJ#fYj^'/;:JKIO`dB%#nLQNK;:f.!b.4PL4W*Dk<I3H#IMhL6#\@qTU#uYJjfqb`-S5U_NdWI@d`[lePdZS>k--6:FiNa^f7ibcP$Ts(Xg>k`?B?k$2.Sc`KAFr[cAHZf-\$\n#Tsp&$auVL%Ns"GkJ?_i7$RYVOOrPO*0KUc\I"KGr`1Grb-P5!0O\8sR+#2TJ%NS9Sid`I;:NC.M;(8k%G*'"mlKnr6Om,i2%)PpMpbW:nE+'.!Z:1JG.^ITL>0\3j#q/,c]3p.e>+gCujm2j'5,AN$fWOBp)tt4KQp@16UOa_U>N`aiE\N%R+mt%rlJ'9$aF8-lTJJ:<?"di#J;$7oUjI64N7uI.`9`2.!W4+G8K!ARg<7"j<d?Dd\E(mDb\LUO1/'W+0kl/Fqfk@H+rMGK9YX1"*_P'bjE7YMF\IP!jm_[TEnP4'R",KEkkug!HC2[BC!beg.,KHi"5#q6@U3@B!5U6d._$&s-W_Crea9X^N3^EM50:N&PRh=T#9sQ^VXZd!Kcb<F#[r4;Xskb7&`2+eLZ^9@mHnte.j<3sq@]iYe[ba`WeK\\pKl`r7ISI<*fsLa2JYDn4;8NrRudiLMVnl'JE4`c&],n<_5JRQ1*[q;nX=.9-LdN`ocV`gQGbhMg_9?gqo"7l.Ae8eTsdpU'qVPU&99cu.RORoT*;CT.4Z\Md-:*5Ot)/k.">.n-s.PAEXX/T8OXbW8^q1=6IE^5bU!u/0e*Z]dpC&m'e;+91tW$Bp&,8BCjZ)i6O$W[:MEkIW\i(*VC"hJVdL!9+t5s"O<Ri>,MAj\!OXB^@oRjH]1AX#K`L<1,nC]fa5ghdSs6![10Vs>MfP'!";b:m<j&6MoZmr'Mc?rUP&!K\Hl?'^V!Q,JI-eR5<GQ-&2VD6r.sq6nHO?rQNSTG_,I=ni+eWK*,ooD,^G-VRC'$)TP3-b;HLpB?&8>=V.-!'H4kr86e%tcp=ahfTd13+l.P8k]ble0$?-8]aYkk;+T7JW4a/#:+nLeAl`pO29gN'O>c;$8$=3<Krg=Zepi$B.r:'n\`@+eskBH"!C"d\4UO7*:rE<7Ro`*g(nIk.io3?*rjT3XE%TYeZbjS0AmHjL/h2s<&WMl%=BQ=G4.h;e0`MZbN>"K9P2O4e&-]ZWbU4oWWoB9rp<E1'Hl?Wc8"3u1YpIWeLr(.im1_pW>0*0'D#ptud&a/a#;^;%u@K2joN5%`oc0a,pPQ9ZiIPr'Dp4l?UJ&TAA/BHdd7M7jqbg^On3i"D?+#CuA*o6k_(.S^;/&ua_4X0[P5P7T/3s)J[JS$\!m\*2tp<.2oCA1t"sKrtH"R1**uK8[V`WKJ#d+p[*('4$VL;X\KZ-=/14,7tAb.eCa_;<.QZ1hAG!GunFe#iEUBH;Ls8>-"l9L#J46mHoQ'g[%`JcRnKP@1VdEe7@I5Kk,\.-7_e0?2FCe:%k,]8G4uW12DbZ>J\$P$bLm+-tPeF-U4d2J)8\rO6\S%7U(u*l<(Jt/cH0O)Jl)[b,dtXT)_iCMB;0bV%clYTf9YALR-'sd.]nK$,piUl.hk_f4j[M:1ujN]lp)<U%l2.'f9:4d`XVJ;W\md?uVF_"o"L<[G8?ro];3:j[j;+=-Qo<Ud$0(<`lVU/\4M.NJ&+2_UGXV5'caHk$Ga2<uCEi_C]181,0(ISo3V7J!SZ#WgiWMWUuFS5W]pSXa+O2;FEsaR]e7\[!"[bA9@9%(k`oGLZ9Oo7A%_ZD\"&?rf*Z5:>I)PJ4/_4%L<@??<1Id#nte36-anr''840gjSi!DBW*)3>cpD51J-4g0tAjNt^oBnP+5n]X4L[a)m:1r>LH=$W-0%N-,%$6OW?6~>endstream
+endobj
+202 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2035
+>>
+stream
+Gau0ED/\/e&H;*)E>UTACMfBXj,6lE"-PQZcur(9GecN,MjcUk)EZ4a#O.TRpYA]P+up8&A6Bne80j8jo'j17KqS6qnagu0YWIS@mh!j]p_;()$fb$e2]hl[:k=4<%TLIJh?<0&bPQj2E'(Q4LIrNV#""n3$6!=Wc<=daldcc1#)Y0/BL1<VA*uXnh!:'<ibZD/A$&HM/jlamc2rr;XI"43+VVh8j[HAF591^`mX7(srciYVjnG<1hX&(VS_[X\r!gY!7.7Q\,1aY^aV7lrI?.&YXl5o*n9[b2QRgWMB8;=NFQEpbh?M4?RHhA!;4M/S+3"U]2.'0VOOo3F2gHsq&Do180Yp%S70[1E:n\?hgGJ;56D;ae'H2,7QA;Rs55n_g,I(fqXQR=uauc/tLIX_TGt8MsH(9(K_>\fg7j%bA)j"nZ%>@*g#2(S-d3L-@2*m-;`1M\s#S\.ho6ZoceUR`^L+Xt9P_n\l[J[Af<Z#?":#ssu<#Edp7T2Uuo*)Qc^HQZs-'cPl@!lOrVN?nW':YdG#&ANElg8Q;`ZSH@s",rNfN+<[C,*p`",KW:]!@ZP":gjV0V_:dVJX.8;O\ou1FL8L''c)!(R*>D@TG+JPEWn);/R1r6q*?N$qU1U"9`-aed8*@AP:cqMqELad9e%XLTD8hZ]ftla0mML7Ve"^U3ZS/O(9@*Nbf9JRQ6%fr<drI0d3@$C(lSPO".Wq4a":uKNKbi]@W$(]+tiSi9H]:hUiZ&KWEmfY4?rGDg,VN5JD[&npEGYR?T(>22(r"MfNeI=-Lgko?4IWYXk]P#Na8uJ@i\\LuO-0jD=s:pLB5V2L0N$aJ9$ohLV1T[]ihS4uPOmq;Q:NK+9os&+?PEEEJ\IHC=n)MQXNS^>I0,-bQ&eOlTTce"#,1k(EX&pooI$#(7XYB2!Q9-!k%g#j"bCf1WWa3[pC/^31qO0^1VV63R=DQ"??U\=BM'5dc2*7W!mEbE;=)rVoRSC"B?/?nUnZc&Lt\(@e[L627%o"K%g;CO"ba-?`^r/GJoj%.m$*iHl,0E([;I4tk0Jd!26^Jll8BYuoc_"br8l\U>0s(p3@XB"9rA?(]G\VWDj4&?#\G4`X`PY1G5cE]:[jICaB[8@PV(#A]q@,&.>?Zm<kf&G;)8[<1@TlHgki8s1-iCKO%mdN"614ZiM2jETPMeX<oW&oK2"j-nHL!3OR$9SM`7Uf+HMhoM/=QFUs<:8_Gl/jYZ;Ce2PpmPesI3#IFuF)gqD/jT&5r3<7t2`U>@PPo\s-o.Ae8pd+PK8X.#/Q>&)H@+ZD;cA_$8a2n?VeURZmL%LlDt("o]dW!_ol;c9B9U:Ml8Y\HAfk)RV7A6'Jh(,5Wfc6#BY_Q\P"XQWE^&Kd((41?)8>US>EW5CjsN+.PJsE,pF[&W+j=kj?g$=1AOa7)dETB=<ZB@.*7$:ADqMl[/^KTlK/D31e6J3WK.Ats^SInQY10I.n2*+F/8ZG/V^S6&jYHKXQ^e=i4>4n9Q:LPd.ftsM,>]3pQXEcn*DDH]@`W.I3NfO#C#q^t!/h0M^5+gd=&rIX5qmp'Bd9aeduJYrgoamZSb0$H8Sg6#)4.2')u+UYe*_+*DEG8\6ql_D/oRUcO:%<tjoo?appui"YYZK<WK80Q<_(SalroBsK;_QtL<?aR9ZE@JD];;_d;N@p['/dFB7&\ZoP)$G,dc:n'aPffWel]\_PSDb;m/OAQ*pW=Tn&fk58*4FCP;i3k9+)k!&eJT'hf%`(/"@pZ="_TC*nuKIn6j]VGc4B'DJEH.4$e%qeB7qL=Zk>-qLe#'fM87\TUI8^t.%'kP4O4&a>`Ck+):`9Qmp6Xrfr\2`]_NqR@_IFlZ@IWa\3\JtsmIF/5<P&gFDq1$tOG)!EBJMJIT5TqarOIRqkD[YNY[P62nhGQ2*%LVWQbkKCSO-<uEhoX()a'6<"*<eK'#J`#A]*hlL('SThoCSbZf:2'(;o+UBLZV'giT@L&D([Gi'>CDreX%p[a-F>fkpK!i,]2co+TAp:`rrT<LWRC~>endstream
+endobj
+203 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1494
+>>
+stream
+Gau`TgMRrh&:N/3bY*I5KiiAMQfY"03%9_1G%A-3M?O>e;B3Z=V8s,ds*\Oi.qN9\[&P_sbGu"(__\d>+Ur+6RIi\5!?CjmQWFA"6N7-)X"<o#^hLRT\YB30F:M9druQf8d!OSG%dlD;i/H)T*[/J#-ti]=E7QL\NM\.0F;,IUN!3df2UR.tdHaWEnuBT#Ri9OT>[auH\d6ZT0eWB,6Qs7>nq-2*2eQddVnEJr[o[4U[n#m^:>sIFnT3oDK)Q.oh%WK"3"W;jAA.XtA/]2VJ'X!jJI4"Z`ZEf@@M`;f6Q'fpArX%k]r=k4A@8"#$Y$MMTqKmrUd_-7Cj)-`rOVIF<6.`?r3uhUP28'q,k!P\b_FfbD`ICRgWFIJ7Vk'Mq(I9h:<1D;TV:<l6RaKp%B&o!%;2G3'/nBSp9Dss/7L.6;+:QQ&l;KnOh@ic,\(RhNAW%RCbY'<TEq*J>H0a7#kZ3;-&Xg<C"]YBM(?\_.#I^,Gu:9RTIY/T':3d<V=XkP+(s-Q=FFVBFkX81p=_;&ABY+='4)fUf$_p(ou@_Ka/8%.])RI^P,4b-2O3RRB>_P+r;GaNU&40:HE`pT@XKu#gg"ttc7cf5:QgSQohP+i=YUGQUjY^eccWIm9F_I6pGEY1<<OYg((Ks-(iH8CHhdMM]R8p<kJM)F+&)+&#WNqlGpdW0qf]<fGTk\/],ktU<]<%0U-'e)1#ta,^HqEM-fTD@5TMS6]kpIb80E@t<n@7Ij,.Sqs.NDP+FZ^WU,UF\^CUQr7ZuRp05jh^Y#R(o/a&&2GkBVKDS-tE:$+CDLF.Tt/lP*ao!VFD6<,n)Am>Onc[&*"AZs5GocI<l3`&B]'Laiq._/ZAO/C,gK=g[;pWM=ZD"*]S8gKbHREHuA]%V,t:Dt1C17F-b<o$jGYe4hWKnEf!er*J=)9q$/jZ,cm2egKS6APB-MfKR1\%;FVE!e=toZ!Xt'c\lfV%aUIEj_VT-g[P"7:cj$/Jj+lmECMC(k*IB8)@eV6R?DCo?jGkZLrPAOA*3b=u1^ea[XgX&&,B6k4U]fOH)a,M2,8i@SfpW<f)[><bHVnS$.T!k0gn1j.>?gSLXs-qu=,`Vr3e0h'rpfa,B1m3.U8O.b/(Iq/k-"+"V'8T_UBJh+9b)&iRBg*lr&+=^5AFjKrd$$+kG?SKgmO)4K9n'A+Ekf$"Mcm%G,fMUAiQA"1M,p>4rrW]D'g\QalC/PdgZ"U^SFP0lP_)&Ik`-C[+"nt&R7-eQ;YK$Imp*8b?A/"s@U<KWF((qGNP;A]Qt[Kl%/;VW9^6*%loi<Qm2:_'`obd(mW`<O&=;2,c"XoRcY3D7#7XdbVdq!b#QPI/ISl#KQIW*!Eo28&"$$^AFmRNc_J$I(p\V9-5Qh+fIm(j>O]i:8amY]G8g6hL;9T23)%*iZ_tAE2too^&%ZenoHn."cnE+`E<B26DUPY#aa*A(GLt5ofce$B7@;[acMVm+&*2I<n3B+1CHu+o~>endstream
+endobj
+204 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1439
+>>
+stream
+Gb!kt968iG&AII3Csu%G:6AgEM+_L@fM7nqYp6;.?;t'&'j6SIN][46?%=+$fd,cpXA^^7'X1^+)rHMUa<-<6aTCC6"><OW8AaR/8.,m%1H66]rZ2?CS2:F<_>dOsD.*-N+:S0(=Fq]I;HX=OH_DDl/APpNUe.G$i,Tr>TbV8Qg*:kN_K_!AJBatmMl*U7c#s8aE*,(:/Qa\%1I;Zfo>1^FStDRG?^qNXJT%IL_tU>u]KUnQ=%>KkkVJ0("MN8YQ!um%a?h:l[I)V1FMe$>%=b%81L@<RSfJUEJsA+p=m_;&P1=g/U*uh'7o>q\jEUbPU+;?;8u8MOL.[\B7uMORUlF8H4[N+M%rM-gJZo@WIE*NWAs8*<p/-fIP30rPP$M$ZCSUg3OEMH>d'&h!7VLn0rNcoK??$Hh_fr3sr$$uQRjhUW(^NotGsHUa$`j&*T^oDI1q51d\ii'UhNK[sCh7/Oo&j?YF,Ed7."\+/#XDdt@c^8s*dgLJ8aRfh(558bZ[E5]2@G^3"DM?B3-^=FA*]@9g-=)U/&PmUY4MSc@sA;uB"'Hs/Jb\I5%X%c>ABUJZcEGP1<JSRjAj3VXC0s='j?([qQnVE<C*oNT=ho5K10@9r&#:)50-@(XjrAR[0gdIq2B?4a*2%EDJo8n]UI'BRiY/8;iFZ.bYX<14lhN+c5F:7B)Q-d"AThugI+Z)/K`J*B%Fu/)9RceC$'`J\t7_O=iJ#CAi<uhAU_$gRhUSP6BbZjQ=+rW)&&G(:,2n&);QOGhRk^OE`.bbDJ+'RPUeeTSBGi5$U<[;H&R/80eU8n>J<:F2)r24E,)1PHoo<JM9sd(UP+;R44C^G1g/>=))2Dp6ln7^#^\!T:,HMGGDJ@t8.kPn@[sC=KhZ8DWX0:0&lK_$7'0?"O(q"7\:bR:'p4HS!YIQA%).#F@om06]b0&LkbmZiO?4L/_cam4&%=_#NK)qMP`rb)>\Cr?gT*EpOR9s+&_i)#6hWZk8KYg))RmD!fsAl>J3:7@a`R^GamI^M9fNdsL?<9(I,;"D#/f7]%5,-,TK17U09a/JP;tk22QQLsH?C@cY.BtIC,$U`_Ok2Mr-KREr,"?)^]]\Uln6*:HFgbX/O(6]5*(c_Aei!<S6jISnFPK2H9OM,C8r97]utOJ&p<D=EZNW^Zh!p#i34/pnkdsili=p&"kIOMlpNm;(h&tu:\<CJnYmMRpG>flQ97ggm/D>4_gLE6mc+2M'0%"Ql<)K)Na<FRR`_-)>,iDU_J)]KZC._S#ifffZ16oi7cACbC+=4S"bm><A^t+B9Vt.T_K6ddQI!D:]#iYY3hKdWA$D`P/T>m5BL2r03Y&/7f?+%UQ)L-D<&WI#B)?bO.0ib9h<CASY$U1/COEFdR;3/*W'$0maEFR4'=7?u=tK>O;_iCZMR73b\]d?;<=B<8"(C.al2~>endstream
+endobj
+205 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1089
+>>
+stream
+Gb"/&9lC\"&A@7.bQ/tQc$76<mij"[<D/#Q/a4I!fLsa1'Hj6J#;5N'H/<AdD+iXi,#2/'AF#;E2rjWp?;HN@n%K=16n]L*ZK9192'9pF(T?#\c"?TrjH:iE,?NhW8d\&J=!MAM@rt'"*K*C\<7akYH^^+Oi5>h*?YP#NZjQ(#\PTW9,<;eLVi#)Y7W@aA1^eAiB:$,#e4bEd*\p_5=RBS;F`1o:GAhQ8:\`Yt*PZmiG%6_Z?G*pHc"Cc4ADBPIWk]c'Q.$:3>[l1:@/2keILT8^g&ZP[K]Tl94;lGbO;JSOr;XqPF\^6\q9G]+rn(*20ou.R@s8[j<u/1nJQcW#`MZ@Rs,:&p=5g,Km">$],?:p=af/C@Y5pO?8:->UcAXG)F4;hS=0t4-:X:*0Bl,-N5Lq)mXi/j!LDJGq>M'-g?F>P[3XGHE0V!E*-09CAX+h+BBF/jM8qu)Pfpo_c,"m0p1l[>Xp^#;;"HjT?kgG:#_?X4*_5pa!<c8[GSHW#>I,6Y@VN26WgtA-o\.]^'5bsau+RtSQSTZoQrTc;#,g"#iHs/FGK7OI&2;75)qUN-,)9@0.du,=aI9F.,P">%f0PSpY5)G&igi^A9`ltC6P=8*q_+\j:J$"ORp>jE5CdP&?-V'Aa:G(T8!aubP`-@B2M1i!lB\$cP)gh&$-Ug4-bpn\;8KZ-q=Aj<KA3O+K#3J;D7:;^\OB;Y;.rmMY>7<Ko;n/\$g?9#)424>N3p<`,`lCT51\u)FRt<2a2eO<;lnT(K!auS^k:IOK)@PjY7Aa4MX?V3"(:0<pNW@8Gj,I%^k=8E"L(NuaX&`ZnZXO(5UgiGKCZT"<<gS)&!I'o7De6X@R0TdCjufL+O?&3?G15fCA\kg/.M-K,(>jhO;5K4-^GXoEo"flTaRS6mR<+Hg\U;B&ngS%^"Slbo_'m5>7:H.MS(@VkHE!1@A75G>OOb^'7@J%TdWGi;E%>GgfNPdNOVmQS5FRcW0,#%qla_Ri3.$(1p.)H-Vl.R*rHh.dcbpdW`Po&hI!am,/':J;%M1L(b&IU12d\#$X38BJUKL;/;QI]QqcdY0SMFmN)fSBQEr~>endstream
+endobj
+206 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1405
+>>
+stream
+Gatm<hfBH$%"@qXTnbs=E#,R_5AiR3l/4C_@6tutK;\$&-A2j?V_gu#@A`tkQ-PD:B61WeP2r,mGPYA:p6/O_#F'/a^7HkUAi2\sikZ;XDnlSoT\bI;HLggKA^1u7\4V2_jUgD?[u$%4EH2Q:4![Q(\J3(%4Y._1i$`dJFTt>La&QLh^kIBS,]L"6bS=C\3K^0:b*t7njj@Y@1=Q^%M]O'Al<&$trVBrP5!R[]49BeR1-^0cq"NT-fRH$\&aFR:5>],,TZlC#!EG.I$>BLhViLQ\$%0pq*/bKfM\)bui0"N3;og@!dIM]MU3;[bomF@oXk*(R)YC:?<U]harHmiL)hnen0LJn8)l,H(#n;S:=$P+da%F<No%,?l+2#o<,C@]EN[]^g'l%i]%4`V7eP^LrN*!pYDRc034RDjVGn1=q(RCW,-[['obYbOmTEqj^kRG17$W$S8(mRR/3Roqj8jc9kFo:qAcAo)'cVHa(91c;A:eD1*BS9b:N034bG9I6;a]spihTa85=0OX9IEX<a^:VW;#J\Pla]l3!>D6n^!W.V(T:/"h2Yp$7$/]DNaXNWns'^6"`.mYl<L11?`i67XqO^kBMo7@K52EVV#dR*#14d:oFHn=AL`!iq=?G`N<:$=X38bN5RhN5EoblVYIaV3%@/g+@JKUH%;X[=c8W&Fq;<fu1-.$0W$g*_b^BmF$/<38+PX^h=GmnH6FFsYeV"c6:0UWJLlF0=%J='PMD0Ju^2=+]'FYgnomH(1_64,V;X71ksc9*$:8&DYWd*dV]fp(0%_P61WOgU$N8R1*-E=g>f[Ed[Sk%F;br=d(n$>4io?GSiJ?H]<0eXjS)eA=D$:lZZmO^]qC3*P$jVfdCfKP#[=fR0'pcb:>Y81bk8kJrC1g&'Cp&JE=jkU3\tNAOuVbk0:pX4q=Di8b7/;ASZU=UrBY+-pBp[6S>@N04YRab]9Y=D"MFFJoO7=l?PrlIF(Kh1M'O#6%?QJrG<pB>7Z$pSfaC*>6#M8rq!Ie$?$>Dko*C:VBs<67,[ol?Y]^*K=VI$q\/g\.kcBfb-\cp@R.C>ZQI+h815P]a):?Nc]]mG_9]_k1G^T/+Jd`1<$iCKm[)(eu?BHWSUXO6C.L[2;"3c7JN-Uc@K6.*27XfI[0\<"eh)f+Vn4`9bD*7/l#jKT_7A8M;j0Z=mBZ>dlLd#+%327H#79M7RFQq5*XL@:neh)<pJqHCWO4K!q\0hNY?<+PEt93[U%O2]T;\s!!\0ZAl\NNlK%R:R4s0]o8p5A<cNW1eT+;a08CDP3]@!>D(og`'($_,c_j-,cN^)=DniGL;bd(hGgie'Y%'9&QM&fcetYR4GgPH$B`Q3`mQi@r4QM#nX?k<Q^!UeR0G"ZodL_J/TAoM!)BQFsnfR\I4cf~>endstream
+endobj
+207 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1851
+>>
+stream
+Gau0DD/\/e&H;*)EPO7NI1aGBMZ'o(9A9pCdNm[.",#nnM-EVn,rnEorJm%WbB?Q.=W9k_W8enjkO/+c@R0J(lME+9GWgfV%0OUYHim%T$01c!2BI8e&L.]c$:odKRN&6ao'M5]pbp8[0g`Ft*/q9n(s3s),phNMo4e;-,9daLQinTbAQAn1<`>2IEBD%2=c6m%/n't]RMZm>Ll9$@OEb0!BTMK?rV?90Zcal7gRIfX&#XpWIKo7:?U'25B,El-\@Y4a5TCbg6A3id+0ip]8,WLG++Q,h'#\\8@GWZEE<]iT)N'Jue)"Y8&$d7;eH>Ac4AK9.,csT0EjdKjS89HtRP<\o**%?/9PqX,LLY)F?gP"HQp9_e`i#+ePDgC*>;0Ig&AaX=#P:#&epAO6KF4N5M=mu>B/,6j[OK'tJ3nJL*Jc.S*H(c6IBOWh578n"clAgSl%J(C'Fu&o9F"6['<]]@g@=hZ(G>[nifVGtLHmBt"/g\.?2RKY>#.,CLeV@DTf;N$G_l_c'OM,0&X^Wf2g(nc$'u;teb1Sk/Ee&l$IVQeL)M=K492b4<5@-tO:@Oa"3Q+p':K+\:.Y#X6:Z"eZBWF.b@&t9..l^nmkIV"d9u_Q_`j:hD7,MkT9n8P,(t6kZrEj-[N;4uHn=j<<Hi=\63Qc>AX2-ge$OdBFq*O_9rGtcQ*4T+ksjf\I%AU+GZd^QeU6N%phliB&)_t3'8<L);q@7#/2hJHrOSG0eU6=^X^Rb_aCG/u?;)kN<q4e,/&'?9g\>BG+iQPoj'N:U%\P:2;-G50/REp=AQ>g0QW6rpZR8H<h;/6CV5tlj@&j7J=FHR_C6Yk\bdaK"B!1iF\W*#T6.1aYB=;ZrKtD>Yb@WAuj`k-5SU?CIYq!k$PqE7P2OkUW+1Le57-nYk?nT:]4Kh$.E=4qfWa\00=]I7.CUn*.4@PmHB8eu8e1cQVBpBKSg8GLXUF8u=fH3]JD)&_lAlJK!OidC$E91B>\4/6_NI]7D[)os6H9Is&V<<R"C=@Z'p>J#l1BdQ\d%;ss#59Ff(4#/ILG:235B0EAbAFiPBI:;DUW1LX@X'ZJZSm6e3o2ftG*mDQM8H*7jks>tY<(uWJ1=$%[A_4r?WG:7Db_*G2,@LjTo9nb;/LC\@@[rYnY#Iu,FR`($O9b"B7<>3fc6oFT4cb8q2>'H<TS0%qd*;U`S<!P7rE*r(a&\bq\#eGSZ&:s[5pZW8PPR-lDLnuElC2EgotblD?9R2cOO%IHZt-=g%:<ihU/e+&132U@EGD'n^S`44&Y+2!MU=:qZRsn:3jfH9uGO-/l(qI,cEqJp5dE4c>gZhDl&_E4hmM<<.ZMI"@SbgZZ'mTHpfO^?6WFNFJ@1[2SjNsD`"G=U8F5P<31F1W/(Tprq>VcoO4YH1i6]HV=s[f(C1Q']j,&J,t@U\TV?c9h\XIrm6S:AOI>gb`s4^dp[<=jT)0&JRksbE<T5+)H==Lik[HUn(m"]oXe?4h,Cg6->$;XmXc5"[*guXX,[NYs^8_`H@gUfjc9<,6&Rg`17D^MF33]9A[.PTn5#g$CAgeK5/):<?48`T^A"=SB*^n"j+B'DaC4+F\RqUbKrO'[#>B5dIMkK$bqLml#'qD^&5`Di8FhA-frp;Q'/khE(90a#c*b6i2?VMb;h0qag$E'tc&2W)%dh0%p:4jqu)AhDS7)qk;oGS0tr:5]Te:'G?MV$1`SPARh\c7IRnJgUtG^VdLD,rP:B@g?t]%q=o(]K&'<[6gakg!tTe$[ZhW%l<ZNY%[!;8(;!L%UA3372"L[ap%VQgKUop0&k5=+m]`T\`U/U:T.d\Yb@u4c`<IbN#>r_<=+d.;:1~>endstream
+endobj
+xref
+0 208
+0000000000 65535 f 
+0000000061 00000 n 
+0000000120 00000 n 
+0000000227 00000 n 
+0000000434 00000 n 
+0000000641 00000 n 
+0000000786 00000 n 
+0000000933 00000 n 
+0000001078 00000 n 
+0000001225 00000 n 
+0000001371 00000 n 
+0000001520 00000 n 
+0000001668 00000 n 
+0000001818 00000 n 
+0000001966 00000 n 
+0000002116 00000 n 
+0000002264 00000 n 
+0000002414 00000 n 
+0000002562 00000 n 
+0000002712 00000 n 
+0000002860 00000 n 
+0000003010 00000 n 
+0000003158 00000 n 
+0000003308 00000 n 
+0000003456 00000 n 
+0000003606 00000 n 
+0000003754 00000 n 
+0000003904 00000 n 
+0000004052 00000 n 
+0000004202 00000 n 
+0000004350 00000 n 
+0000004500 00000 n 
+0000004648 00000 n 
+0000004798 00000 n 
+0000004946 00000 n 
+0000005096 00000 n 
+0000005244 00000 n 
+0000005394 00000 n 
+0000005542 00000 n 
+0000005692 00000 n 
+0000005840 00000 n 
+0000005990 00000 n 
+0000006138 00000 n 
+0000006288 00000 n 
+0000006436 00000 n 
+0000006586 00000 n 
+0000006734 00000 n 
+0000006884 00000 n 
+0000007032 00000 n 
+0000007182 00000 n 
+0000007330 00000 n 
+0000007480 00000 n 
+0000007628 00000 n 
+0000007778 00000 n 
+0000007926 00000 n 
+0000008076 00000 n 
+0000008224 00000 n 
+0000008374 00000 n 
+0000008522 00000 n 
+0000008672 00000 n 
+0000008820 00000 n 
+0000008970 00000 n 
+0000009118 00000 n 
+0000009268 00000 n 
+0000009416 00000 n 
+0000009566 00000 n 
+0000009714 00000 n 
+0000009864 00000 n 
+0000010012 00000 n 
+0000010162 00000 n 
+0000010310 00000 n 
+0000010460 00000 n 
+0000010608 00000 n 
+0000010758 00000 n 
+0000010906 00000 n 
+0000011056 00000 n 
+0000011779 00000 n 
+0000011927 00000 n 
+0000012077 00000 n 
+0000012225 00000 n 
+0000012375 00000 n 
+0000012523 00000 n 
+0000012673 00000 n 
+0000012821 00000 n 
+0000012971 00000 n 
+0000013119 00000 n 
+0000013269 00000 n 
+0000013417 00000 n 
+0000013566 00000 n 
+0000013714 00000 n 
+0000013864 00000 n 
+0000014012 00000 n 
+0000014162 00000 n 
+0000014310 00000 n 
+0000014460 00000 n 
+0000014608 00000 n 
+0000014758 00000 n 
+0000014906 00000 n 
+0000015056 00000 n 
+0000015204 00000 n 
+0000015354 00000 n 
+0000015503 00000 n 
+0000015654 00000 n 
+0000015803 00000 n 
+0000015954 00000 n 
+0000016103 00000 n 
+0000016254 00000 n 
+0000016403 00000 n 
+0000016554 00000 n 
+0000016703 00000 n 
+0000016854 00000 n 
+0000017003 00000 n 
+0000017154 00000 n 
+0000017648 00000 n 
+0000017857 00000 n 
+0000018066 00000 n 
+0000018275 00000 n 
+0000018484 00000 n 
+0000018693 00000 n 
+0000018902 00000 n 
+0000019111 00000 n 
+0000019320 00000 n 
+0000019529 00000 n 
+0000019738 00000 n 
+0000019947 00000 n 
+0000020156 00000 n 
+0000020365 00000 n 
+0000021836 00000 n 
+0000080689 00000 n 
+0000080917 00000 n 
+0000082357 00000 n 
+0000083659 00000 n 
+0000153126 00000 n 
+0000153354 00000 n 
+0000154636 00000 n 
+0000154726 00000 n 
+0000155160 00000 n 
+0000155238 00000 n 
+0000155426 00000 n 
+0000155550 00000 n 
+0000155657 00000 n 
+0000155881 00000 n 
+0000156016 00000 n 
+0000156161 00000 n 
+0000156286 00000 n 
+0000156536 00000 n 
+0000156664 00000 n 
+0000156801 00000 n 
+0000156986 00000 n 
+0000157108 00000 n 
+0000157398 00000 n 
+0000157548 00000 n 
+0000157743 00000 n 
+0000157907 00000 n 
+0000158050 00000 n 
+0000158310 00000 n 
+0000158459 00000 n 
+0000158605 00000 n 
+0000158840 00000 n 
+0000159101 00000 n 
+0000159224 00000 n 
+0000159378 00000 n 
+0000159493 00000 n 
+0000159614 00000 n 
+0000159866 00000 n 
+0000159994 00000 n 
+0000160144 00000 n 
+0000160337 00000 n 
+0000160590 00000 n 
+0000160746 00000 n 
+0000160876 00000 n 
+0000161133 00000 n 
+0000161316 00000 n 
+0000161502 00000 n 
+0000161707 00000 n 
+0000161948 00000 n 
+0000162089 00000 n 
+0000162314 00000 n 
+0000162490 00000 n 
+0000162691 00000 n 
+0000162922 00000 n 
+0000163076 00000 n 
+0000163279 00000 n 
+0000163412 00000 n 
+0000163554 00000 n 
+0000163720 00000 n 
+0000163882 00000 n 
+0000164114 00000 n 
+0000164225 00000 n 
+0000164443 00000 n 
+0000164551 00000 n 
+0000164741 00000 n 
+0000166509 00000 n 
+0000167643 00000 n 
+0000169445 00000 n 
+0000170835 00000 n 
+0000173657 00000 n 
+0000175964 00000 n 
+0000177736 00000 n 
+0000180118 00000 n 
+0000182410 00000 n 
+0000184287 00000 n 
+0000186612 00000 n 
+0000188740 00000 n 
+0000190327 00000 n 
+0000191859 00000 n 
+0000193041 00000 n 
+0000194539 00000 n 
+trailer
+<<
+/ID 
+[<0401286f08569462d07c07f834d54d21><0401286f08569462d07c07f834d54d21>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 135 0 R
+/Root 134 0 R
+/Size 208
+>>
+startxref
+196483
+%%EOF

--- a/sql/data_setting.sql
+++ b/sql/data_setting.sql
@@ -1,5 +1,13 @@
--- brand 테이블 초기화 & 데이터 삽입
+-- 성능 실험 전용 데이터입니다. local 프로필로 스키마를 새로 만든 직후에만 실행하세요.
+-- 기존 데이터를 보존해야 하는 환경에서는 실행하지 마세요.
+SET FOREIGN_KEY_CHECKS = 0;
+TRUNCATE TABLE loopers.product_like;
+TRUNCATE TABLE loopers.product;
 TRUNCATE TABLE loopers.brand;
+TRUNCATE TABLE loopers.member;
+SET FOREIGN_KEY_CHECKS = 1;
+
+-- brand 테이블 데이터 삽입
 
 SET SESSION cte_max_recursion_depth = 500;
 INSERT INTO loopers.brand (created_at, updated_at, name, description)
@@ -14,8 +22,7 @@ SELECT NOW(),
     CONCAT('Description for brand ', n)
 FROM seq;
 
--- product 테이블 초기화 & 데이터 삽입
-TRUNCATE TABLE loopers.product;
+-- product 테이블 데이터 삽입
 
 SET SESSION cte_max_recursion_depth = 300000;
 INSERT INTO loopers.product (price, brand_id, created_at, updated_at, name, description, latest_at, like_count)
@@ -34,8 +41,7 @@ SELECT ROUND(RAND() * 3000, 2),
     FLOOR(RAND() * 300000)
 FROM seq;
 
--- member 테이블 초기화 & 데이터 삽입
-TRUNCATE TABLE loopers.member;
+-- member 테이블 데이터 삽입
 
 SET SESSION cte_max_recursion_depth = 10000;
 INSERT INTO loopers.member (created_at, updated_at, gender, email, member_id, password_hash)
@@ -53,8 +59,7 @@ SELECT NOW(),
 FROM seq;
 
 
--- product_like 테이블 초기화 & 데이터 삽입
-TRUNCATE TABLE loopers.product_like;
+-- product_like 테이블 데이터 삽입
 
 SET SESSION cte_max_recursion_depth = 300000;
 INSERT INTO loopers.product_like (created_at, updated_at, member_id, product_id)
@@ -68,3 +73,14 @@ SELECT NOW(),
     1 + FLOOR(RAND() * 10000),
     1 + FLOOR(RAND() * 300000)
 FROM seq;
+
+-- 정규화 집계값과 비정규화 like_count가 같은 의미를 갖도록 맞춥니다.
+UPDATE loopers.product p
+LEFT JOIN (
+    SELECT product_id, COUNT(*) AS like_count
+    FROM loopers.product_like
+    GROUP BY product_id
+) pl ON pl.product_id = p.id
+SET p.like_count = COALESCE(pl.like_count, 0);
+
+ANALYZE TABLE loopers.brand, loopers.product, loopers.member, loopers.product_like;

--- a/sql/denormalization_test.sql
+++ b/sql/denormalization_test.sql
@@ -1,4 +1,4 @@
--- 50만건의 product와 500건의 brand 일때
+-- data_setting.sql 기준 30만 건의 product와 500건의 brand일 때
 
 CREATE INDEX idx_like_count_brand ON product (like_count, brand_id);
 DROP INDEX idx_like_count_brand ON product;

--- a/sql/normalization_test.sql
+++ b/sql/normalization_test.sql
@@ -1,4 +1,4 @@
--- 50만건의 product와 500건의 brand 일때
+-- data_setting.sql 기준 30만 건의 product와 500건의 brand일 때
 
 CREATE INDEX idx_like_count_brand ON product (like_count, brand_id);
 DROP INDEX idx_like_count_brand ON product;

--- a/supports/monitoring/src/main/resources/monitoring.yml
+++ b/supports/monitoring/src/main/resources/monitoring.yml
@@ -3,6 +3,12 @@ management:
     distribution:
       percentiles-histogram:
         http.server.requests: true
+      minimum-expected-value:
+        http.server.requests: 5ms
+      maximum-expected-value:
+        http.server.requests: 5s
+      slo:
+        http.server.requests: 100ms,300ms,500ms,1s,2s
     tags:
       application:
         ${spring.application.name}


### PR DESCRIPTION
## What changed

- Add a reproducible k6 product-query lab for normalized, denormalized, and Redis-backed reads.
- Add smoke/load/stress/spike/soak profiles with p50/p95/p99, error, check, and dropped-iteration thresholds.
- Add Prometheus remote-write support and a provisioned Grafana dashboard for k6, HTTP, JVM, Tomcat, and HikariCP signals.
- Add deterministic local performance data setup and a Korean performance guide, measured smoke report, and PDF workbook.

## Validation

- `./gradlew build` — BUILD SUCCESSFUL (50 actionable tasks)
- `docker compose -f docker/monitoring-compose.yml config`
- Prometheus `promtool check config`
- k6 inspect for 3 variants × 5 profiles
- Three local 2 RPS / 30s smoke runs: 0 errors, 0 dropped iterations
- Grafana dashboard API registration and PromQL p95/p99 queries verified

The smoke results are connectivity and measurement-path evidence only; they are not capacity claims.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * Prometheus와 Grafana 기반의 Loopers 성능 모니터링 대시보드를 추가했습니다.
  * 상품 조회 API의 정규화·비정규화·Redis 경로를 검증하는 k6 성능 테스트 프로필을 제공합니다.
  * 모니터링 환경에서 대시보드와 데이터가 자동으로 구성되고 영속적으로 보존됩니다.

* **문서**
  * 성능 실험 실행 방법, 지표 해석, 장애 진단 및 결과 기록 가이드를 추가했습니다.
  * 로컬 smoke 테스트 결과와 검증 내용을 문서화했습니다.

* **개선**
  * Prometheus 수집 대상과 메트릭 설정을 확장하고, 성능 테스트용 초기 데이터 구성을 정비했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->